### PR TITLE
EclSimulator: make compile with dune-alugrid

### DIFF
--- a/applications/ebos/eclgridmanager.hh
+++ b/applications/ebos/eclgridmanager.hh
@@ -266,6 +266,29 @@ public:
 #endif
     }
 
+    /*!
+     * \brief Extract Cartesian index triplet (i,j,k) of an active cell.
+     *
+     * \param [in]   c   active cell index.
+     * \param [out] ijk  Cartesian index triplet
+    */
+    void getIJK(const int c, std::array<int,3>& ijk) const
+    {
+        assert( c < int(cartesianCellId().size()) );
+        int gc = cartesianCellId()[ c ];
+        ijk[0] = gc % cartesianSize_[0];  gc /= cartesianSize_[0];
+        ijk[1] = gc % cartesianSize_[1];
+        ijk[2] = gc / cartesianSize_[1];
+
+#if not defined NDEBUG && HAVE_DUNE_ALUGRID == 0
+        // make sure ijk computation is the same as in CpGrid
+        std::array<int,3> checkijk;
+        grid_->getIJK( c, checkijk );
+        for( int i=0; i<3; ++i )
+          assert( checkijk[ i ] == ijk[ i ] );
+#endif
+    }
+
 private:
     std::string caseName_;
     GridPointer grid_;

--- a/applications/ebos/eclgridmanager.hh
+++ b/applications/ebos/eclgridmanager.hh
@@ -188,8 +188,15 @@ public:
           cartesianCellId_ = cpgrid->globalCell();
         }
         else
-          // todo
-          std::abort();
+        {
+          const int size = ordering.size();
+          cartesianCellId_.reserve( size );
+          const std::vector<int>& globalCell = cpgrid->globalCell();
+          for( int i=0; i<size; ++i )
+          {
+            cartesianCellId_.push_back( globalCell[ ordering[ i ] ] );
+          }
+        }
 #else
         grid_ = GridPointer( cpgrid );
 #endif

--- a/applications/ebos/eclgridmanager.hh
+++ b/applications/ebos/eclgridmanager.hh
@@ -30,6 +30,11 @@
 
 #include <dune/grid/CpGrid.hpp>
 
+#if HAVE_DUNE_ALUGRID
+#include <dune/alugrid/grid.hh>
+#include <dune/alugrid/common/fromtogridfactory.hh>
+#endif
+
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Log/Logger.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -64,7 +69,11 @@ NEW_PROP_TAG(EclDeckFileName);
 SET_STRING_PROP(EclGridManager, EclDeckFileName, "data/ecl.DATA");
 
 // set the Grid and GridManager properties
+#if HAVE_DUNE_ALUGRID
+SET_TYPE_PROP(EclGridManager, Grid, Dune :: ALUGrid< 3, 3, Dune::cube, Dune::nonconforming > );
+#else
 SET_TYPE_PROP(EclGridManager, Grid, Dune::CpGrid);
+#endif
 SET_TYPE_PROP(EclGridManager, GridManager, Ewoms::EclGridManager<TypeTag>);
 }} // namespace Opm, Properties
 
@@ -84,6 +93,7 @@ class EclGridManager : public BaseGridManager<TypeTag>
 
     typedef std::unique_ptr<Grid> GridPointer;
 
+    static const int dimension = Grid :: dimension;
 public:
     /*!
      * \brief Register all run-time parameters for the grid manager.
@@ -101,7 +111,9 @@ public:
      * a cornerpoint description of the grid.
      */
     EclGridManager(Simulator &simulator)
-        : ParentType(simulator)
+        : ParentType(simulator),
+          cartesianCellId_(),
+          cartesianSize_()
     {
         std::string fileName = EWOMS_GET_PARAM(TypeTag, std::string, EclDeckFileName);
 
@@ -153,11 +165,34 @@ public:
             opmLog->printAll(std::cout);
         }
 
-        grid_ = GridPointer(new Grid());
-        grid_->processEclipseFormat(eclState_->getEclipseGrid(),
-                                    /*isPeriodic=*/false,
-                                    /*flipNormals=*/false,
-                                    /*clipZ=*/false);
+#if HAVE_DUNE_ALUGRID
+        std::unique_ptr< Dune::CpGrid > cpgrid( new Dune::CpGrid() );
+#else
+        Grid* cpgrid = new Grid();
+#endif
+        cpgrid->processEclipseFormat(eclState_->getEclipseGrid(),
+                                     /*isPeriodic=*/false,
+                                     /*flipNormals=*/false,
+                                     /*clipZ=*/false);
+
+        for( int i=0; i<dimension; ++i )
+          cartesianSize_[ i ] = cpgrid->logicalCartesianSize()[ i ];
+
+#if HAVE_DUNE_ALUGRID
+        Dune::FromToGridFactory< Grid > factory;
+        std::vector< int > ordering;
+        grid_ = GridPointer( factory.convert( *cpgrid, ordering ) );
+        if( ordering.empty() )
+        {
+          // copy cartesian cell index from cp grid
+          cartesianCellId_ = cpgrid->globalCell();
+        }
+        else
+          // todo
+          std::abort();
+#else
+        grid_ = GridPointer( cpgrid );
+#endif
 
         this->finalizeInit_();
     }
@@ -211,11 +246,34 @@ public:
     const std::string& caseName() const
     { return caseName_; }
 
+    /*!
+     * \brief Returns the logical Cartesian size
+     */
+    const std::array<int, dimension>& logicalCartesianSize() const
+    {
+      return cartesianSize_;
+    }
+
+    /*!
+     * \brief Returns the Cartesian cell id for identifaction with Ecl data
+     */
+    const std::vector<int>& cartesianCellId() const
+    {
+#if HAVE_DUNE_ALUGRID
+      return cartesianCellId_;
+#else
+      return grid_->globalCell();
+#endif
+    }
+
 private:
     std::string caseName_;
     GridPointer grid_;
     Opm::DeckConstPtr deck_;
     Opm::EclipseStateConstPtr eclState_;
+
+    std::vector<int> cartesianCellId_;
+    std::array<int,dimension> cartesianSize_;
 };
 
 } // namespace Ewoms

--- a/applications/ebos/eclproblem.hh
+++ b/applications/ebos/eclproblem.hh
@@ -822,7 +822,8 @@ private:
     void readInitialCondition_()
     {
         const auto deck = this->simulator().gridManager().deck();
-        const auto &cartesianCellId = this->simulator().gridManager().cartesianCellId();
+        const auto &gridManager = this->simulator().gridManager();
+        const auto &cartesianCellId = gridManager.cartesianCellId();
 
         if (!deck->hasKeyword("SWAT") ||
             !deck->hasKeyword("SGAS"))
@@ -928,7 +929,7 @@ private:
 
             if (RsReal > RsSat) {
                 std::array<int, 3> ijk;
-                // grid.getIJK(dofIdx, ijk);
+                gridManager.getIJK(dofIdx, ijk);
                 std::cerr << "Warning: The specified amount gas (R_s = " << RsReal << ") is more"
                           << " than the maximium\n"
                           << "         amount which can be dissolved in oil"

--- a/cmake/Modules/FindMETIS.cmake
+++ b/cmake/Modules/FindMETIS.cmake
@@ -20,7 +20,7 @@ endif()
 find_path (METIS_INCLUDE_DIRS
   NAMES "metis.h"
   PATHS ${METIS_SEARCH_PATH}
-  PATH_SUFFIXES "include" "METISLib"
+  PATH_SUFFIXES "include" "METISLib" "include/metis"
   ${METIS_NO_DEFAULT_PATH})
 
 # only search in architecture-relevant directory
@@ -39,7 +39,7 @@ if (METIS_INCLUDE_DIRS OR METIS_LIBRARIES)
   set(METIS_FOUND TRUE)
   set(HAVE_METIS TRUE)
 endif()
-  
+
 # print a message to indicate status of this package
 include (FindPackageHandleStandardArgs)
 find_package_handle_standard_args(METIS

--- a/cmake/Modules/FindZOLTAN.cmake
+++ b/cmake/Modules/FindZOLTAN.cmake
@@ -1,0 +1,51 @@
+# -*-cmake-*-
+#
+# Try to find the libzoltan graph partioning library
+#
+# Once done, this will define:
+#
+#  ZOLTAN_FOUND        - system has the libzoltan graph partioning library
+#  HAVE_ZOLTAN         - like ZOLTAN_FOUND, but for the inclusion in config.h
+#  ZOLTAN_INCLUDE_DIR  - incude paths to use libzoltan
+#  ZOLTAN_LIBRARIES    - Link these to use libzoltan
+
+set(ZOLTAN_SEARCH_PATH "/usr" "/usr/local" "/opt" "/opt/local")
+set(ZOLTAN_NO_DEFAULT_PATH "")
+if(ZOLTAN_ROOT)
+  set(ZOLTAN_SEARCH_PATH "${ZOLTAN_ROOT}")
+  set(ZOLTAN_NO_DEFAULT_PATH "NO_DEFAULT_PATH")
+endif()
+
+# search for files which implements this module
+find_path (ZOLTAN_INCLUDE_DIRS
+  NAMES "zoltan.h"
+  PATHS ${ZOLTAN_SEARCH_PATH}
+  PATH_SUFFIXES "include" 
+  ${ZOLTAN_NO_DEFAULT_PATH})
+
+# only search in architecture-relevant directory
+if (CMAKE_SIZEOF_VOID_P)
+  math (EXPR _BITS "8 * ${CMAKE_SIZEOF_VOID_P}")
+endif (CMAKE_SIZEOF_VOID_P)
+
+find_library(ZOLTAN_LIBRARIES
+  NAMES "zoltan"
+  PATHS ${ZOLTAN_SEARCH_PATH}
+  PATH_SUFFIXES "lib/.libs" "lib" "lib${_BITS}" "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+  ${ZOLTAN_NO_DEFAULT_PATH})
+
+set (ZOLTAN_FOUND FALSE)
+if (ZOLTAN_INCLUDE_DIRS OR ZOLTAN_LIBRARIES)
+  set(ZOLTAN_FOUND TRUE)
+  set(HAVE_ZOLTAN 1)
+endif()
+
+set (ZOLTAN_CONFIG_VAR HAVE_ZOLTAN)
+  
+# print a message to indicate status of this package
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ZOLTAN
+  DEFAULT_MSG
+  ZOLTAN_LIBRARIES
+  ZOLTAN_INCLUDE_DIRS
+  )

--- a/cmake/Modules/Finddune-alugrid.cmake
+++ b/cmake/Modules/Finddune-alugrid.cmake
@@ -22,6 +22,7 @@ find_opm_package (
   "CXX11Features REQUIRED;
    dune-grid REQUIRED;
    ZLIB REQUIRED;
+   ZOLTAN;
    METIS
   "
   # header to search for

--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -265,6 +265,7 @@ for OPT in "$@"; do
             opm-*       |\
             dune        |\
             dune-*      |\
+            zoltan      |\
             zlib)
               rootvar="$(uppercase ${pkgname})_ROOT"
               rootvar="${rootvar/-/_}"


### PR DESCRIPTION
This patch makes the ebos simulator compile with ALUGrid (and by that assure that the code still follows the DUNE grid interface). 
For that reasons the identification to the Cartesian cell id has been moved to the grid manager. 
Some minor other fixes have been made to make the code compile. 
Also, I added the FindZOLTAN.cmake check but for some reasons it is not working correctly yet. 

The switch between CpGrid and ALUGrid needs to be put into the ewoms way by @andlaus. 