### PR TITLE
In dune 2.4 and later it will be necessary to avoid iterator dereferencing.

### DIFF
--- a/ewoms/models/common/multiphasebasemodel.hh
+++ b/ewoms/models/common/multiphasebasemodel.hh
@@ -128,6 +128,7 @@ class MultiPhaseBaseModel : public GET_PROP_TYPE(TypeTag, Discretization)
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
 
     typedef typename GridView::template Codim<0>::Iterator ElementIterator;
+    typedef typename GridView::template Codim<0>::Entity Element;
 
     enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
     enum { numComponents = FluidSystem::numComponents };
@@ -208,10 +209,11 @@ public:
                  !threadedElemIt.isFinished(elemIt);
                  threadedElemIt.increment(elemIt))
             {
-                if (elemIt->partitionType() != Dune::InteriorEntity)
+                const Element& elem = *elemIt;
+                if (elem.partitionType() != Dune::InteriorEntity)
                     continue; // ignore ghost and overlap elements
 
-                elemCtx.updateStencil(*elemIt);
+                elemCtx.updateStencil(elem);
                 elemCtx.updateIntensiveQuantities(/*timeIdx=*/0);
 
                 const auto &stencil = elemCtx.stencil(/*timeIdx=*/0);

--- a/ewoms/models/pvs/pvsmodel.hh
+++ b/ewoms/models/pvs/pvsmodel.hh
@@ -470,9 +470,10 @@ public:
         ElementIterator elemIt = this->gridView_.template begin<0>();
         ElementIterator elemEndIt = this->gridView_.template end<0>();
         for (; elemIt != elemEndIt; ++elemIt) {
-            if (elemIt->partitionType() != Dune::InteriorEntity)
+            const Element& elem = *elemIt;
+            if (elem.partitionType() != Dune::InteriorEntity)
                 continue;
-            elemCtx.updateStencil(*elemIt);
+            elemCtx.updateStencil(elem);
 
             int numLocalDof = elemCtx.stencil(/*timeIdx=*/0).numPrimaryDof();
             for (int dofIdx = 0; dofIdx < numLocalDof; ++dofIdx) {

--- a/ewoms/models/stokes/stokesmodel.hh
+++ b/ewoms/models/stokes/stokesmodel.hh
@@ -245,6 +245,7 @@ class StokesModel : public GET_PROP_TYPE(TypeTag, Discretization)
     typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
 
     typedef typename GridView::template Codim<0>::Iterator ElementIterator;
+    typedef typename GridView::template Codim<0>::Entity   Element;
 
 public:
     StokesModel(Simulator &simulator)
@@ -347,10 +348,11 @@ public:
         ElementIterator elemIt = this->gridView().template begin<0>();
         ElementIterator elemEndIt = this->gridView().template end<0>();
         for (; elemIt != elemEndIt; ++elemIt) {
-            if (elemIt->partitionType() != Dune::InteriorEntity)
+            const Element& elem = *elemIt;
+            if (elem.partitionType() != Dune::InteriorEntity)
                 continue;
 
-            elemCtx.updateAll(*elemIt);
+            elemCtx.updateAll(elem);
 
             int numScv = elemCtx.numPrimaryDof(/*timeIdx=*/0);
             for (int dofIdx = 0; dofIdx < numScv; ++dofIdx)


### PR DESCRIPTION
The reason is that entities will be copied. To be on the save side, we just dereference the iterator once. 
This PR fixed some of the occurrences, but probably not all of them. 
