### PR TITLE
fix the regressions caused by PR#20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# -*- mode: cmake; tab-width: 2; indent-tabs-mode: t; truncate-lines: t; compile-command: "cmake -Wdev" -*-
+# -*- mode: cmake; tab-width: 2; indent-tabs-mode: nil; truncate-lines: t
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
 ###########################################################################
@@ -117,57 +117,38 @@ endforeach()
 # shipped as part of the eWoms distribution
 include(EwomsAddApplication)
 
-opm_add_test(test_propertysystem
-             SOURCES tests/test_propertysystem.cc
-             DRIVER_ARGS --plain test_propertysystem
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+# the general-purpose ECL simulator ("ebos" == "&ecl &black-&oil &simulator)
+EwomsAddApplication(ebos
+                    SOURCES applications/ebos/ebos.cc
+                    EXE_NAME ebos
+                    CONDITION HAVE_DUNE_CORNERPOINT AND HAVE_ERT)
+
+opm_set_test_driver("${PROJECT_SOURCE_DIR}/bin/runtest.sh" "--simulation")
+opm_set_test_default_working_directory("${PROJECT_BINARY_DIR}")
 
 # add targets for all tests of the models. we add the water-air test
 # first because it take longest and so that we don't have to wait for
 # them as long for parallel test runs
 opm_add_test(waterair_pvs_ni
-             SOURCES tests/waterair_pvs_ni.cc
-             DRIVER_ARGS --simulation=waterair_pvs_ni
-                         --grid-global-refinements=1
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             TEST_ARGS --grid-global-refinements=1)
 
 opm_add_test(lens_immiscible_vcfv
-             SOURCES tests/lens_immiscible_vcfv.cc
-             DRIVER_ARGS --simulation=lens_immiscible_vcfv --end-time=3000
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             TEST_ARGS --end-time=3000)
 
 opm_add_test(lens_immiscible_ecfv
-             SOURCES tests/lens_immiscible_ecfv.cc
-             DRIVER_ARGS --simulation=lens_immiscible_ecfv --end-time=3000
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             TEST_ARGS --end-time=3000)
 
 opm_add_test(finger_immiscible
-             SOURCES tests/finger_immiscible.cc
-             CONDITION DUNE_ALUGRID_FOUND OR ALUGRID_FOUND
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             CONDITION DUNE_ALUGRID_FOUND OR ALUGRID_FOUND)
 
 opm_add_test(test_navierstokes
-             SOURCES tests/test_navierstokes.cc
-             CONDITION (DUNE_ALUGRID_FOUND OR ALUGRID_FOUND) AND SUPERLU_FOUND
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             CONDITION (DUNE_ALUGRID_FOUND OR ALUGRID_FOUND) AND SUPERLU_FOUND)
 
 opm_add_test(test_stokes2c
-             SOURCES tests/test_stokes2c.cc
-             CONDITION SUPERLU_FOUND
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             CONDITION SUPERLU_FOUND)
 
 opm_add_test(test_stokesni
-             SOURCES tests/test_stokesni.cc
-             CONDITION SUPERLU_FOUND
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             CONDITION SUPERLU_FOUND)
 
 foreach(tapp co2injection_flash_ni_vcfv
              co2injection_flash_ni_ecfv
@@ -200,45 +181,29 @@ foreach(tapp co2injection_flash_ni_vcfv
              diffusion_ncp
              diffusion_pvs
              groundwater_immiscible)
-  opm_add_test(${tapp} SOURCES tests/${tapp}.cc
-                       WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-                       DRIVER_ARGS --simulation=${tapp}
-                       LIBRARIES ${ewoms_LIBRARIES})
+  opm_add_test(${tapp})
 endforeach()
 
 opm_add_test(fracture_discretefracture
-             SOURCES tests/fracture_discretefracture.cc
              CONDITION DUNE_ALUGRID_FOUND OR ALUGRID_FOUND
-             DRIVER_ARGS --simulation=fracture_discretefracture --end-time=400
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             TEST_ARGS --end-time=400)
+
+opm_add_test(test_propertysystem
+             DRIVER_ARGS --plain)
 
 opm_add_test(test_quadrature
-             SOURCES tests/test_quadrature.cc
-             DRIVER_ARGS --plain test_quadrature
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
-
-# the general-purpose ECL simulator ("ebos" == "&ecl &black-&oil &simulator)
-EwomsAddApplication(ebos
-                    SOURCES applications/ebos/ebos.cc
-                    EXE_NAME ebos
-                    CONDITION HAVE_DUNE_CORNERPOINT AND HAVE_ERT
-                    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-                    LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --plain)
 
 # test for the parallelization of the element centered finite volume
-# discretization (using the non-isothermal NCP model and BiCGSTAB +
-# ILU0)
+# discretization (using the non-isothermal NCP model and the parallel
+# AMG linear solver)
 opm_add_test(co2injection_ncp_ni_ecfv_parallel
              EXE_NAME co2injection_ncp_ni_ecfv
              NO_COMPILE
              PROCESSORS 4
              CONDITION MPI_FOUND
-             DRIVER_ARGS --parallel-simulation=4 co2injection_ncp_ni_ecfv
-                         --end-time=10 --initial-time-step-size=1
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --parallel-simulation=4
+             TEST_ARGS --end-time=10 --initial-time-step-size=1)
 
 # test for the parallelization of the vertex centered finite volume
 # discretization (using BiCGSTAB + ILU0)
@@ -247,10 +212,8 @@ opm_add_test(obstacle_immiscible_parallel
              NO_COMPILE
              PROCESSORS 4
              CONDITION MPI_FOUND
-             DRIVER_ARGS --parallel-simulation=4 obstacle_immiscible
-                         --end-time=1 --initial-time-step-size=1
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --parallel-simulation=4
+             TEST_ARGS --end-time=1 --initial-time-step-size=1)
 
 # test for the parallel AMG linear solver using the vertex centered
 # finite volume discretization
@@ -259,48 +222,35 @@ opm_add_test(lens_immiscible_vcfv_parallel
              NO_COMPILE
              PROCESSORS 4
              CONDITION MPI_FOUND
-             DRIVER_ARGS --parallel-simulation=4 lens_immiscible_vcfv
-                         --end-time=250 --initial-time-step-size=250
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --parallel-simulation=4
+             TEST_ARGS --end-time=250 --initial-time-step-size=250)
 
 opm_add_test(lens_immiscible_ecfv_parallel
              EXE_NAME lens_immiscible_ecfv
              NO_COMPILE
              PROCESSORS 4
              CONDITION MPI_FOUND
-             DRIVER_ARGS --parallel-simulation=4 lens_immiscible_ecfv
-                         --end-time=250 --initial-time-step-size=250
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --parallel-simulation=4
+             TEST_ARGS --end-time=250 --initial-time-step-size=250)
 
 opm_add_test(obstacle_immiscible_parameters
              EXE_NAME obstacle_immiscible
              NO_COMPILE
              DEPENDS obstacle_immiscible
-             DRIVER_ARGS --parameters=obstacle_immiscible
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --parameters)
 
 opm_add_test(obstacle_pvs_restart
              EXE_NAME obstacle_pvs
              NO_COMPILE
              DEPENDS obstacle_pvs
-             DRIVER_ARGS --restart=obstacle_pvs --pvs-verbosity=2
-                         --end-time=15000
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             DRIVER_ARGS --restart
+             TEST_ARGS --pvs-verbosity=2 --end-time=15000)
 
 
 # the test for the plain stokes model is completes quite
 # quickly. thus, we put it to the end of the list...
 opm_add_test(test_stokes
-             SOURCES tests/test_stokes.cc
-             CONDITION SUPERLU_FOUND
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             CONDITION SUPERLU_FOUND)
 
 opm_add_test(tutorial1
-             SOURCES tutorial/tutorial1.cc
-             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-             LIBRARIES ${ewoms_LIBRARIES})
+             SOURCES tutorial/tutorial1.cc)

--- a/bin/runtest.sh
+++ b/bin/runtest.sh
@@ -12,7 +12,7 @@ usage() {
     echo "Usage:"
     echo
     echo "runTest.sh TEST_TYPE TEST_BINARY [TEST_ARGS]"
-    echo "where TEST_TYPE can either be --plain,  --simulation or --parallel-simulation=\$NUM_CORES (is '$TEST_TYPE')."
+    echo "where TEST_TYPE can either be --plain, --simulation or --parallel-simulation=\$NUM_CORES (is '$TEST_TYPE')."
 };
 
 validateResults() {


### PR DESCRIPTION
The most important issue was that PR#20 removed the possibility to use
a test driver script. In eWoms, this script is responsible for
(fuzzily) comparing the results of the test runs with reference
solutions, to test the simulators in parallel and compare the results,
and to make sure that the --help command continues to work as
intended.

the approach taken to bring this functionality back is to specify the
test driver script and its parameters using the new macro
'opm_set_test_driver(${DRIVER_COMMAND} ${DRIVER_DEFAULT_ARGUMENTS})'
before the first call to 'opm_add_test'. If no test driver is
specified, the binary is run 'naked', so nothing should change in this
case.

this patch requires the changes for opm-cmake (OPM/opm-cmake#14) to be merged first.