### PR TITLE
EclEquilInitializer: adjust to BlackoilPropertiesFromDeck changes from opm-core.

### DIFF
--- a/applications/ebos/eclequilinitializer.hh
+++ b/applications/ebos/eclequilinitializer.hh
@@ -87,8 +87,6 @@ public:
             Opm::UgGridHelpers::numCells(grid),
             Opm::UgGridHelpers::globalCell(grid),
             Opm::UgGridHelpers::cartDims(grid),
-            Opm::UgGridHelpers::beginCellCentroids(grid),
-            Opm::UgGridHelpers::dimensions(grid),
             tmpParam);
 
         // initialize the boiler plate of opm-core the state structure.


### PR DESCRIPTION
The constructor in BlackoilPropertiesFromDeck has changed and this PR fixes this.