### PR TITLE
Make fracture discretefracture run with new ALUGrid.

### DIFF
--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -252,16 +252,17 @@ public:
         boundaryFaces_.resize(0);
 
         for (; isIt != endIsIt; ++isIt) {
+            const auto& intersection = *isIt;
             // if the current intersection has a neighbor, add a
             // degree of freedom and an internal face, else add a
             // boundary face
-            if (isIt->neighbor()) {
-                elements_.push_back(isIt->outside());
-                subControlVolumes_.push_back(SubControlVolume(isIt->outside()));
-                interiorFaces_.push_back(SubControlVolumeFace(*isIt, subControlVolumes_.size() - 1));
+            if (intersection.neighbor()) {
+                elements_.push_back(intersection.outside());
+                subControlVolumes_.push_back(SubControlVolume(intersection.outside()));
+                interiorFaces_.push_back(SubControlVolumeFace(intersection, subControlVolumes_.size() - 1));
             }
             else {
-                boundaryFaces_.push_back(SubControlVolumeFace(*isIt, - 10000));
+                boundaryFaces_.push_back(SubControlVolumeFace(intersection, - 10000));
             }
         }
     }

--- a/ewoms/disc/vcfv/vcfvstencil.hh
+++ b/ewoms/disc/vcfv/vcfvstencil.hh
@@ -960,10 +960,12 @@ public:
         // fill boundary face data:
         IntersectionIterator endit = gridView_.iend(e);
         for (IntersectionIterator it = gridView_.ibegin(e); it != endit; ++it) {
-            if (!it->boundary())
+            const auto& intersection = *it ;
+
+            if ( ! intersection.boundary())
                 continue;
 
-            int face = it->indexInInside();
+            int face = intersection.indexInInside();
             int numVerticesOfFace = referenceElement.size(face, 1, dim);
             for (int vertInFace = 0; vertInFace < numVerticesOfFace; vertInFace++)
             {
@@ -979,7 +981,7 @@ public:
                     boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(vertInElement, dim)
                         + referenceElement.position(face, 1);
                     boundaryFace_[bfIdx].ipLocal_ *= 0.5;
-                    boundaryFace_[bfIdx].area_ = 0.5*it->geometry().volume();
+                    boundaryFace_[bfIdx].area_ = 0.5 * intersection.geometry().volume();
                 }
                 else if (dim == 3) {
                     int leftEdge;
@@ -1004,7 +1006,7 @@ public:
                 boundaryFace_[bfIdx].j = vertInElement;
 
                 // ASSUME constant normal on the segment of the boundary face
-                boundaryFace_[bfIdx].normal_ = it->centerUnitOuterNormal();
+                boundaryFace_[bfIdx].normal_ = intersection.centerUnitOuterNormal();
             }
         }
 

--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -29,6 +29,8 @@
 #include <ewoms/models/discretefracture/discretefracturemodel.hh>
 
 #if HAVE_DUNE_ALUGRID
+// avoid reordering of macro elements, otherwise this problem won't work
+#define DISABLE_ALUGRID_SFC_ORDERING 1
 #include <dune/alugrid/grid.hh>
 #include <dune/grid/io/file/dgfparser/dgfalu.hh>
 #else


### PR DESCRIPTION
This PR fixes a small issue with the new ALUGrid version. 
To make the fracture_discretefracture problem work, we have to disable the internal space filling curve reordering. It is not exactly clear why. 

Also, some minor improvement in the FV stencils.