### PR TITLE
update redhat packaging

### DIFF
--- a/redhat/ewoms.spec
+++ b/redhat/ewoms.spec
@@ -9,13 +9,13 @@ Group:   Development/Libraries/C and C++
 URL: 	 http://opm-project.org/ewoms
 Source0:        https://github.com/OPM/%{name}/archive/release/%{version}/%{tag}.tar.gz#/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildRequires: cmake28 dune-common-devel openmpi environment-modules valgrind
-BuildRequires: make pkgconfig openmpi-devel dune-grid-devel
+BuildRequires: dune-common-devel openmpi environment-modules valgrind
+BuildRequires: make pkgconfig openmpi-devel dune-grid-devel opm-common-devel
 BuildRequires: opm-core-devel opm-material-devel boost148-devel
 BuildRequires: dune-istl-devel dune-localfunctions-devel doxygen
 Requires:      ewoms-devel
-%{?el5:BuildRequires: gcc44 gcc44-c++}
-%{!?el5:BuildRequires: gcc gcc-c++}
+%{?el6:BuildRequires: cmake28 devtoolset-2}
+%{!?el6:BuildRequires: cmake gcc gcc-c++}
 
 %description
 eWoms is an simulation framework which is primary focused on fully implicit
@@ -43,8 +43,9 @@ flow and transport processes in porous media.
 %setup -q -n %{name}-release-%{version}-%{tag}
 
 %build
-%{!?el5: module add openmpi-%{_arch}}
-cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGING_SYMBOLS=ON -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{?el5:-DCMAKE_CXX_COMPILER=g++44 -DCMAKE_C_COMPILER=gcc44} -DBOOST_LIBRARYDIR=%{_libdir}/boost148 -DBOOST_INCLUDEDIR=/usr/include/boost148
+module add openmpi-%{_arch}
+%{?el6:scl enable devtoolset-2 bash}
+%{?el6:cmake28} %{!?el6:cmake} -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGING_SYMBOLS=ON -DCMAKE_INSTALL_PREFIX=%{_prefix} -DCMAKE_INSTALL_DOCDIR=share/doc/%{name}-%{version} -DUSE_RUNPATH=OFF %{?el6:-DCMAKE_CXX_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/g++ -DCMAKE_C_COMPILER=/opt/rh/devtoolset-2/root/usr/bin/gcc} -DBOOST_LIBRARYDIR=%{_libdir}/boost148 -DBOOST_INCLUDEDIR=/usr/include/boost148
 %__make %{?jobs:-j%{jobs}}
 
 # No symbols in a template-only library
@@ -52,15 +53,16 @@ cmake28 -DBUILD_SHARED_LIBS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSTRIP_DEBUGGIN
 
 %install
 make install DESTDIR=${RPM_BUILD_ROOT}
-make doc
+%{!?el6:make doc}
 
 %clean
 rm -fr %buildroot
 
 %files
 %defattr(-,root,root)
+%{!?el6:
 %doc README
-%doc doc/doxygen/html
+%doc doc/doxygen/html}
 
 %files devel
 %defattr(-,root,root)


### PR DESCRIPTION
- el5 removed
- el7 added

additionally i had to disable the documentation on el6 as it crashes doxygen. i don't feel like hunting down a bug in an 8 year old doxygen version.