### PR TITLE
Implement storage cache

### DIFF
--- a/applications/ebos/eclproblem.hh
+++ b/applications/ebos/eclproblem.hh
@@ -152,6 +152,9 @@ SET_BOOL_PROP(EclBaseProblem, EnableEclSummaryOutput, true);
 // decent speedup...
 SET_BOOL_PROP(EclBaseProblem, EnableIntensiveQuantityCache, true);
 
+// the cache for the storage term can also be used and also yields a decent speedup
+SET_BOOL_PROP(EclBaseProblem, EnableStorageCache, true);
+
 // Use the "velocity module" which uses the Eclipse "NEWTRAN" transmissibilities
 SET_TYPE_PROP(EclBaseProblem, FluxModule, Ewoms::EclTransFluxModule<TypeTag>);
 

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -209,6 +209,9 @@ SET_BOOL_PROP(FvBaseDiscretization, EnableLinearizationRecycling, false);
 // disable partial relinearization by default
 SET_BOOL_PROP(FvBaseDiscretization, EnablePartialRelinearization, false);
 
+// disable caching the storage term by default
+SET_BOOL_PROP(FvBaseDiscretization, EnableStorageCache, false);
+
 // disable constraints by default
 SET_BOOL_PROP(FvBaseDiscretization, EnableConstraints, false);
 
@@ -302,6 +305,8 @@ public:
         , localLinearizer_(ThreadManager::maxThreads())
         , linearizer_(new Linearizer())
     {
+        enableStorageCache_ = EWOMS_GET_PARAM(TypeTag, bool, EnableStorageCache);
+
         asImp_().updateBoundary_();
 
         unsigned nDofs = asImp_().numGridDof();
@@ -312,6 +317,9 @@ public:
                 intensiveQuantityCache_[timeIdx].resize(nDofs);
                 intensiveQuantityCacheUpToDate_[timeIdx].resize(nDofs, /*value=*/false);
             }
+
+            if (enableStorageCache_)
+                storageCache_[timeIdx].resize(nDofs);
         }
 
         asImp_().registerOutputModules_();
@@ -347,6 +355,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableVtkOutput, "Global switch for turing on writing VTK files");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableThermodynamicHints, "Enable thermodynamic hints");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableIntensiveQuantityCache, "Turn on caching of intensive quantities");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableStorageCache, "Store previous storage terms and avoid re-calculating them.");
     }
 
     /*!
@@ -593,6 +602,39 @@ public:
         std::fill(intensiveQuantityCacheUpToDate_[/*timeIdx=*/0].begin(),
                   intensiveQuantityCacheUpToDate_[/*timeIdx=*/0].end(),
                   false);
+    }
+
+    /*!
+     * \brief Retrieve an entry of the cache for the storage term.
+     *
+     * This is supposed to represent a DOF's total amount of conservation quantities per
+     * volume unit at a given time. The user is responsible for making sure that the
+     * value of this is correct and that it can be used before this method is called.
+     *
+     * \param globalDofIdx The index of the relevant degree of freedom in a grid-global vector
+     * \param timeIdx The relevant index for the time discretization
+     */
+    const EqVector& cachedStorage(int globalIdx, int timeIdx) const
+    {
+        assert(enableStorageCache_);
+        return storageCache_[timeIdx][globalIdx];
+    }
+
+    /*!
+     * \brief Set an entry of the cache for the storage term.
+     *
+     * This is supposed to represent a DOF's total amount of conservation quantities per
+     * volume unit at a given time. The user is responsible for making sure that the
+     * storage cache is enabled before this method is called.
+     *
+     * \param globalDofIdx The index of the relevant degree of freedom in a grid-global vector
+     * \param timeIdx The relevant index for the time discretization
+     * \param value The new value of the cache for the storage term
+     */
+    void updateCachedStorage(int globalIdx, int timeIdx, const EqVector& value) const
+    {
+        assert(enableStorageCache_);
+        storageCache_[timeIdx][globalIdx] = value;
     }
 
     /*!
@@ -1555,6 +1597,9 @@ protected:
     Scalar gridTotalVolume_;
     std::vector<Scalar> dofTotalVolume_;
     std::vector<bool> isLocalDof_;
+
+    mutable GlobalEqVector storageCache_[historySize];
+    bool enableStorageCache_;
 };
 } // namespace Ewoms
 

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -605,6 +605,15 @@ public:
     }
 
     /*!
+     * \brief Returns true iff the storage term is cached.
+     *
+     * Be aware that calling the *CachedStorage() methods if the storage cache is
+     * disabled will crash the program.
+     */
+    bool enableStorageCache() const
+    { return enableStorageCache_; }
+
+    /*!
      * \brief Retrieve an entry of the cache for the storage term.
      *
      * This is supposed to represent a DOF's total amount of conservation quantities per
@@ -750,7 +759,9 @@ public:
                     continue; // ignore ghost and overlap elements
 
                 elemCtx.updateStencil(elem);
-                elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
+
+                if (timeIdx == 0 || !enableStorageCache())
+                    elemCtx.updatePrimaryIntensiveQuantities(timeIdx);
 
                 unsigned numPrimaryDof = elemCtx.numPrimaryDof(timeIdx);
                 elemStorage.resize(numPrimaryDof);

--- a/ewoms/disc/common/fvbaselocalresidual.hh
+++ b/ewoms/disc/common/fvbaselocalresidual.hh
@@ -110,7 +110,7 @@ public:
      *
      * \copydetails Doxygen::ecfvScvIdxParam
      */
-    const VectorBlock &residual(int dofIdx) const
+    const VectorBlock &residual(unsigned dofIdx) const
     { return internalResidual_[dofIdx]; }
 
     /*!
@@ -126,7 +126,7 @@ public:
      *
      * \copydetails Doxygen::ecfvScvIdxParam
      */
-    const VectorBlock &storageTerm(int dofIdx) const
+    const VectorBlock &storageTerm(unsigned dofIdx) const
     { return internalStorageTerm_[dofIdx]; }
 
     /*!
@@ -159,8 +159,8 @@ public:
      */
     void eval(const ElementContext &elemCtx)
     {
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        unsigned numDof = elemCtx.numDof(/*timeIdx=*/0);
+        unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
         internalResidual_.resize(numDof);
         internalStorageTerm_.resize(numPrimaryDof);
         asImp_().eval(internalResidual_, internalStorageTerm_, elemCtx);
@@ -193,13 +193,13 @@ public:
         // evaluate the boundary conditions
         asImp_().evalBoundary_(residual, elemCtx, /*timeIdx=*/0);
 
-        // evaluate the constraint DOFs
+        // evaluate the constraunsigned DOFs
         asImp_().evalConstraints_(residual, storage, elemCtx, /*timeIdx=*/0);
 
         // make the residual volume specific (i.e., make it incorrect mass per cubic
         // meter instead of total mass)
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);;
-        for (int dofIdx=0; dofIdx < numDof; ++dofIdx) {
+        unsigned numDof = elemCtx.numDof(/*timeIdx=*/0);;
+        for (unsigned dofIdx=0; dofIdx < numDof; ++dofIdx) {
             if (elemCtx.dofTotalVolume(dofIdx, /*timeIdx=*/0) > 0) {
                 // interior DOF
                 Scalar dofVolume = elemCtx.dofTotalVolume(dofIdx, /*timeIdx=*/0);
@@ -207,7 +207,7 @@ public:
                 assert(std::isfinite(dofVolume));
                 Valgrind::CheckDefined(dofVolume);
 
-                for (int eqIdx = 0; eqIdx < numEq; ++ eqIdx)
+                for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx)
                     residual[dofIdx][eqIdx] /= dofVolume;
             }
         }
@@ -223,9 +223,9 @@ public:
      * \copydetails Doxygen::ecfvElemCtxParam
      * \copydetails Doxygen::timeIdxParam
      */
-    void evalStorage(const ElementContext &elemCtx, int timeIdx)
+    void evalStorage(const ElementContext &elemCtx, unsigned timeIdx)
     {
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
         internalStorageTerm_.resize(numPrimaryDof);
         evalStorage(internalStorageTerm_,
                     elemCtx,
@@ -245,7 +245,7 @@ public:
      */
     void evalStorage(LocalBlockVector &storage,
                      const ElementContext &elemCtx,
-                     int timeIdx) const
+                     unsigned timeIdx) const
     {
         if (timeIdx == 0) {
             // for the most current solution, the storage term depends on the current
@@ -253,12 +253,12 @@ public:
 
             // calculate the amount of conservation each quantity inside
             // all primary sub control volumes
-            int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-            for (int dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
+            unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+            for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
                 storage[dofIdx] = 0.0;
                 asImp_().computeStorage(storage[dofIdx], elemCtx, dofIdx, timeIdx);
 
-                for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
                     storage[dofIdx][eqIdx] *=
                         elemCtx.stencil(timeIdx).subControlVolume(dofIdx).volume()
                         * elemCtx.intensiveQuantities(dofIdx, timeIdx).extrusionFactor();
@@ -268,24 +268,31 @@ public:
         else {
             // for all previous solutions, the storage term does _not_ depend on the
             // current primary variables, so we use scalars to store it.
+            if (elemCtx.model().enableStorageCache()) {
+                unsigned numPrimaryDof = elemCtx.numPrimaryDof(timeIdx);
+                for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
+                    unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
+                    storage[dofIdx] = elemCtx.model().cachedStorage(globalDofIdx, timeIdx);
+                }
+            }
+            else {
+                // calculate the amount of conservation each quantity inside
+                // all primary sub control volumes
+                Dune::FieldVector<Scalar, numEq> tmp;
+                unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+                for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
+                    tmp = 0.0;
+                    asImp_().computeStorage(tmp,
+                                            elemCtx,
+                                            dofIdx,
+                                            timeIdx);
+                    tmp *=
+                        elemCtx.stencil(timeIdx).subControlVolume(dofIdx).volume()
+                        * elemCtx.intensiveQuantities(dofIdx, timeIdx).extrusionFactor();
 
-            // calculate the amount of conservation each quantity inside
-            // all primary sub control volumes
-            Dune::FieldVector<Scalar, numEq> tmp;
-            int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-            for (int dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
-                tmp = 0.0;
-                asImp_().computeStorage(tmp,
-                                        elemCtx,
-                                        dofIdx,
-                                        timeIdx);
-                tmp *=
-                    elemCtx.stencil(timeIdx).subControlVolume(dofIdx).volume()
-                    * elemCtx.intensiveQuantities(dofIdx, timeIdx).extrusionFactor();
-
-
-                for (int eqIdx = 0; eqIdx < numEq; ++eqIdx)
-                    storage[dofIdx][eqIdx] = tmp[eqIdx];
+                    for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
+                        storage[dofIdx][eqIdx] = tmp[eqIdx];
+                }
             }
         }
     }
@@ -299,17 +306,17 @@ public:
      */
     void evalFluxes(LocalBlockVector &residual,
                     const ElementContext &elemCtx,
-                    int timeIdx) const
+                    unsigned timeIdx) const
     {
         RateVector flux;
 
         const auto &stencil = elemCtx.stencil(timeIdx);
         // calculate the mass flux over the sub-control volume faces
-        int numInteriorFaces = elemCtx.numInteriorFaces(timeIdx);
-        for (int scvfIdx = 0; scvfIdx < numInteriorFaces; scvfIdx++) {
+        unsigned numInteriorFaces = elemCtx.numInteriorFaces(timeIdx);
+        for (unsigned scvfIdx = 0; scvfIdx < numInteriorFaces; scvfIdx++) {
             const auto &face = stencil.interiorFace(scvfIdx);
-            int i = face.interiorIndex();
-            int j = face.exteriorIndex();
+            unsigned i = face.interiorIndex();
+            unsigned j = face.exteriorIndex();
 
             Valgrind::SetUndefined(flux);
             asImp_().computeFlux(flux, /*context=*/elemCtx, scvfIdx, timeIdx);
@@ -318,7 +325,7 @@ public:
             Scalar alpha = elemCtx.extensiveQuantities(scvfIdx, timeIdx).extrusionFactor();
             alpha *= face.area();
             Valgrind::CheckDefined(alpha);
-            for (int eqIdx = 0; eqIdx < numEq; ++ eqIdx)
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx)
                 flux[eqIdx] *= alpha;
 
             // The balance equation for a finite volume is given by
@@ -340,9 +347,9 @@ public:
 
 #if !defined NDEBUG
         // in debug mode, ensure that the residual is well-defined
-        int numDof = elemCtx.numDof(timeIdx);
-        for (int i=0; i < numDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        unsigned numDof = elemCtx.numDof(timeIdx);
+        for (unsigned i=0; i < numDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(residual[i][j])));
                 Valgrind::CheckDefined(residual[i][j]);
             }
@@ -365,8 +372,8 @@ public:
      */
     void computeStorage(EqVector &storage,
                         const ElementContext &elemCtx,
-                        int dofIdx,
-                        int timeIdx) const
+                        unsigned dofIdx,
+                        unsigned timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: The local residual " << Opm::className<Implementation>()
@@ -382,8 +389,8 @@ public:
      */
     void computeFlux(RateVector &flux,
                      const ElementContext &elemCtx,
-                     int scvfIdx,
-                     int timeIdx) const
+                     unsigned scvfIdx,
+                     unsigned timeIdx) const
     {
         OPM_THROW(std::logic_error,
                   "Not implemented: The local residual " << Opm::className<Implementation>()
@@ -398,8 +405,8 @@ public:
      */
     void computeSource(RateVector &source,
                        const ElementContext &elemCtx,
-                       int dofIdx,
-                       int timeIdx) const
+                       unsigned dofIdx,
+                       unsigned timeIdx) const
     {
         OPM_THROW(std::logic_error,
                   "Not implemented: The local residual " << Opm::className<Implementation>()
@@ -412,7 +419,7 @@ protected:
      */
     void evalBoundary_(LocalBlockVector &residual,
                        const ElementContext &elemCtx,
-                       int timeIdx) const
+                       unsigned timeIdx) const
     {
         if (!elemCtx.onBoundary())
             return;
@@ -420,8 +427,8 @@ protected:
         BoundaryContext boundaryCtx(elemCtx);
 
         // evaluate the boundary for all boundary faces of the current context
-        int numBoundaryFaces = boundaryCtx.numBoundaryFaces(/*timeIdx=*/0);
-        for (int faceIdx = 0; faceIdx < numBoundaryFaces; ++faceIdx) {
+        unsigned numBoundaryFaces = boundaryCtx.numBoundaryFaces(/*timeIdx=*/0);
+        for (unsigned faceIdx = 0; faceIdx < numBoundaryFaces; ++faceIdx) {
             // add the residual of all vertices of the boundary
             // segment
             evalBoundarySegment_(residual,
@@ -432,9 +439,9 @@ protected:
 
 #if !defined NDEBUG
         // in debug mode, ensure that the residual and the storage terms are well-defined
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        for (int i=0; i < numDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        unsigned numDof = elemCtx.numDof(/*timeIdx=*/0);
+        for (unsigned i=0; i < numDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(residual[i][j])));
                 Valgrind::CheckDefined(residual[i][j]);
             }
@@ -449,8 +456,8 @@ protected:
      */
     void evalBoundarySegment_(LocalBlockVector &residual,
                               const BoundaryContext &boundaryCtx,
-                              int boundaryFaceIdx,
-                              int timeIdx) const
+                              unsigned boundaryFaceIdx,
+                              unsigned timeIdx) const
     {
         BoundaryRateVector values;
 
@@ -462,7 +469,7 @@ protected:
         Valgrind::CheckDefined(values);
 
         const auto &stencil = boundaryCtx.stencil(timeIdx);
-        int dofIdx = stencil.boundaryFace(boundaryFaceIdx).interiorIndex();
+        unsigned dofIdx = stencil.boundaryFace(boundaryFaceIdx).interiorIndex();
         const auto &insideIntQuants = boundaryCtx.elementContext().intensiveQuantities(dofIdx, timeIdx);
         for (unsigned eqIdx = 0; eqIdx < values.size(); ++eqIdx)
             values[eqIdx] *=
@@ -475,12 +482,12 @@ protected:
     }
 
     /*!
-     * \brief Set the values of the constraint volumes of the current element.
+     * \brief Set the values of the constraunsigned volumes of the current element.
      */
     void evalConstraints_(LocalBlockVector &residual,
                           LocalBlockVector &storage,
                           const ElementContext &elemCtx,
-                          int timeIdx) const
+                          unsigned timeIdx) const
     {
         if (!GET_PROP_VALUE(TypeTag, EnableConstraints))
             return;
@@ -488,9 +495,9 @@ protected:
         const auto &problem = elemCtx.problem();
         Constraints constraints;
         ConstraintsContext constraintsCtx(elemCtx);
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-        for (int dofIdx = 0; dofIdx < numPrimaryDof; ++dofIdx) {
-            // ask the problem for the constraint values
+        unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        for (unsigned dofIdx = 0; dofIdx < numPrimaryDof; ++dofIdx) {
+            // ask the problem for the constraunsigned values
             constraints.reset();
             problem.constraints(constraints, elemCtx, dofIdx, timeIdx);
 
@@ -499,11 +506,11 @@ protected:
 
             // enforce the constraints
             const PrimaryVariables &priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
                 if (!constraints.isConstraint(eqIdx))
                     continue;
 
-                int pvIdx = constraints.eqToPvIndex(eqIdx);
+                unsigned pvIdx = constraints.eqToPvIndex(eqIdx);
 
                 assert(0 <= pvIdx && pvIdx < numEq);
                 Valgrind::CheckDefined(constraints[pvIdx]);
@@ -515,16 +522,16 @@ protected:
 
 #if !defined NDEBUG
         // in debug mode, ensure that the residual and the storage terms are well-defined
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        for (int i=0; i < numDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        unsigned numDof = elemCtx.numDof(/*timeIdx=*/0);
+        for (unsigned i=0; i < numDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(residual[i][j])));
                 Valgrind::CheckDefined(residual[i][j]);
             }
         }
 
-        for (int i=0; i < numPrimaryDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        for (unsigned i=0; i < numPrimaryDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(storage[i][j])));
                 Valgrind::CheckDefined(storage[i][j]);
             }
@@ -549,8 +556,8 @@ protected:
         tmp2 = 0.0;
 
         // evaluate the volumetric terms (storage + source terms)
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-        for (int dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
+        unsigned numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
             Scalar extrusionFactor =
                 elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).extrusionFactor();
             Scalar scvVolume =
@@ -571,12 +578,12 @@ protected:
 
             if (enableStorageCache_) {
                 const auto& model = elemCtx.model();
-                int globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+                unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
                 if (model.newtonMethod().numIterations() == 0) {
                     // if the storage term is cached and we're in the first iteration of
                     // the time step, update the storage term cache (this assumes that
                     // the initial solution is the same for each time index.)
-                    for (int eqIdx = 0; eqIdx < numEq; ++ eqIdx)
+                    for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx)
                         tmp2[eqIdx] = Toolbox::value(tmp[eqIdx]);
                     Valgrind::CheckDefined(tmp2);
 
@@ -601,7 +608,7 @@ protected:
             }
 
             tmp -= tmp2;
-            for (int eqIdx = 0; eqIdx < numEq; eqIdx++)
+            for (unsigned eqIdx = 0; eqIdx < numEq; eqIdx++)
                 tmp[eqIdx] *= scvVolume / elemCtx.simulator().timeStepSize();
 
             storage[dofIdx] += tmp;
@@ -612,7 +619,7 @@ protected:
 
             // deal with the source term
             asImp_().computeSource(sourceRate, elemCtx, dofIdx, /*timeIdx=*/0);
-            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx)
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
                 sourceRate[eqIdx] *= scvVolume;
             residual[dofIdx] -= sourceRate;
 
@@ -621,16 +628,16 @@ protected:
 
 #if !defined NDEBUG
         // in debug mode, ensure that the residual and the storage terms are well-defined
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        for (int i=0; i < numDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        unsigned numDof = elemCtx.numDof(/*timeIdx=*/0);
+        for (unsigned i=0; i < numDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(residual[i][j])));
                 Valgrind::CheckDefined(residual[i][j]);
             }
         }
 
-        for (int i=0; i < numPrimaryDof; i++) {
-            for (int j = 0; j < numEq; ++ j) {
+        for (unsigned i=0; i < numPrimaryDof; i++) {
+            for (unsigned j = 0; j < numEq; ++ j) {
                 assert(std::isfinite(Toolbox::value(storage[i][j])));
                 Valgrind::CheckDefined(storage[i][j]);
             }

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -226,6 +226,15 @@ NEW_PROP_TAG(MaxTimeStepDivisions);
 NEW_PROP_TAG(EnableIntensiveQuantityCache);
 
 /*!
+ * \brief Specify whether the storage terms for previous solutions should be cached.
+ *
+ * This potentially reduces the CPU time, but comes at the cost of higher memory
+ * consumption. And it may lead to problems with partial relinearization and
+ * linearization recycling.
+ */
+NEW_PROP_TAG(EnableStorageCache);
+
+/*!
  * \brief Specify whether to use the already calculated solutions as
  *        starting values of the intensive quantities.
  *


### PR DESCRIPTION
this is a bit hacky because it assumes that an Euler time discretization is used and that the solution for the time indices 0 and 1 are identical at the beginning of a time step. Nevertheless, it saves us from updating the intensive variables for solutions other than the one of the current iteration.

on my machine, this accelerates the linearization with ebos by about 30% for SPE9 (6.4 instead of 8.7 seconds, but the linearization still takes up the largest time chunk with about 50% of the total time spend).