### PR TITLE
improve the art2dgf utility and unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,16 @@ EwomsAddApplication(ebos
                     EXE_NAME ebos
                     CONDITION HAVE_DUNE_CORNERPOINT AND HAVE_ERT)
 
+# the ART to DGF file format conversion utility
+EwomsAddApplication(art2dgf
+                    SOURCES applications/art2dgf.cc
+                    EXE_NAME art2dgf)
+
+opm_add_test(art2dgf
+  NO_COMPILE
+  DRIVER_ARGS --plain
+  TEST_ARGS "data/fracture.art")
+
 # add targets for all tests of the models. we add the water-air test
 # first because it take longest and so that we don't have to wait for
 # them as long for parallel test runs
@@ -248,9 +258,6 @@ opm_add_test(obstacle_pvs_restart
              DEPENDS obstacle_pvs
              DRIVER_ARGS --restart
              TEST_ARGS --pvs-verbosity=2 --end-time=15000)
-
-opm_add_test(art2dgf
-             DRIVER_ARGS --plain)
 
 
 # the test for the plain stokes model is completes quite

--- a/applications/art2dgf.cc
+++ b/applications/art2dgf.cc
@@ -264,14 +264,22 @@ namespace Ewoms {
 
 int main( int argc, char** argv )
 {
-    if( argc > 1 )
-    {
-        std::string filename( argv[ 1 ] );
-        std::string dgfname( filename );
-        dgfname += ".dgf";
-
-        std::ofstream dgfFile( dgfname );
-        Ewoms::Art2DGF::convert( filename, dgfFile );
+    if (argc != 2) {
+        std::cout << "Converts a grid file from the ART file format to DGF (Dune grid format)\n"
+                  << "\n"
+                  << "Usage: " << argv[0] << " ART_FILENAME\n"
+                  << "\n"
+                  << "The result will be written to the file $ART_FILENAME.dgf\n";
+        return 1;
     }
+
+    std::string filename( argv[ 1 ] );
+    std::string dgfname( filename );
+    dgfname += ".dgf";
+
+    std::cout << "Converting ART file \"" << filename << "\" to DGF file \"" << dgfname << "\"\n";
+    std::ofstream dgfFile( dgfname );
+    Ewoms::Art2DGF::convert( filename, dgfFile );
+
     return 0;
 }


### PR DESCRIPTION
the utility is now more verbose (it actually prints what it does or
does not do), the test converts the example ART file shipped with
eWoms, and finally the art2dgf utility is now not considered a "unit
test" anymore (instead, it is an application).