### PR TITLE
adapt to the recent API changes in opm-material

### DIFF
--- a/applications/ebos/ecloutputblackoilmodule.hh
+++ b/applications/ebos/ecloutputblackoilmodule.hh
@@ -191,12 +191,12 @@ public:
             }
             if (gasFormationVolumeFactorOutput_()) {
                 gasFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template formationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template inverseFormationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
                 Valgrind::CheckDefined(gasFormationVolumeFactor_[globalDofIdx]);
             }
             if (saturatedOilFormationVolumeFactorOutput_()) {
                 saturatedOilFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template saturatedFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template saturatedInverseFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
                 Valgrind::CheckDefined(saturatedOilFormationVolumeFactor_[globalDofIdx]);
             }
             if (oilSaturationPressureOutput_()) {

--- a/ewoms/io/vtkblackoilmodule.hh
+++ b/ewoms/io/vtkblackoilmodule.hh
@@ -241,13 +241,13 @@ public:
                 oilVaporizationFactor_[globalDofIdx] = Rv;
             if (oilFormationVolumeFactorOutput_())
                 oilFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template formationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template inverseFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
             if (gasFormationVolumeFactorOutput_())
                 gasFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template formationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template inverseFormationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
             if (waterFormationVolumeFactorOutput_())
                 waterFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template formationVolumeFactor<FluidState, Scalar>(fs, waterPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template inverseFormationVolumeFactor<FluidState, Scalar>(fs, waterPhaseIdx, pvtRegionIdx);
             if (oilSaturationPressureOutput_())
                 oilSaturationPressure_[globalDofIdx] =
                     FluidSystem::template saturationPressure<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
@@ -271,10 +271,10 @@ public:
             }
             if (saturatedOilFormationVolumeFactorOutput_())
                 saturatedOilFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template saturatedFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template saturatedInverseFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
             if (saturatedGasFormationVolumeFactorOutput_())
                 saturatedGasFormationVolumeFactor_[globalDofIdx] =
-                    FluidSystem::template saturatedFormationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
+                    1.0/FluidSystem::template saturatedInverseFormationVolumeFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
 
             if (primaryVarsMeaningOutput_())
                 primaryVarsMeaning_[globalDofIdx] =

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -191,7 +191,7 @@ public:
 
         // set the phase densities and viscosities
         for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            const auto& b = 1.0/FluidSystem::formationVolumeFactor(fluidState_, phaseIdx, pvtRegionIdx);
+            const auto& b = FluidSystem::inverseFormationVolumeFactor(fluidState_, phaseIdx, pvtRegionIdx);
             fluidState_.setInvB(phaseIdx, b);
 
             const auto& mu = FluidSystem::viscosity(fluidState_, paramCache, phaseIdx);

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -235,7 +235,7 @@ public:
             (*this)[compositionSwitchIdx] = FsToolbox::value(fluidState.saturation(gasPhaseIdx));
         }
         else if (primaryVarsMeaning() == Sw_po_Rs) {
-            const auto& Rs = getRs_(fluidState);
+            const auto& Rs = Opm::BlackOil::getRs_<FluidSystem, Scalar, FluidState>(fluidState, pvtRegionIdx_);
 
             (*this)[waterSaturationIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
             (*this)[pressureSwitchIdx] = FsToolbox::value(fluidState.pressure(oilPhaseIdx));
@@ -244,7 +244,7 @@ public:
         else {
             assert(primaryVarsMeaning() == Sw_pg_Rv);
 
-            const auto& Rv = getRv_(fluidState);
+            const auto& Rv = Opm::BlackOil::getRv_<FluidSystem, Scalar, FluidState>(fluidState, pvtRegionIdx_);
             (*this)[waterSaturationIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
             (*this)[pressureSwitchIdx] = FsToolbox::value(fluidState.pressure(gasPhaseIdx));
             (*this)[compositionSwitchIdx] = Rv;
@@ -414,40 +414,6 @@ private:
 
     const Implementation &asImp_() const
     { return *static_cast<const Implementation*>(this); }
-
-    template <class FluidState>
-    Scalar getRs_(const FluidState& fluidState) const
-    {
-        typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
-
-        Scalar XoG = FsToolbox::value(fluidState.massFraction(oilPhaseIdx, gasCompIdx));
-        return convertXoGToRs_(XoG);
-    }
-
-    template <class FluidState>
-    Scalar getRv_(const FluidState& fluidState) const
-    {
-        typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
-
-        Scalar XgO = FsToolbox::value(fluidState.massFraction(gasPhaseIdx, oilCompIdx));
-        return convertXgOToRv_(XgO);
-    }
-
-    Scalar convertXoGToRs_(Scalar XoG) const
-    {
-        Scalar rho_oRef = FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx_);
-        Scalar rho_gRef = FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx_);
-
-        return XoG/(1.0 - XoG)*(rho_oRef/rho_gRef);
-    }
-
-    Scalar convertXgOToRv_(Scalar XgO) const
-    {
-        Scalar rho_oRef = FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx_);
-        Scalar rho_gRef = FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx_);
-
-        return XgO/(1.0 - XgO)*(rho_gRef/rho_oRef);
-    }
 
     // the standard blackoil model is isothermal
     Scalar temperature_() const


### PR DESCRIPTION
the change for the inverse formation volume factors (instead of the
FVFs) is needed to keep the build happy, using the new
getRv_()/getRs_() infrastructure might slightly improve
performance. (the emphasis is *slightly* because it only changes
something if BlackOilFluidState is used for initialization and
initialization is not time critical in the first place.)

the changes of this PR are required to keep the build happy after OPM/opm-material#114 has been merged.