### PR TITLE
Renaming dune-cornerpoint -> opm-grid.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ set(CMAKE_PROJECT_NAME "${PROJECT_NAME}")
 EwomsAddApplication(ebos
                     SOURCES applications/ebos/ebos.cc
                     EXE_NAME ebos
-                    CONDITION HAVE_DUNE_CORNERPOINT AND HAVE_ERT)
+                    CONDITION HAVE_OPM_GRID AND HAVE_ERT)
 
 # the ART to DGF file format conversion utility
 EwomsAddApplication(art2dgf

--- a/INSTALL
+++ b/INSTALL
@@ -24,7 +24,7 @@ the following modules:
 
   - opm-parser         from [3]
   - opm-core           from [3]
-  - dune-cornerpoint   from [3]
+  - dune-grid          from [3]
 
 For eWoms, the latest release or development branch version of the
 prerequisite software usually works fine.

--- a/applications/ebos/collecttoiorank.hh
+++ b/applications/ebos/collecttoiorank.hh
@@ -23,12 +23,12 @@
 #ifndef EWOMS_PARALLELSERIALOUTPUT_HH
 #define EWOMS_PARALLELSERIALOUTPUT_HH
 
-//#if HAVE_DUNE_CORNERPOINT
+//#if HAVE_OPM_GRID
 #include <dune/grid/common/p2pcommunicator.hh>
 #include <dune/grid/utility/persistentcontainer.hh>
 #include <dune/grid/common/gridenums.hh>
 //#else
-//#error "This header needs the dune-cornerpoint module."
+//#error "This header needs the opm-grid module."
 //#endif
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/applications/ebos/eclproblem.hh
+++ b/applications/ebos/eclproblem.hh
@@ -798,7 +798,7 @@ private:
 
         // read the intrinsic permeabilities from the eclState. Note that all arrays
         // provided by eclState are one-per-cell of "uncompressed" grid, whereas the
-        // dune-cornerpoint grid object might remove a few elements...
+        // opm-grid CpGrid object might remove a few elements...
         if (eclState->hasDeckDoubleGridProperty("PERMX")) {
             const std::vector<double> &permxData =
                 eclState->getDoubleGridProperty("PERMX")->getData();

--- a/applications/ebos/eclwriter.hh
+++ b/applications/ebos/eclwriter.hh
@@ -103,7 +103,7 @@ class EclWriterHelper
  *   ERT libraries with development headers installed and the ERT
  *   build system test must pass sucessfully.
  * - The only DUNE grid which is currently supported is Dune::CpGrid
- *   from the OPM module "dune-cornerpoint". Using another grid won't
+ *   from the OPM module "opm-core". Using another grid won't
  *   fail at compile time but you will provoke a fatal exception as
  *   soon as you try to write an ECL output file.
  * - This class requires to use the black oil model with the element

--- a/applications/ebos/ertwrappers.hh
+++ b/applications/ebos/ertwrappers.hh
@@ -266,7 +266,7 @@ public:
                                               coordKeyword.ertHandle(),
                                               actnumKeyword.ertHandle(),
                                               mapaxesData.size()?mapaxesKeyword.ertHandle():NULL);
-#endif // HAVE_ERT && HAVE_DUNE_CORNERPOINT
+#endif // HAVE_ERT
     }
 
     ~ErtGrid()

--- a/dune.module
+++ b/dune.module
@@ -12,6 +12,6 @@ Maintainer: and@poware.org
 Depends: dune-grid (>= 2.3) dune-localfunctions  (>= 2.3) dune-istl  (>= 2.3) opm-common opm-material
 
 # actually, we also suggest opm-parser, but this dependency only makes
-# any sense if dune-cornerpoint is available and opm-parser is a
-# required dependency of dune-cornerpoint...
-Suggests: dune-fem dune-alugrid dune-cornerpoint
+# any sense if opm-grid is available and opm-parser is a
+# required dependency of opm-grid...
+Suggests: dune-fem dune-alugrid opm-grid


### PR DESCRIPTION
This updates code to refer to opm-grid instead of dune-cornerpoint.

Requires OPM/opm-common#104.