### PR TITLE
fixed: restore build of ebos after opm-parser changes

### DIFF
--- a/applications/ebos/eclwellmanager.hh
+++ b/applications/ebos/eclwellmanager.hh
@@ -100,7 +100,7 @@ public:
         // create the wells which intersect with the current process' grid
         for (size_t deckWellIdx = 0; deckWellIdx < deckSchedule->numWells(); ++deckWellIdx)
         {
-            Opm::WellConstPtr deckWell = deckSchedule->getWells()[deckWellIdx];
+            const Opm::Well* deckWell = deckSchedule->getWells()[deckWellIdx];
             const std::string &wellName = deckWell->name();
 
             // set the name of the well but not much else. (i.e., if it is not completed,
@@ -134,10 +134,10 @@ public:
         // linearized system of equations
         updateWellParameters_(episodeIdx, wellCompMap);
 
-        const std::vector<Opm::WellConstPtr>& deckWells = deckSchedule->getWells(episodeIdx);
+        const std::vector<const Opm::Well*>& deckWells = deckSchedule->getWells(episodeIdx);
         // set the injection data for the respective wells.
         for (size_t deckWellIdx = 0; deckWellIdx < deckWells.size(); ++deckWellIdx) {
-            Opm::WellConstPtr deckWell = deckWells[deckWellIdx];
+            const Opm::Well* deckWell = deckWells[deckWellIdx];
 
             if (!hasWell(deckWell->name()))
                 continue;
@@ -674,9 +674,9 @@ protected:
 
         // compute the mapping from logically Cartesian indices to the well the
         // respective completion.
-        const std::vector<Opm::WellConstPtr>& deckWells = deckSchedule->getWells(reportStepIdx);
+        const std::vector<const Opm::Well*>& deckWells = deckSchedule->getWells(reportStepIdx);
         for (size_t deckWellIdx = 0; deckWellIdx < deckWells.size(); ++deckWellIdx) {
-            Opm::WellConstPtr deckWell = deckWells[deckWellIdx];
+            const Opm::Well* deckWell = deckWells[deckWellIdx];
             const std::string& wellName = deckWell->name();
 
             if (!hasWell(wellName))
@@ -716,11 +716,11 @@ protected:
     {
         auto eclStatePtr = simulator_.gridManager().eclState();
         auto deckSchedule = eclStatePtr->getSchedule();
-        const std::vector<Opm::WellConstPtr>& deckWells = deckSchedule->getWells(reportStepIdx);
+        const std::vector<const Opm::Well*>& deckWells = deckSchedule->getWells(reportStepIdx);
 
         // set the reference depth for all wells
         for (size_t deckWellIdx = 0; deckWellIdx < deckWells.size(); ++deckWellIdx) {
-            Opm::WellConstPtr deckWell = deckWells[deckWellIdx];
+            const Opm::Well* deckWell = deckWells[deckWellIdx];
             const std::string& wellName = deckWell->name();
 
             if( hasWell( wellName ) )

--- a/applications/ebos/ertwrappers.hh
+++ b/applications/ebos/ertwrappers.hh
@@ -395,7 +395,7 @@ public:
 
 private:
     void appendIwelData_(std::vector<int>& iwelData,
-                         Opm::WellConstPtr eclWell,
+                         const Opm::Well* eclWell,
                          size_t reportStepIdx) const
     {
         int offset = iwelData.size();
@@ -414,7 +414,7 @@ private:
     }
 
     void appendZwelData_(std::vector<const char*>& zwelData,
-                         Opm::WellConstPtr eclWell,
+                         const Opm::Well* eclWell,
                          size_t /*reportStepIdx*/) const
     {
         zwelData.push_back(eclWell->name().c_str());
@@ -425,7 +425,7 @@ private:
     }
 
     void appendIconData_(std::vector<int>& iconData,
-                         Opm::WellConstPtr eclWell,
+                         const Opm::Well* eclWell,
                          size_t reportStepIdx,
                          int maxNumConnections) const
     {
@@ -467,7 +467,7 @@ private:
         assert(iconData.size() % numIconItemsPerConnection == 0);
     }
 
-    int ertWellType_(Opm::WellConstPtr eclWell, size_t reportStepIdx) const
+    int ertWellType_(const Opm::Well* eclWell, size_t reportStepIdx) const
     {
         int ertWellType = IWEL_UNDOCUMENTED_ZERO;
 
@@ -496,7 +496,7 @@ private:
         return ertWellType;
     }
 
-    int ertWellStatus_(Opm::WellConstPtr eclWell, size_t reportStepIdx) const
+    int ertWellStatus_(const Opm::Well* eclWell, size_t reportStepIdx) const
     {
         int ertWellStatus;
 


### PR DESCRIPTION
the WellConstPtr typedef is gone