### PR TITLE
ebos: implement support for the VAPPARS keyword

### DIFF
--- a/applications/ebos/ecloutputblackoilmodule.hh
+++ b/applications/ebos/ecloutputblackoilmodule.hh
@@ -187,8 +187,9 @@ public:
                 }
             }
             if (gasDissolutionFactorOutput_()) {
+                Scalar SoMax = elemCtx.model().maxOilSaturation(globalDofIdx);
                 gasDissolutionFactor_[globalDofIdx] =
-                    FluidSystem::template saturatedDissolutionFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx);
+                    FluidSystem::template saturatedDissolutionFactor<FluidState, Scalar>(fs, gasPhaseIdx, pvtRegionIdx, SoMax);
                 Valgrind::CheckDefined(gasDissolutionFactor_[globalDofIdx]);
             }
             if (gasFormationVolumeFactorOutput_()) {

--- a/applications/ebos/eclproblem.hh
+++ b/applications/ebos/eclproblem.hh
@@ -401,8 +401,12 @@ public:
         if (nextEpisodeIdx < numReportSteps) {
             simulator.startNextEpisode(episodeLength);
             simulator.setTimeStepSize(dt);
+        }
+
+        if (this->simulator().episodeIndex() > 1) {
             if (updateHysteresis_())
                 this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+            this->model().updateMaxOilSaturations();
         }
 
         if (!GET_PROP_VALUE(TypeTag, DisableWells))
@@ -726,7 +730,9 @@ public:
         }
 
         // update the data required for capillary pressure hysteresis
-        updateHysteresis_();
+        if (updateHysteresis_())
+            this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
+        this->model().updateMaxOilSaturations();
 
         // let the object for threshold pressures initialize itself. this is done only at
         // this point, because determining the threshold pressures may require to access

--- a/ewoms/io/vtkblackoilmodule.hh
+++ b/ewoms/io/vtkblackoilmodule.hh
@@ -216,6 +216,7 @@ public:
             const auto& primaryVars = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0);
 
             int pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
+            Scalar SoMax = elemCtx.model().maxOilSaturation(globalDofIdx);
             Scalar x_oG = Toolbox::value(fs.moleFraction(oilPhaseIdx, gasCompIdx));
             Scalar x_gO = Toolbox::value(fs.moleFraction(gasPhaseIdx, oilCompIdx));
             Scalar X_oG = Toolbox::value(fs.massFraction(oilPhaseIdx, gasCompIdx));
@@ -226,14 +227,16 @@ public:
             Scalar RsSat =
                 FluidSystem::template saturatedDissolutionFactor<FluidState, Scalar>(fs,
                                                                                      oilPhaseIdx,
-                                                                                     pvtRegionIdx);
+                                                                                     pvtRegionIdx,
+                                                                                     SoMax);
             Scalar X_oG_sat = FluidSystem::convertRsToXoG(RsSat, pvtRegionIdx);
             Scalar x_oG_sat = FluidSystem::convertXoGToxoG(X_oG_sat, pvtRegionIdx);
 
             Scalar RvSat =
                 FluidSystem::template saturatedDissolutionFactor<FluidState, Scalar>(fs,
                                                                                      gasPhaseIdx,
-                                                                                     pvtRegionIdx);
+                                                                                     pvtRegionIdx,
+                                                                                     SoMax);
             Scalar X_gO_sat = FluidSystem::convertRvToXgO(RvSat, pvtRegionIdx);
             Scalar x_gO_sat = FluidSystem::convertXgOToxgO(X_gO_sat, pvtRegionIdx);
 

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -130,8 +130,8 @@ public:
 
         const ExtensiveQuantities &extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
         unsigned interiorIdx = extQuants.interiorIndex();
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-            int upIdx = extQuants.upstreamIndex(phaseIdx);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            unsigned upIdx = extQuants.upstreamIndex(phaseIdx);
             const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
             if (upIdx == interiorIdx)
                 evalPhaseFluxes_<Evaluation>(flux, phaseIdx, extQuants, up);

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -211,6 +211,7 @@ public:
      */
     void finishInit()
     {
+        maxOilSaturation_.resize(this->numGridDof(), 0.0);
         ParentType::finishInit();
 
         Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-35);
@@ -333,6 +334,9 @@ public:
         // write the pseudo primary variables
         outstream << priVars.primaryVarsMeaning() << " ";
         outstream << priVars.pvtRegionIndex() << " ";
+
+        if (maxOilSaturation_.size() > 0)
+            outstream << maxOilSaturation_[dofIdx] << " ";
     }
 
     /*!
@@ -368,6 +372,9 @@ public:
 
         int pvtRegionIdx;
         instream >> pvtRegionIdx;
+
+        if (maxOilSaturation_.size() > 0)
+            instream >> maxOilSaturation_[dofIdx];
 
         if (!instream.good())
             OPM_THROW(std::runtime_error,
@@ -408,6 +415,48 @@ public:
         this->solution(/*timeIdx=*/1) = this->solution(/*timeIdx=*/0);
     }
 
+    /*!
+     * \brief Returns an elements maximum oil phase saturation observed during the
+     *        simulation.
+     *
+     * This is a bit of a hack from the conceptional point of view, but it is required to
+     * match the results of the 'flow' and ECLIPSE 100 simulators.
+     */
+    Scalar maxOilSaturation(unsigned globalDofIdx) const
+    { return maxOilSaturation_[globalDofIdx]; }
+
+    /*!
+     * \brief Update the maximum oil saturation observed during the simulation for all
+     *        elements.
+     *
+     * This method must be called manually by the problem because depending on the exact
+     * simulation it sometimes needs to be called after a time step or before an episode
+     * starts.
+     */
+    void updateMaxOilSaturations()
+    {
+        if (maxOilSaturation_.size() > 0) {
+            unsigned nGridDofs = this->numGridDof();
+            assert(maxOilSaturation_.size() == nGridDofs);
+            for (unsigned dofIdx = 0; dofIdx < nGridDofs; ++dofIdx) {
+                const PrimaryVariables& priVars = this->solution(/*timeIdx=*/0)[dofIdx];
+                Scalar So = 0.0;
+                switch (priVars.primaryVarsMeaning()) {
+                case PrimaryVariables::Sw_po_Sg:
+                    So = 1.0 - priVars[Indices::waterSaturationIdx] - priVars[Indices::compositionSwitchIdx];
+                    break;
+                case PrimaryVariables::Sw_po_Rv:
+                    So = 0.0;
+                    break;
+                case PrimaryVariables::Sw_po_Rs:
+                    So = 1.0 - priVars[Indices::waterSaturationIdx];
+                    break;
+                }
+
+                maxOilSaturation_[dofIdx] = std::max(maxOilSaturation_[dofIdx], So);
+            }
+        }
+    }
 
 // HACK: this should be made private and the BaseModel should be
 // declared to be a friend. Since C++-2003 (and more relevantly GCC
@@ -421,7 +470,9 @@ public:
     template <class Context>
     void supplementInitialSolution_(PrimaryVariables &priVars,
                                     const Context &context, int dofIdx, int timeIdx)
-    { updatePvtRegionIndex_(priVars, context, dofIdx, timeIdx); }
+    {
+        updatePvtRegionIndex_(priVars, context, dofIdx, timeIdx);
+    }
 
     void registerOutputModules_()
     {
@@ -444,6 +495,8 @@ private:
         int regionIdx = context.problem().pvtRegionIndex(context, dofIdx, timeIdx);
         priVars.setPvtRegionIndex(regionIdx);
     }
+
+    std::vector<Scalar> maxOilSaturation_;
 };
 } // namespace Ewoms
 

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -151,9 +151,8 @@ protected:
             nextValue[eqIdx] = currentValue[eqIdx] - delta;
         }
 
-        // switch the new primary variables to something which is
-        // physically meaningful
-        if (nextValue.adaptPrimaryVariables())
+        // switch the new primary variables to something which is physically meaningful
+        if (nextValue.adaptPrimaryVariables(this->model(), globalDofIdx))
             ++ numPriVarsSwitched_;
     }
 


### PR DESCRIPTION
this implements support for the VAPPARS keyword in ebos. it depends on OPM/opm-material#154.