### PR TITLE
Reflect changes in parser api, removed shared_ptr

### DIFF
--- a/applications/ebos/eclthresholdpressure.hh
+++ b/applications/ebos/eclthresholdpressure.hh
@@ -101,9 +101,9 @@ public:
 
         const auto& gridManager = simulator_.gridManager();
         Opm::EclipseStateConstPtr eclState = gridManager.eclState();
-        Opm::SimulationConfigConstPtr simConfig = eclState->getSimulationConfig();
+        const auto& simConfig = eclState->getSimulationConfig();
 
-        enableThresholdPressure_ = simConfig->hasThresholdPressure();
+        enableThresholdPressure_ = simConfig.hasThresholdPressure();
         if (!enableThresholdPressure_)
             return;
 

--- a/applications/ebos/ecltransmissibility.hh
+++ b/applications/ebos/ecltransmissibility.hh
@@ -98,7 +98,7 @@ public:
         const auto& cartMapper = gridManager.cartesianIndexMapper();
         const auto eclState = gridManager.eclState();
         const auto eclGrid = eclState->getInputGrid();
-        const auto transMult = eclState->getTransMult();
+        const auto& transMult = eclState->getTransMult();
 
         const std::vector<double>& ntg =
             eclState->get3DProperties().getDoubleGridProperty("NTG").getData();
@@ -214,9 +214,9 @@ public:
 
                 // apply the full face transmissibility multipliers
                 // for the inside ...
-                applyMultipliers_(trans, insideFaceIdx, insideCartElemIdx, *transMult);
+                applyMultipliers_(trans, insideFaceIdx, insideCartElemIdx, transMult);
                 // ... and outside elements
-                applyMultipliers_(trans, outsideFaceIdx, outsideCartElemIdx, *transMult);
+                applyMultipliers_(trans, outsideFaceIdx, outsideCartElemIdx, transMult);
 
                 // apply the region multipliers (cf. the MULTREGT keyword)
                 Opm::FaceDir::DirEnum faceDir;
@@ -240,9 +240,9 @@ public:
                     OPM_THROW(std::logic_error, "Could not determine a face direction");
                 }
 
-                trans *= transMult->getRegionMultiplier(insideCartElemIdx,
-                                                        outsideCartElemIdx,
-                                                        faceDir);
+                trans *= transMult.getRegionMultiplier(insideCartElemIdx,
+                                                       outsideCartElemIdx,
+                                                       faceDir);
 
                 trans_[isId_(insideElemIdx, outsideElemIdx)] = trans;
             }


### PR DESCRIPTION
getTransMult and getSimulationConfig are no longer returned as shared_ptr from parser, but as references.  Updated use in ewoms.

Downstream of OPM/opm-parser#890.