### PR TITLE
add the control files for the travis CI system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: cpp
+
+compiler:
+  - gcc
+
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - libboost1.55-all-dev
+      - gcc-4.8
+      - g++-4.8
+      - gfortran-4.8
+      - liblapack-dev
+      - libgmp3-dev
+      - libsuitesparse-dev
+      - libeigen3-dev
+
+before_script:
+    - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
+    - cd ..
+    - git clone https://github.com/OPM/opm-common.git
+    - opm-common/travis/clone-opm.sh opm-material
+    - opm-common/travis/build-prereqs.sh
+    
+
+script: opm-common/travis/build-and-test.sh ewoms

--- a/travis/build-and-test-ewoms.sh
+++ b/travis/build-and-test-ewoms.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+pushd . > /dev/null
+ewoms/travis/build-ewoms.sh
+cd ewoms/build
+ctest --output-on-failure
+popd > /dev/null

--- a/travis/build-ewoms.sh
+++ b/travis/build-ewoms.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+pushd . > /dev/null
+cd ewoms
+mkdir build
+cd build
+cmake -DADD_DISABLED_CTESTS=OFF -DUSE_QUADMATH=OFF -DBUILD_TESTING=ON  ../
+make
+popd > /dev/null


### PR DESCRIPTION
this patch is based on the travis files from opm-material, so it may be that they work. (I've no experience with travis yet, nor do I know a way to test this besides the live system, so bear with me.)

this will not break anything outside travis, so I'll be self-merging immediately.