### PR TITLE
ebos: precalculate the depth of the center of an element

### DIFF
--- a/applications/ebos/eclfluxmodule.hh
+++ b/applications/ebos/eclfluxmodule.hh
@@ -210,7 +210,6 @@ protected:
         Valgrind::SetUndefined(*this);
 
         const auto& problem = elemCtx.problem();
-        const auto& grid = elemCtx.simulator().gridManager().grid();
         const auto& stencil = elemCtx.stencil(timeIdx);
         const auto& scvf = stencil.interiorFace(scvfIdx);
 
@@ -237,8 +236,8 @@ protected:
         // grids). The "good" solution would be to take the Z coordinate of the element
         // centers, but since ECL seems to like to be inconsistent on that front, it
         // needs to be done like here...
-        Scalar zIn = grid.cellCenterDepth(I);
-        Scalar zEx = grid.cellCenterDepth(J);
+        Scalar zIn = problem.dofCenterDepth(elemCtx, interiorDofIdx_, timeIdx);
+        Scalar zEx = problem.dofCenterDepth(elemCtx, exteriorDofIdx_, timeIdx);
 
         // the distances from the DOF's depths. (i.e., the additional depth of the
         // exterior DOF)


### PR DESCRIPTION
it turns out that this is quite slow in Dune::CpGrid, so this patch caches the values. on my machine linearization for SPE9_CP went from taking 7.02 seconds to 6.46 seconds.

note that I think that this is stuff which should be merged after the 2016.10 release branches have been created. @atgeirr: if you want it in the release, you have permission to press green.