### PR TITLE
Use correct cellcenterdepth

### DIFF
--- a/applications/ebos/eclfluxmodule.hh
+++ b/applications/ebos/eclfluxmodule.hh
@@ -210,7 +210,6 @@ protected:
         Valgrind::SetUndefined(*this);
 
         const auto& problem = elemCtx.problem();
-        const auto& grid = elemCtx.simulator().gridManager().grid();
         const auto& stencil = elemCtx.stencil(timeIdx);
         const auto& scvf = stencil.interiorFace(scvfIdx);
 
@@ -237,8 +236,8 @@ protected:
         // grids). The "good" solution would be to take the Z coordinate of the element
         // centers, but since ECL seems to like to be inconsistent on that front, it
         // needs to be done like here...
-        Scalar zIn = grid.cellCenterDepth(I);
-        Scalar zEx = grid.cellCenterDepth(J);
+        Scalar zIn = problem.dofCenterDepth(elemCtx, interiorDofIdx_, timeIdx);
+        Scalar zEx = problem.dofCenterDepth(elemCtx, exteriorDofIdx_, timeIdx);
 
         // the distances from the DOF's depths. (i.e., the additional depth of the
         // exterior DOF)

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -262,8 +262,8 @@ public:
             // degree of freedom and an internal face, else add a
             // boundary face
             if (intersection.neighbor()) {
-                elements_.emplace_back(/*SubControlVolume(*/intersection.outside()/*)*/);
-                subControlVolumes_.emplace_back(/*SubControlVolume(*/intersection.outside()/*)*/);
+                elements_.emplace_back( intersection.outside() );
+                subControlVolumes_.emplace_back(/*SubControlVolume(*/ elements_.back() /*)*/);
                 interiorFaces_.emplace_back(/*SubControlVolumeFace(*/intersection, subControlVolumes_.size() - 1/*)*/);
             }
             else {
@@ -304,7 +304,7 @@ public:
      * \brief Return the element to which the stencil refers.
      */
     const Element &element() const
-    { return *elements_[0]; }
+    { return element( 0 ); }
 
     /*!
      * \brief Return the grid view of the element to which the stencil


### PR DESCRIPTION
This replaces the grid.cellCenterDepth method with the correct DUNE interface usage for the same computation.