### PR TITLE
[feature] Make mapper inside stencil a reference to avoid re-computation.

### DIFF
--- a/ewoms/disc/common/fvbaseelementcontext.hh
+++ b/ewoms/disc/common/fvbaseelementcontext.hh
@@ -91,7 +91,7 @@ public:
      */
     explicit FvBaseElementContext(const Simulator &simulator)
         : gridView_(simulator.gridView())
-        , stencil_(gridView_)
+        , stencil_(gridView_, simulator.model().dofMapper() )
     {
         // remember the simulator object
         simulatorPtr_ = &simulator;

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -267,7 +267,7 @@ private:
         // allocate raw matrix
         matrix_ = new Matrix(numAllDof, numAllDof, Matrix::random);
 
-        Stencil stencil(gridView_());
+        Stencil stencil(gridView_(), model_().dofMapper() );
 
         // for the main model, find out the global indices of the neighboring degrees of
         // freedom of each primary degree of freedom

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -69,7 +69,8 @@ class EcfvStencil
     typedef Dune::FieldVector<Scalar, dimWorld> WorldVector;
 
 public:
-    typedef Element  Entity;
+    typedef Element        Entity;
+    typedef ElementMapper  Mapper;
 
     typedef typename Element::Geometry LocalGeometry;
 
@@ -228,9 +229,9 @@ public:
         WorldVector normal_;
     };
 
-    EcfvStencil(const GridView &gridView)
+    EcfvStencil(const GridView &gridView, const Mapper& mapper)
         : gridView_(gridView)
-        , elementMapper_(gridView)
+        , elementMapper_(mapper)
     { }
 
     void updateTopology(const Element &element)
@@ -413,9 +414,9 @@ public:
     const SubControlVolumeFace &boundaryFace(unsigned bfIdx) const
     { return boundaryFaces_[bfIdx]; }
 
-private:
-    GridView gridView_;
-    ElementMapper elementMapper_;
+protected:
+    const GridView&       gridView_;
+    const ElementMapper&  elementMapper_;
 
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
     std::vector<Element> elements_;
@@ -423,9 +424,9 @@ private:
     std::vector<ElementPointer> elements_;
 #endif
 
-    std::vector<SubControlVolume> subControlVolumes_;
-    std::vector<SubControlVolumeFace> interiorFaces_;
-    std::vector<SubControlVolumeFace> boundaryFaces_;
+    std::vector<SubControlVolume>      subControlVolumes_;
+    std::vector<SubControlVolumeFace>  interiorFaces_;
+    std::vector<SubControlVolumeFace>  boundaryFaces_;
 };
 
 } // namespace Ewoms

--- a/ewoms/disc/vcfv/vcfvstencil.hh
+++ b/ewoms/disc/vcfv/vcfvstencil.hh
@@ -728,6 +728,8 @@ private:
 public:
     typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView,
                                                       Dune::MCMGVertexLayout > VertexMapper;
+    //! exported Mapper type
+    typedef VertexMapper  Mapper;
 
     class ScvGeometry
     {
@@ -813,9 +815,9 @@ public:
     //! compatibility typedef
     typedef SubControlVolumeFace BoundaryFace;
 
-    VcfvStencil(const GridView &gridView)
+    VcfvStencil(const GridView &gridView, const VertexMapper& vertexMapper)
         : gridView_(gridView)
-        , vertexMapper_(gridView)
+        , vertexMapper_( vertexMapper )
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         , element_(*gridView.template begin</*codim=*/0>())
 #else
@@ -1358,8 +1360,8 @@ private:
             OPM_THROW(std::logic_error, "Not implemented:VcfvStencil for dim = " << dim);
     }
 
-    GridView gridView_;
-    VertexMapper vertexMapper_;
+    const GridView&     gridView_;
+    const VertexMapper& vertexMapper_;
 
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
     Element element_;

--- a/tests/problems/richardslensproblem.hh
+++ b/tests/problems/richardslensproblem.hh
@@ -122,12 +122,12 @@ SET_STRING_PROP(RichardsLensProblem, GridFile, "./data/richardslens_24x16.dgf");
  *        embedded into a high-permeability domain.
  *
  * The domain is rectangular. The left and right boundaries are
- * free-flow boundaries with fixed water pressure which corrosponds to
+ * free-flow boundaries with fixed water pressure which corresponds to
  * a fixed saturation of \f$S_w = 0\f$ in the Richards model, the
  * bottom boundary is closed. The top boundary is also closed except
  * for an infiltration section, where water is infiltrating into an
  * initially unsaturated porous medium. This problem is very similar
- * the the \c LensProblem, with the main difference being that the domain
+ * the \c LensProblem, with the main difference being that the domain
  * is initally fully saturated by gas instead of water and water
  * instead of a \c DNAPL infiltrates from the top.
  */
@@ -218,7 +218,7 @@ public:
         outerK_ = this->toDimMatrix_(5e-12);
 
         // determine which degrees of freedom are in the lens
-        Stencil stencil(this->gridView());
+        Stencil stencil(this->gridView(), this->simulator().model().dofMapper() );
         auto elemIt = this->gridView().template begin</*codim=*/0>();
         auto elemEndIt = this->gridView().template end</*codim=*/0>();
         for (; elemIt != elemEndIt; ++elemIt) {

--- a/tests/test_quadrature.cc
+++ b/tests/test_quadrature.cc
@@ -113,7 +113,10 @@ void writeTetrahedronSubControlVolumes(const Grid &grid)
     GridFactory2 gf2;
     const auto &gridView = grid.leafView();
     typedef Ewoms::VcfvStencil<Scalar, GridView> Stencil;
-    Stencil stencil(gridView);
+    typedef typename Stencil :: Mapper Mapper;
+
+    Mapper mapper( gridView );
+    Stencil stencil(gridView, mapper);
 
     auto eIt = gridView.template begin<0>();
     const auto &eEndIt = gridView.template end<0>();
@@ -298,7 +301,10 @@ void testQuadrature()
     Scalar result = 0;
     // instanciate a stencil
     typedef Ewoms::VcfvStencil<Scalar, GridView> Stencil;
-    Stencil stencil(gridView);
+    typedef typename Stencil :: Mapper Mapper;
+
+    Mapper mapper( gridView );
+    Stencil stencil(gridView, mapper);
     for (; eIt != eEndIt; ++eIt) {
         const auto &elemGeom = eIt->geometry();
 


### PR DESCRIPTION
This PR makes the mapper inside the Stencil class a reference, to avoid re-computation of offsets etc. 