### PR TITLE
Fix mismatch between vector and allocator.

### DIFF
--- a/ewoms/disc/common/fvbaseelementcontext.hh
+++ b/ewoms/disc/common/fvbaseelementcontext.hh
@@ -599,7 +599,7 @@ protected:
     GradientCalculator gradientCalculator_;
 
     std::vector<DofStore_, Ewoms::aligned_allocator<DofStore_, alignof(DofStore_)> > dofVars_;
-    std::vector<ExtensiveQuantities, Ewoms::aligned_allocator<IntensiveQuantities, alignof(IntensiveQuantities)> > extensiveQuantities_;
+    std::vector<ExtensiveQuantities, Ewoms::aligned_allocator<ExtensiveQuantities, alignof(ExtensiveQuantities)> > extensiveQuantities_;
 
     const Simulator *simulatorPtr_;
     const Element *elemPtr_;


### PR DESCRIPTION
With clang/libc++ this gives a static assertation failure.