### PR TITLE
fix most pedantic compiler warnings in the basic infrastructure

### DIFF
--- a/applications/art2dgf.cc
+++ b/applications/art2dgf.cc
@@ -21,6 +21,7 @@
   copyright holders.
 */
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
@@ -48,15 +49,15 @@ namespace Ewoms {
      */
     static void convert( const std::string& artFileName,
                          std::ostream& dgfFile,
-                         const int precision = 16 )
+                         const unsigned precision = 16 )
     {
         typedef double Scalar;
         typedef Dune::FieldVector< Scalar, 2 > GlobalPosition;
         enum ParseMode { Vertex, Edge, Element, Finished };
-        std::vector< std::pair<GlobalPosition, int > > vertexPos;
-        std::vector<std::pair<int, int> > edges;
-        std::vector<std::pair<int, int> > fractureEdges;
-        std::vector< std::vector< unsigned int > > elements;
+        std::vector< std::pair<GlobalPosition, unsigned> > vertexPos;
+        std::vector<std::pair<unsigned, unsigned> > edges;
+        std::vector<std::pair<unsigned, unsigned> > fractureEdges;
+        std::vector<std::vector<unsigned> > elements;
         std::ifstream inStream(artFileName);
         if (!inStream.is_open()) {
             OPM_THROW(std::runtime_error,
@@ -138,7 +139,7 @@ namespace Ewoms {
                 // an edge always has two indices!
                 assert(vertIndices.size() == 2);
 
-                std::pair<int, int> edge(vertIndices[0], vertIndices[1]);
+                std::pair<unsigned, unsigned> edge(vertIndices[0], vertIndices[1]);
                 edges.push_back(edge);
 
                 // add the edge to the fracture mapper if it is a fracture
@@ -158,9 +159,9 @@ namespace Ewoms {
                 assert(tmp == ":");
 
                 // read the edge indices of an element
-                std::vector<unsigned int> edgeIndices;
+                std::vector<unsigned> edgeIndices;
                 while (iss) {
-                    unsigned int tmp2;
+                    unsigned tmp2;
                     iss >> tmp2;
                     if (!iss)
                         break;
@@ -172,12 +173,12 @@ namespace Ewoms {
                 assert(edgeIndices.size() == 3);
 
                 // extract the vertex indices of the element
-                std::vector<unsigned int> vertIndices;
-                for (int i = 0; i < 3; ++i) {
+                std::vector<unsigned> vertIndices;
+                for (unsigned i = 0; i < 3; ++i) {
                     bool haveFirstVertex = false;
-                    for (int j = 0; j < int(vertIndices.size()); ++j) {
+                    for (unsigned j = 0; j < vertIndices.size(); ++j) {
                         assert(edgeIndices[i] < edges.size());
-                        if (int(vertIndices[j]) == edges[edgeIndices[i]].first) {
+                        if (vertIndices[j] == edges[edgeIndices[i]].first) {
                             haveFirstVertex = true;
                             break;
                         }
@@ -188,7 +189,7 @@ namespace Ewoms {
                     bool haveSecondVertex = false;
                     for (unsigned j = 0; j < vertIndices.size(); ++j) {
                         assert(edgeIndices[i] < edges.size());
-                        if (int(vertIndices[j]) == edges[edgeIndices[i]].second) {
+                        if (vertIndices[j] == edges[edgeIndices[i]].second) {
                             haveSecondVertex = true;
                             break;
                         }

--- a/applications/ebos/collecttoiorank.hh
+++ b/applications/ebos/collecttoiorank.hh
@@ -37,6 +37,8 @@
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 
+#include <dune/grid/common/mcmgmapper.hh>
+
 #include <stdexcept>
 
 namespace Ewoms

--- a/applications/ebos/eclalugridmanager.hh
+++ b/applications/ebos/eclalugridmanager.hh
@@ -162,7 +162,7 @@ protected:
     void createGrids_()
     {
         const auto& gridProps = this->eclState()->get3DProperties();
-        const std::vector<double> &porv = gridProps.getDoubleGridProperty("PORV").getData();
+        const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
 
         // we use separate grid objects: one for the calculation of the initial condition
         // via EQUIL and one for the actual simulation. The reason is that the EQUIL code

--- a/applications/ebos/eclbasegridmanager.hh
+++ b/applications/ebos/eclbasegridmanager.hh
@@ -94,7 +94,7 @@ public:
      * This is the file format used by the commercial ECLiPSE simulator. Usually it uses
      * a cornerpoint description of the grid.
      */
-    EclBaseGridManager(Simulator &simulator)
+    EclBaseGridManager(Simulator& simulator)
         : ParentType(simulator)
     {
         int myRank = 0;

--- a/applications/ebos/eclcpgridmanager.hh
+++ b/applications/ebos/eclcpgridmanager.hh
@@ -160,7 +160,7 @@ protected:
     void createGrids_()
     {
         const auto& gridProps = this->eclState()->get3DProperties();
-        const std::vector<double> &porv = gridProps.getDoubleGridProperty("PORV").getData();
+        const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
 
         grid_ = new Dune::CpGrid();
         grid_->processEclipseFormat(this->eclState()->getInputGrid(),

--- a/applications/ebos/ecldummygradientcalculator.hh
+++ b/applications/ebos/ecldummygradientcalculator.hh
@@ -30,6 +30,9 @@
 
 #include <ewoms/disc/common/fvbaseproperties.hh>
 
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <dune/common/fvector.hh>
 
 namespace Ewoms {
@@ -60,42 +63,42 @@ public:
     { }
 
     template <bool prepareValues = true, bool prepareGradients = true>
-    void prepare(const ElementContext &elemCtx, unsigned timeIdx)
+    void prepare(const ElementContext& elemCtx, unsigned timeIdx)
     { }
 
     template <class QuantityCallback, class QuantityType = Scalar>
-    QuantityType calculateValue(const ElementContext &elemCtx,
+    QuantityType calculateValue(const ElementContext& elemCtx,
                                 unsigned fapIdx,
-                                const QuantityCallback &quantityCallback) const
+                                const QuantityCallback& quantityCallback) const
     {
         OPM_THROW(std::logic_error,
                   "Generic values are not supported by the ECL black-oil simulator");
     }
 
     template <class QuantityCallback>
-    void calculateGradient(DimVector &quantityGrad,
-                           const ElementContext &elemCtx,
+    void calculateGradient(DimVector& quantityGrad,
+                           const ElementContext& elemCtx,
                            unsigned fapIdx,
-                           const QuantityCallback &quantityCallback) const
+                           const QuantityCallback& quantityCallback) const
     {
         OPM_THROW(std::logic_error,
                   "Generic gradients are not supported by the ECL black-oil simulator");
     }
 
     template <class QuantityCallback>
-    Scalar calculateBoundaryValue(const ElementContext &elemCtx,
+    Scalar calculateBoundaryValue(const ElementContext& elemCtx,
                                   unsigned fapIdx,
-                                  const QuantityCallback &quantityCallback)
+                                  const QuantityCallback& quantityCallback)
     {
         OPM_THROW(std::logic_error,
                   "Generic boundary values are not supported by the ECL black-oil simulator");
     }
 
     template <class QuantityCallback>
-    void calculateBoundaryGradient(DimVector &quantityGrad,
-                                   const ElementContext &elemCtx,
+    void calculateBoundaryGradient(DimVector& quantityGrad,
+                                   const ElementContext& elemCtx,
                                    unsigned fapIdx,
-                                   const QuantityCallback &quantityCallback) const
+                                   const QuantityCallback& quantityCallback) const
     {
         OPM_THROW(std::logic_error,
                   "Generic boundary gradients are not supported by the ECL black-oil simulator");

--- a/applications/ebos/eclequilinitializer.hh
+++ b/applications/ebos/eclequilinitializer.hh
@@ -142,7 +142,7 @@ public:
         initialFluidStates_.resize(numCartesianElems);
         for (unsigned equilElemIdx = 0; equilElemIdx < numEquilElems; ++equilElemIdx) {
             unsigned cartesianElemIdx = gridManager.equilCartesianIndex(equilElemIdx);
-            auto &fluidState = initialFluidStates_[cartesianElemIdx];
+            auto& fluidState = initialFluidStates_[cartesianElemIdx];
 
             // get the PVT region index of the current element
             unsigned regionIdx = simulator_.problem().pvtRegionIndex(equilElemIdx);

--- a/applications/ebos/eclfluxmodule.hh
+++ b/applications/ebos/eclfluxmodule.hh
@@ -34,6 +34,10 @@
 #include <ewoms/disc/common/fvbaseproperties.hh>
 #include <ewoms/common/signum.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
@@ -87,7 +91,7 @@ class EclTransIntensiveQuantities
 {
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
 protected:
-    void update_(const ElementContext &elemCtx, unsigned dofIdx, unsigned timeIdx)
+    void update_(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
     { }
 };
 
@@ -205,7 +209,7 @@ protected:
     /*!
      * \brief Update the required gradients for interior faces
      */
-    void calculateGradients_(const ElementContext &elemCtx, unsigned scvfIdx, unsigned timeIdx)
+    void calculateGradients_(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         Valgrind::SetUndefined(*this);
 
@@ -228,8 +232,8 @@ protected:
         // acts into the downwards direction. (i.e., no centrifuge experiments, sorry.)
         Scalar g = elemCtx.problem().gravity()[dimWorld - 1];
 
-        const auto &intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx_, timeIdx);
-        const auto &intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx_, timeIdx);
+        const auto& intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx_, timeIdx);
+        const auto& intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx_, timeIdx);
 
         // this is quite hacky because the dune grid interface does not provide a
         // cellCenterDepth() method (so we ask the problem to provide it). The "good"
@@ -338,7 +342,7 @@ protected:
     /*!
      * \brief Update the volumetric fluxes for all fluid phases on the interior faces of the context
      */
-    void calculateFluxes_(const ElementContext &elemCtx, unsigned scvfIdx, unsigned timeIdx)
+    void calculateFluxes_(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     { }
 
     // transmissibility [m^3 s]

--- a/applications/ebos/ecloutputblackoilmodule.hh
+++ b/applications/ebos/ecloutputblackoilmodule.hh
@@ -31,9 +31,10 @@
 #include "ecldeckunits.hh"
 
 #include <ewoms/io/baseoutputmodule.hh>
-
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
+
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -96,7 +97,7 @@ class EclOutputBlackOilModule : public BaseOutputModule<TypeTag>
     typedef typename ParentType::ScalarBuffer ScalarBuffer;
 
 public:
-    EclOutputBlackOilModule(const Simulator &simulator)
+    EclOutputBlackOilModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -158,7 +159,7 @@ public:
      * \brief Modify the internal buffers according to the intensive quanties relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableEclOutput))
             return;
@@ -169,7 +170,7 @@ public:
             return;
 
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
-            const auto &fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
+            const auto& fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
             typedef typename std::remove_const<typename std::remove_reference<decltype(fs)>::type>::type FluidState;
             unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
             unsigned pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
@@ -213,7 +214,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &writer)
+    void commitBuffers(BaseOutputWriter& writer)
     {
         if (!std::is_same<Discretization, Ewoms::EcfvDiscretization<TypeTag> >::value)
             return;

--- a/applications/ebos/eclpolyhedralgridmanager.hh
+++ b/applications/ebos/eclpolyhedralgridmanager.hh
@@ -145,7 +145,7 @@ protected:
     void createGrids_()
     {
         const auto& gridProps = this->eclState()->get3DProperties();
-        const std::vector<double> &porv = gridProps.getDoubleGridProperty("PORV").getData();
+        const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
 
         grid_ = new Grid(*(this->deck()), porv);
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);

--- a/applications/ebos/eclproblem.hh
+++ b/applications/ebos/eclproblem.hh
@@ -72,10 +72,12 @@
 #include <opm/material/fluidsystems/blackoilpvt/DeadOilPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityOilPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/ConstantCompressibilityWaterPvt.hpp>
-
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
@@ -291,7 +293,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    EclProblem(Simulator &simulator)
+    EclProblem(Simulator& simulator)
         : ParentType(simulator)
         , transmissibilities_(simulator)
         , thresholdPressures_(simulator)
@@ -361,7 +363,7 @@ public:
      * \param res The deserializer object
      */
     template <class Restarter>
-    void deserialize(Restarter &res)
+    void deserialize(Restarter& res)
     {
         // reload the current episode/report step from the deck
         beginEpisode(/*isOnRestart=*/true);
@@ -375,7 +377,7 @@ public:
      *        to the harddisk.
      */
     template <class Restarter>
-    void serialize(Restarter &res)
+    void serialize(Restarter& res)
     { wellManager_.serialize(res); }
 
     /*!
@@ -584,7 +586,7 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context,
+    const DimMatrix& intrinsicPermeability(const Context& context,
                                            unsigned spaceIdx,
                                            unsigned timeIdx) const
     {
@@ -598,14 +600,14 @@ public:
      *
      * Its main (only?) usage is the ECL transmissibility calculation code...
      */
-    const DimMatrix &intrinsicPermeability(unsigned globalElemIdx) const
+    const DimMatrix& intrinsicPermeability(unsigned globalElemIdx) const
     { return intrinsicPermeability_[globalElemIdx]; }
 
     /*!
      * \copydoc BlackOilBaseProblem::transmissibility
      */
     template <class Context>
-    Scalar transmissibility(const Context &context,
+    Scalar transmissibility(const Context& context,
                             unsigned fromDofLocalIdx,
                             unsigned toDofLocalIdx) const
     {
@@ -623,7 +625,7 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
         return porosity_[globalSpaceIdx];
@@ -636,7 +638,7 @@ public:
      * thus slightly different from the depth of an element's centroid.
      */
     template <class Context>
-    Scalar dofCenterDepth(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar dofCenterDepth(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
         return elementCenterDepth_[globalSpaceIdx];
@@ -646,7 +648,7 @@ public:
      * \copydoc BlackoilProblem::rockCompressibility
      */
     template <class Context>
-    Scalar rockCompressibility(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar rockCompressibility(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         if (rockParams_.empty())
             return 0.0;
@@ -664,7 +666,7 @@ public:
      * \copydoc BlackoilProblem::rockReferencePressure
      */
     template <class Context>
-    Scalar rockReferencePressure(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar rockReferencePressure(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         if (rockParams_.empty())
             return 1e5;
@@ -682,7 +684,7 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
+    const MaterialLawParams& materialLawParams(const Context& context,
                                                unsigned spaceIdx, unsigned timeIdx) const
     {
         unsigned globalSpaceIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
@@ -696,7 +698,7 @@ public:
      * \brief Returns the index of the relevant region for thermodynmic properties
      */
     template <class Context>
-    unsigned pvtRegionIndex(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    unsigned pvtRegionIndex(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     { return pvtRegionIndex(context.globalSpaceIndex(spaceIdx, timeIdx)); }
 
     /*!
@@ -720,7 +722,7 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         // use the temporally constant temperature, i.e. use the initial temperature of
         // the DOF
@@ -734,8 +736,8 @@ public:
      * ECLiPSE uses no-flow conditions for all boundaries. \todo really?
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values,
-                  const Context &context,
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
                   unsigned spaceIdx,
                   unsigned timeIdx) const
     { values.setNoFlow(); }
@@ -747,7 +749,7 @@ public:
      * the whole domain.
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    void initial(PrimaryVariables& values, const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
         unsigned globalDofIdx = context.globalSpaceIndex(spaceIdx, timeIdx);
 
@@ -785,8 +787,8 @@ public:
      * For this problem, the source term of all components is 0 everywhere.
      */
     template <class Context>
-    void source(RateVector &rate,
-                const Context &context,
+    void source(RateVector& rate,
+                const Context& context,
                 unsigned spaceIdx,
                 unsigned timeIdx) const
     {
@@ -913,7 +915,7 @@ private:
         // provided by eclState are one-per-cell of "uncompressed" grid, whereas the
         // opm-grid CpGrid object might remove a few elements...
         if (props.hasDeckDoubleGridProperty("PERMX")) {
-                const std::vector<double> &permxData =
+                const std::vector<double>& permxData =
                 props.getDoubleGridProperty("PERMX").getData();
             std::vector<double> permyData(permxData);
             if (props.hasDeckDoubleGridProperty("PERMY"))
@@ -966,9 +968,9 @@ private:
 
         porosity_.resize(numDof);
 
-        const std::vector<double> &porvData =
+        const std::vector<double>& porvData =
             props.getDoubleGridProperty("PORV").getData();
-        const std::vector<int> &actnumData =
+        const std::vector<int>& actnumData =
             props.getIntGridProperty("ACTNUM").getData();
 
         int nx = eclGrid.getNX();
@@ -1046,7 +1048,7 @@ private:
         size_t numElems = this->model().numGridDof();
         initialFluidStates_.resize(numElems);
         for (size_t elemIdx = 0; elemIdx < numElems; ++elemIdx) {
-            auto &elemFluidState = initialFluidStates_[elemIdx];
+            auto& elemFluidState = initialFluidStates_[elemIdx];
             elemFluidState.assign(equilInitializer.initialFluidState(elemIdx));
         }
     }
@@ -1100,7 +1102,7 @@ private:
         if (enableVapoil)
             rvData = &deck->getKeyword("RV").getSIDoubleData();
         // initial reservoir temperature
-        const std::vector<double> &tempiData =
+        const std::vector<double>& tempiData =
             eclState->get3DProperties().getDoubleGridProperty("TEMPI").getData();
 
         // make sure that the size of the data arrays is correct
@@ -1118,7 +1120,7 @@ private:
 
         // calculate the initial fluid states
         for (size_t dofIdx = 0; dofIdx < numDof; ++dofIdx) {
-            auto &dofFluidState = initialFluidStates_[dofIdx];
+            auto& dofFluidState = initialFluidStates_[dofIdx];
 
             int pvtRegionIdx = pvtRegionIndex(dofIdx);
             size_t cartesianDofIdx = gridManager.cartesianIndex(dofIdx);
@@ -1278,7 +1280,7 @@ private:
     // update the prefetch friendly data object
     void updatePffDofData_()
     {
-        const auto &distFn =
+        const auto& distFn =
             [this](PffDofData_& dofData,
                    const Stencil& stencil,
                    unsigned localDofIdx)

--- a/applications/ebos/eclsummarywriter.hh
+++ b/applications/ebos/eclsummarywriter.hh
@@ -97,7 +97,7 @@ class EclSummaryWriter
     static const unsigned oilPhaseIdx = FluidSystem::oilPhaseIdx;
 
 public:
-    EclSummaryWriter(const Simulator &simulator)
+    EclSummaryWriter(const Simulator& simulator)
         : simulator_(simulator)
 #if HAVE_ERT
         , ertSummary_(simulator)

--- a/applications/ebos/eclthresholdpressure.hh
+++ b/applications/ebos/eclthresholdpressure.hh
@@ -38,6 +38,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/grid/common/gridenums.hh>
 #include <dune/common/version.hh>
@@ -177,10 +179,10 @@ private:
                 continue;
 
             elemCtx.updateAll(elem);
-            const auto &stencil = elemCtx.stencil(/*timeIdx=*/0);
+            const auto& stencil = elemCtx.stencil(/*timeIdx=*/0);
 
             for (unsigned scvfIdx = 0; scvfIdx < stencil.numInteriorFaces(); ++ scvfIdx) {
-                const auto &face = stencil.interiorFace(scvfIdx);
+                const auto& face = stencil.interiorFace(scvfIdx);
 
                 unsigned i = face.interiorIndex();
                 unsigned j = face.exteriorIndex();

--- a/applications/ebos/ecltransmissibility.hh
+++ b/applications/ebos/ecltransmissibility.hh
@@ -34,6 +34,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
@@ -303,7 +305,7 @@ private:
         return x;
     }
 
-    void applyMultipliers_(Scalar &trans, unsigned faceIdx, unsigned cartElemIdx,
+    void applyMultipliers_(Scalar& trans, unsigned faceIdx, unsigned cartElemIdx,
                            const Opm::TransMult& transMult) const
     {
         // apply multiplyer for the transmissibility of the face. (the
@@ -333,7 +335,7 @@ private:
         }
     }
 
-    void applyNtg_(Scalar &trans, unsigned faceIdx, unsigned cartElemIdx,
+    void applyNtg_(Scalar& trans, unsigned faceIdx, unsigned cartElemIdx,
                    const std::vector<double>& ntg) const
     {
         // apply multiplyer for the transmissibility of the face. (the

--- a/applications/ebos/eclwellmanager.hh
+++ b/applications/ebos/eclwellmanager.hh
@@ -39,6 +39,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/parallel/threadedentityiterator.hh>
@@ -84,7 +86,7 @@ class EclWellManager
     typedef Dune::FieldVector<Evaluation, numEq> EvalEqVector;
 
 public:
-    EclWellManager(Simulator &simulator)
+    EclWellManager(Simulator& simulator)
         : simulator_(simulator)
     { }
 
@@ -101,7 +103,7 @@ public:
         for (size_t deckWellIdx = 0; deckWellIdx < deckSchedule.numWells(); ++deckWellIdx)
         {
             const Opm::Well* deckWell = deckSchedule.getWells()[deckWellIdx];
-            const std::string &wellName = deckWell->name();
+            const std::string& wellName = deckWell->name();
 
             // set the name of the well but not much else. (i.e., if it is not completed,
             // the well primarily serves as a placeholder.) The big rest of the well is
@@ -168,7 +170,7 @@ public:
             if (deckWell->isInjector(episodeIdx)) {
                 well->setWellType(Well::Injector);
 
-                const Opm::WellInjectionProperties &injectProperties =
+                const Opm::WellInjectionProperties& injectProperties =
                     deckWell->getInjectionProperties(episodeIdx);
 
                 switch (injectProperties.injectorType) {
@@ -244,7 +246,7 @@ public:
             if (deckWell->isProducer(episodeIdx)) {
                 well->setWellType(Well::Producer);
 
-                const Opm::WellProductionProperties &producerProperties =
+                const Opm::WellProductionProperties& producerProperties =
                     deckWell->getProductionProperties(episodeIdx);
 
                 switch (producerProperties.controlMode) {
@@ -321,7 +323,7 @@ public:
     /*!
      * \brief Return if a given well name is known to the wells manager
      */
-    bool hasWell(const std::string &wellName) const
+    bool hasWell(const std::string& wellName) const
     {
         return wellNameToIndex_.find( wellName ) != wellNameToIndex_.end();
     }
@@ -337,10 +339,10 @@ public:
      *
      * A std::runtime_error will be thrown if the well name is unknown.
      */
-    unsigned wellIndex(const std::string &wellName) const
+    unsigned wellIndex(const std::string& wellName) const
     {
         assert( hasWell( wellName ) );
-        const auto &it = wellNameToIndex_.find(wellName);
+        const auto& it = wellNameToIndex_.find(wellName);
         if (it == wellNameToIndex_.end())
         {
             OPM_THROW(std::runtime_error,
@@ -354,7 +356,7 @@ public:
      *
      * A std::runtime_error will be thrown if the well name is unknown.
      */
-    std::shared_ptr<const Well> well(const std::string &wellName) const
+    std::shared_ptr<const Well> well(const std::string& wellName) const
     { return wells_[wellIndex(wellName)]; }
 
     /*!
@@ -362,7 +364,7 @@ public:
      *
      * A std::runtime_error will be thrown if the well name is unknown.
      */
-    std::shared_ptr<Well> well(const std::string &wellName)
+    std::shared_ptr<Well> well(const std::string& wellName)
     { return wells_[wellIndex(wellName)]; }
 
     /*!
@@ -513,8 +515,8 @@ public:
      *        freedom.
      */
     template <class Context>
-    void computeTotalRatesForDof(EvalEqVector &q,
-                                 const Context &context,
+    void computeTotalRatesForDof(EvalEqVector& q,
+                                 const Context& context,
                                  unsigned dofIdx,
                                  unsigned timeIdx) const
     {
@@ -540,7 +542,7 @@ public:
      *        to the hard disk.
      */
     template <class Restarter>
-    void serialize(Restarter &res)
+    void serialize(Restarter& res)
     {
         /* do nothing: Everything which we need here is provided by the deck->.. */
     }
@@ -552,7 +554,7 @@ public:
      * It is the inverse of the serialize() method.
      */
     template <class Restarter>
-    void deserialize(Restarter &res)
+    void deserialize(Restarter& res)
     {
         // initialize the wells for the current episode
         beginEpisode(simulator_.gridManager().eclState(), /*wasRestarted=*/true);
@@ -791,7 +793,7 @@ protected:
         }
     }
 
-    Simulator &simulator_;
+    Simulator& simulator_;
 
     std::vector<std::shared_ptr<Well> > wells_;
     std::vector<bool> gridDofIsPenetrated_;

--- a/applications/ebos/eclwriter.hh
+++ b/applications/ebos/eclwriter.hh
@@ -37,6 +37,8 @@
 #include <ewoms/io/baseoutputwriter.hh>
 
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -61,7 +63,7 @@ class EclWriterHelper
 {
     friend class EclWriter<TypeTag>;
 
-    static void writeHeaders_(EclWriter<TypeTag> &writer)
+    static void writeHeaders_(EclWriter<TypeTag>& writer)
     {
         typedef typename GET_PROP_TYPE(TypeTag, Discretization) Discretization;
         if (!std::is_same<Discretization, Ewoms::EcfvDiscretization<TypeTag> >::value)
@@ -129,7 +131,7 @@ class EclWriter : public BaseOutputWriter
     friend class EclWriterHelper<TypeTag, GridManager>;
 
 public:
-    EclWriter(const Simulator &simulator)
+    EclWriter(const Simulator& simulator)
         : simulator_(simulator)
         , gridView_(simulator_.gridView())
         , elementMapper_(gridView_)
@@ -178,7 +180,7 @@ public:
      * For the EclWriter, this method is a no-op which throws a
      * std::logic_error exception
      */
-    void attachScalarVertexData(ScalarBuffer &buf, std::string name)
+    void attachScalarVertexData(ScalarBuffer& buf, std::string name)
     {
         OPM_THROW(std::logic_error,
                   "The EclWriter can only write element based quantities!");
@@ -190,7 +192,7 @@ public:
      * For the EclWriter, this method is a no-op which throws a
      * std::logic_error exception
      */
-    void attachVectorVertexData(VectorBuffer &buf, std::string name)
+    void attachVectorVertexData(VectorBuffer& buf, std::string name)
     {
         OPM_THROW(std::logic_error,
                   "The EclWriter can only write element based quantities!");
@@ -199,7 +201,7 @@ public:
     /*
      * \brief Add a vertex-centered tensor field to the output.
      */
-    void attachTensorVertexData(TensorBuffer &buf, std::string name)
+    void attachTensorVertexData(TensorBuffer& buf, std::string name)
     {
         OPM_THROW(std::logic_error,
                   "The EclWriter can only write element based quantities!");
@@ -212,7 +214,7 @@ public:
      * finishes. Modifying the buffer between the call to this method
      * and endWrite() results in _undefined behavior_.
      */
-    void attachScalarElementData(ScalarBuffer &buf, std::string name)
+    void attachScalarElementData(ScalarBuffer& buf, std::string name)
     {
         attachedBuffers_.push_back(std::pair<std::string, ScalarBuffer*>(name, &buf));
     }
@@ -223,7 +225,7 @@ public:
      * For the EclWriter, this method is a no-op which throws a
      * std::logic_error exception
      */
-    void attachVectorElementData(VectorBuffer &buf, std::string name)
+    void attachVectorElementData(VectorBuffer& buf, std::string name)
     {
         OPM_THROW(std::logic_error,
                   "Currently, the EclWriter can only write scalar quantities!");
@@ -232,7 +234,7 @@ public:
     /*
      * \brief Add a element-centered tensor field to the output.
      */
-    void attachTensorElementData(TensorBuffer &buf, std::string name)
+    void attachTensorElementData(TensorBuffer& buf, std::string name)
     {
         OPM_THROW(std::logic_error,
                   "Currently, the EclWriter can only write scalar quantities!");
@@ -270,10 +272,10 @@ public:
 
             ErtSolution solution(restartFile);
             auto bufIt = attachedBuffers_.begin();
-            const auto &bufEndIt = attachedBuffers_.end();
+            const auto& bufEndIt = attachedBuffers_.end();
             for (; bufIt != bufEndIt; ++ bufIt) {
-                const std::string &name = bufIt->first;
-                const ScalarBuffer &buffer = *bufIt->second;
+                const std::string& name = bufIt->first;
+                const ScalarBuffer& buffer = *bufIt->second;
 
                 std::shared_ptr<const ErtKeyword<float>>
                     bufKeyword(new ErtKeyword<float>(name, buffer));
@@ -293,7 +295,7 @@ public:
      * \brief Write the multi-writer's state to a restart file.
      */
     template <class Restarter>
-    void serialize(Restarter &res)
+    void serialize(Restarter& res)
     {
         res.serializeSectionBegin("EclWriter");
         res.serializeStream() << reportStepIdx_ << "\n";
@@ -304,7 +306,7 @@ public:
      * \brief Read the multi-writer's state from a restart file.
      */
     template <class Restarter>
-    void deserialize(Restarter &res)
+    void deserialize(Restarter& res)
     {
         res.deserializeSectionBegin("EclWriter");
         res.deserializeStream() >> reportStepIdx_;
@@ -317,7 +319,7 @@ private:
 
     // make sure the field is well defined if running under valgrind
     // and make sure that all values can be displayed by paraview
-    void sanitizeBuffer_(std::vector<float> &b)
+    void sanitizeBuffer_(std::vector<float>& b)
     {
         static bool warningPrinted = false;
         for (size_t i = 0; i < b.size(); ++i) {

--- a/applications/ebos/ertwrappers.hh
+++ b/applications/ebos/ertwrappers.hh
@@ -48,8 +48,9 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
-#include <opm/common/ErrorMacros.hpp>
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/grid/common/mcmgmapper.hh>
@@ -83,7 +84,7 @@ public:
 #endif
 
     // don't allow copies for objects of this class
-    ErtKeyword(const ErtKeyword &) = delete;
+    ErtKeyword(const ErtKeyword& ) = delete;
 
     // Default constructor
     ErtKeyword()
@@ -157,7 +158,7 @@ public:
 #endif
     }
 
-    const std::string &name() const
+    const std::string& name() const
     { return name_; }
 
     ErtHandleType *ertHandle() const
@@ -310,10 +311,10 @@ class ErtRestartFile
     static const unsigned numIconItemsPerConnection = 15;
 
 public:
-    ErtRestartFile(const ErtRestartFile &) = delete;
+    ErtRestartFile(const ErtRestartFile& ) = delete;
 
     template <class Simulator>
-    ErtRestartFile(const Simulator &simulator, unsigned reportStepIdx)
+    ErtRestartFile(const Simulator& simulator, unsigned reportStepIdx)
     {
         std::string caseName = simulator.gridManager().caseName();
 
@@ -343,7 +344,7 @@ public:
      * pierced by them.
      */
     template <class Simulator>
-    void writeHeader(const Simulator &simulator, unsigned reportStepIdx)
+    void writeHeader(const Simulator& simulator, unsigned reportStepIdx)
     {
         const auto& eclGrid = simulator.gridManager().eclGrid();
         const auto& eclState = simulator.gridManager().eclState();
@@ -524,7 +525,7 @@ class ErtSolution
 public:
     ErtSolution(const ErtSolution&) = delete;
 
-    ErtSolution(ErtRestartFile &restartHandle)
+    ErtSolution(ErtRestartFile& restartHandle)
         : restartHandle_(&restartHandle)
     {  ecl_rst_file_start_solution(restartHandle_->ertHandle()); }
 

--- a/ewoms/aux/baseauxiliarymodule.hh
+++ b/ewoms/aux/baseauxiliarymodule.hh
@@ -64,9 +64,12 @@ class BaseAuxiliaryModule
     typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) JacobianMatrix;
 
 protected:
-    typedef std::set<int> NeighborSet;
+    typedef std::set<unsigned> NeighborSet;
 
 public:
+    virtual ~BaseAuxiliaryModule()
+    {}
+
     /*!
      * \brief Returns the number of additional degrees of freedom required for the
      *        auxiliary module.

--- a/ewoms/aux/compatibility.hh
+++ b/ewoms/aux/compatibility.hh
@@ -74,7 +74,7 @@ namespace Dune
       typedef Dune::cpgrid::Entity< codim >   EntityType;
       typedef EntityType                      GridEntityType;
 
-      static const GridEntityType &gridEntity ( const EntityType &entity )
+      static const GridEntityType& gridEntity ( const EntityType& entity )
       {
         return entity;
       }
@@ -88,7 +88,7 @@ namespace Dune
 #if HAVE_QUAD
     template< class Traits >
     inline OutStreamInterface< Traits > &
-      operator<< ( OutStreamInterface< Traits > &out,
+      operator<< ( OutStreamInterface< Traits >& out,
                    const __float128 value )
     {
       double val = double( value );
@@ -98,7 +98,7 @@ namespace Dune
 
     template< class Traits >
     inline InStreamInterface< Traits > &
-      operator>> ( InStreamInterface< Traits > &in,
+      operator>> ( InStreamInterface< Traits >& in,
                    __float128& value )
     {
       double val;

--- a/ewoms/common/alignedallocator.hh
+++ b/ewoms/common/alignedallocator.hh
@@ -44,6 +44,7 @@
 #include <utility>
 #include <memory>
 #include <type_traits>
+#include <cassert>
 
 namespace Ewoms {
 

--- a/ewoms/common/basicproperties.hh
+++ b/ewoms/common/basicproperties.hh
@@ -125,7 +125,7 @@ SET_PROP(NumericModel, ParameterTree)
 {
     typedef Dune::ParameterTree type;
 
-    static Dune::ParameterTree &tree()
+    static Dune::ParameterTree& tree()
     {
         static Dune::ParameterTree obj_;
         return obj_;

--- a/ewoms/common/declval.hh
+++ b/ewoms/common/declval.hh
@@ -43,7 +43,7 @@ namespace Ewoms {
  * 4.4 which do not feature std::declval in their standard library.
  */
 template <class T>
-T &declval();
+T& declval();
 } // namespace Ewoms
 
 #endif

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -116,7 +116,7 @@ struct ParamInfo
     std::string usageString;
     std::string compileTimeValue;
 
-    bool operator==(const ParamInfo &other) const
+    bool operator==(const ParamInfo& other) const
     {
         return other.paramName == paramName
                && other.paramTypeName == paramTypeName
@@ -129,7 +129,7 @@ struct ParamInfo
 
 // forward declaration
 template <class TypeTag, class ParamType, class PropTag>
-const ParamType &get(const char *propTagName, const char *paramName,
+const ParamType& get(const char *propTagName, const char *paramName,
                      bool errorIfNotRegistered = true);
 
 class ParamRegFinalizerBase_
@@ -144,7 +144,7 @@ template <class TypeTag, class ParamType, class PropTag>
 class ParamRegFinalizer_ : public ParamRegFinalizerBase_
 {
 public:
-    ParamRegFinalizer_(const std::string &paramName) : paramName_(paramName)
+    ParamRegFinalizer_(const std::string& paramName) : paramName_(paramName)
     {}
 
     void retrieve()
@@ -177,20 +177,20 @@ SET_PROP(ParameterSystem, ParameterMetaData)
 {
     typedef Dune::ParameterTree type;
 
-    static Dune::ParameterTree &tree()
+    static Dune::ParameterTree& tree()
     { return storage_().tree; }
 
-    static std::map<std::string, ::Ewoms::Parameters::ParamInfo> &mutableRegistry()
+    static std::map<std::string, ::Ewoms::Parameters::ParamInfo>& mutableRegistry()
     { return storage_().registry; }
 
-    static const std::map<std::string, ::Ewoms::Parameters::ParamInfo> &registry()
+    static const std::map<std::string, ::Ewoms::Parameters::ParamInfo>& registry()
     { return storage_().registry; }
 
     static std::list< ::Ewoms::Parameters::ParamRegFinalizerBase_ *> &
     registrationFinalizers()
     { return storage_().finalizers; }
 
-    static bool &registrationOpen()
+    static bool& registrationOpen()
     { return storage_().registrationOpen; }
 
 private:
@@ -210,7 +210,7 @@ private:
     static Storage_& storage_() {
         static Storage_ obj;
         return obj;
-    };
+    }
 };
 
 SET_STRING_PROP(ParameterSystem, ParameterGroupPrefix, "");
@@ -220,13 +220,13 @@ SET_STRING_PROP(ParameterSystem, Description, "");
 
 namespace Parameters {
 // function prototype declarations
-void printParamUsage_(std::ostream &os, const ParamInfo &paramInfo);
-void getFlattenedKeyList_(std::list<std::string> &dest,
-                          const Dune::ParameterTree &tree,
-                          const std::string &prefix = "");
+void printParamUsage_(std::ostream& os, const ParamInfo& paramInfo);
+void getFlattenedKeyList_(std::list<std::string>& dest,
+                          const Dune::ParameterTree& tree,
+                          const std::string& prefix = "");
 
 
-void printParamUsage_(std::ostream &os, const ParamInfo &paramInfo)
+void printParamUsage_(std::ostream& os, const ParamInfo& paramInfo)
 {
     std::string paramMessage, paramType, paramDescription;
 
@@ -280,13 +280,13 @@ void printParamUsage_(std::ostream &os, const ParamInfo &paramInfo)
     os << paramMessage;
 }
 
-void getFlattenedKeyList_(std::list<std::string> &dest,
-                          const Dune::ParameterTree &tree,
-                          const std::string &prefix)
+void getFlattenedKeyList_(std::list<std::string>& dest,
+                          const Dune::ParameterTree& tree,
+                          const std::string& prefix)
 {
     // add the keys of the current sub-structure
     auto keyIt = tree.getValueKeys().begin();
-    const auto &keyEndIt = tree.getValueKeys().end();
+    const auto& keyEndIt = tree.getValueKeys().end();
     for (; keyIt != keyEndIt; ++keyIt) {
         std::string newKey(prefix);
         newKey += *keyIt;
@@ -295,7 +295,7 @@ void getFlattenedKeyList_(std::list<std::string> &dest,
 
     // recursively add all substructure keys
     auto subStructIt = tree.getSubKeys().begin();
-    const auto &subStructEndIt = tree.getSubKeys().end();
+    const auto& subStructEndIt = tree.getSubKeys().end();
     for (; subStructIt != subStructEndIt; ++subStructIt) {
         std::string newPrefix(prefix);
         newPrefix += *subStructIt;
@@ -307,14 +307,14 @@ void getFlattenedKeyList_(std::list<std::string> &dest,
 
 // print the values of a list of parameters
 template <class TypeTag>
-void printParamList_(std::ostream &os, const std::list<std::string> &keyList)
+void printParamList_(std::ostream& os, const std::list<std::string>& keyList)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
 
-    const Dune::ParameterTree &tree = ParamsMeta::tree();
+    const Dune::ParameterTree& tree = ParamsMeta::tree();
 
     auto keyIt = keyList.begin();
-    const auto &keyEndIt = keyList.end();
+    const auto& keyEndIt = keyList.end();
     for (; keyIt != keyEndIt; ++keyIt) {
         std::string value = ParamsMeta::registry().at(*keyIt).compileTimeValue;
         if (tree.hasKey(*keyIt))
@@ -325,15 +325,15 @@ void printParamList_(std::ostream &os, const std::list<std::string> &keyList)
 
 // print the values of a list of parameters
 template <class TypeTag>
-void printCompileTimeParamList_(std::ostream &os,
-                                const std::list<std::string> &keyList)
+void printCompileTimeParamList_(std::ostream& os,
+                                const std::list<std::string>& keyList)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
 
     auto keyIt = keyList.begin();
-    const auto &keyEndIt = keyList.end();
+    const auto& keyEndIt = keyList.end();
     for (; keyIt != keyEndIt; ++keyIt) {
-        const auto &paramInfo = ParamsMeta::registry().at(*keyIt);
+        const auto& paramInfo = ParamsMeta::registry().at(*keyIt);
         os << *keyIt << "=\"" << paramInfo.compileTimeValue
            << "\" # property: " << paramInfo.propertyName << "\n";
     }
@@ -349,8 +349,8 @@ void printCompileTimeParamList_(std::ostream &os,
  * \param progName The name of the program
  */
 template <class TypeTag>
-void printUsage(const std::string &progName, const std::string &errorMsg = "",
-                bool handleHelp = true, std::ostream &os = std::cerr)
+void printUsage(const std::string& progName, const std::string& errorMsg = "",
+                bool handleHelp = true, std::ostream& os = std::cerr)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
     std::string desc = GET_PROP_VALUE(TypeTag, Description);
@@ -374,7 +374,7 @@ void printUsage(const std::string &progName, const std::string &errorMsg = "",
     }
 
     auto paramIt = ParamsMeta::registry().begin();
-    const auto &paramEndIt = ParamsMeta::registry().end();
+    const auto& paramEndIt = ParamsMeta::registry().end();
     for (; paramIt != paramEndIt; ++paramIt) {
         printParamUsage_(os, paramIt->second);
     }
@@ -398,7 +398,7 @@ void printUsage(const std::string &progName, const std::string &errorMsg = "",
 template <class TypeTag>
 std::string parseCommandLineOptions(int argc, char **argv, bool handleHelp = true)
 {
-    Dune::ParameterTree &paramTree = GET_PROP(TypeTag, ParameterMetaData)::tree();
+    Dune::ParameterTree& paramTree = GET_PROP(TypeTag, ParameterMetaData)::tree();
 
     if (handleHelp) {
         for (int i = 1; i < argc; ++i) {
@@ -542,11 +542,11 @@ std::string parseCommandLineOptions(int argc, char **argv, bool handleHelp = tru
  * \param os The \c std::ostream on which the message should be printed
  */
 template <class TypeTag>
-void printValues(std::ostream &os = std::cout)
+void printValues(std::ostream& os = std::cout)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
 
-    const Dune::ParameterTree &tree = ParamsMeta::tree();
+    const Dune::ParameterTree& tree = ParamsMeta::tree();
 
     std::list<std::string> runTimeAllKeyList;
     std::list<std::string> runTimeKeyList;
@@ -554,7 +554,7 @@ void printValues(std::ostream &os = std::cout)
 
     getFlattenedKeyList_(runTimeAllKeyList, tree);
     auto keyIt = runTimeAllKeyList.begin();
-    const auto &keyEndIt = runTimeAllKeyList.end();
+    const auto& keyEndIt = runTimeAllKeyList.end();
     for (; keyIt != keyEndIt; ++keyIt) {
         if (ParamsMeta::registry().find(*keyIt) == ParamsMeta::registry().end()) {
             // key was not registered by the program!
@@ -569,10 +569,10 @@ void printValues(std::ostream &os = std::cout)
     // loop over all registered parameters
     std::list<std::string> compileTimeKeyList;
     auto paramInfoIt = ParamsMeta::registry().begin();
-    const auto &paramInfoEndIt = ParamsMeta::registry().end();
+    const auto& paramInfoEndIt = ParamsMeta::registry().end();
     for (; paramInfoIt != paramInfoEndIt; ++paramInfoIt) {
         // check whether the key was specified at run-time
-        const auto &keyName = paramInfoIt->first;
+        const auto& keyName = paramInfoIt->first;
         if (tree.hasKey(keyName))
             continue;
         else
@@ -594,7 +594,7 @@ void printValues(std::ostream &os = std::cout)
     if (unknownKeyList.size() > 0) {
         os << "# [unused run-time specified parameters]\n";
         auto unusedKeyIt = unknownKeyList.begin();
-        const auto &unusedKeyEndIt = unknownKeyList.end();
+        const auto& unusedKeyEndIt = unknownKeyList.end();
         for (; unusedKeyIt != unusedKeyEndIt; ++unusedKeyIt) {
             os << *unusedKeyIt << "=\"" << tree.get(*unusedKeyIt, "") << "\"\n" << std::flush;
         }
@@ -610,17 +610,17 @@ void printValues(std::ostream &os = std::cout)
  * \return true if something was printed
  */
 template <class TypeTag>
-bool printUnused(std::ostream &os = std::cout)
+bool printUnused(std::ostream& os = std::cout)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
 
-    const Dune::ParameterTree &tree = ParamsMeta::tree();
+    const Dune::ParameterTree& tree = ParamsMeta::tree();
     std::list<std::string> runTimeAllKeyList;
     std::list<std::string> unknownKeyList;
 
     getFlattenedKeyList_(runTimeAllKeyList, tree);
     auto keyIt = runTimeAllKeyList.begin();
-    const auto &keyEndIt = runTimeAllKeyList.end();
+    const auto& keyEndIt = runTimeAllKeyList.end();
     for (; keyIt != keyEndIt; ++keyIt) {
         if (ParamsMeta::registry().find(*keyIt) == ParamsMeta::registry().end()) {
             // key was not registered by the program!
@@ -631,7 +631,7 @@ bool printUnused(std::ostream &os = std::cout)
     if (unknownKeyList.size() > 0) {
         os << "# [unused run-time specified parameters]\n";
         auto unusedKeyIt = unknownKeyList.begin();
-        const auto &unusedKeyEndIt = unknownKeyList.end();
+        const auto& unusedKeyEndIt = unknownKeyList.end();
         for (; unusedKeyIt != unusedKeyEndIt; ++unusedKeyIt) {
             os << *unusedKeyIt << "=\"" << tree.get(*unusedKeyIt, "") << "\"\n" << std::flush;
         }
@@ -648,10 +648,10 @@ class Param
 
 public:
     template <class ParamType, class PropTag>
-    static const ParamType &get(const char *propTagName, const char *paramName,
+    static const ParamType& get(const char *propTagName, const char *paramName,
                                 bool errorIfNotRegistered = true)
     {
-        static const ParamType &value =
+        static const ParamType& value =
             retrieve_<ParamType, PropTag>(propTagName,
                                           paramName,
                                           errorIfNotRegistered);
@@ -665,7 +665,7 @@ private:
         std::string paramTypeName;
         std::string groupName;
 
-        Blubb &operator=(const Blubb &b)
+        Blubb& operator=(const Blubb& b)
         {
             propertyName = b.propertyName;
             paramTypeName = b.paramTypeName;
@@ -674,8 +674,8 @@ private:
         }
     };
 
-    static void check_(const std::string &paramTypeName,
-                       const std::string &propertyName, const char *paramName)
+    static void check_(const std::string& paramTypeName,
+                       const std::string& propertyName, const char *paramName)
     {
         typedef std::unordered_map<std::string, Blubb> StaticData;
         static StaticData staticData;
@@ -708,7 +708,7 @@ private:
     }
 
     template <class ParamType, class PropTag>
-    static const ParamType &retrieve_(const char *propTagName,
+    static const ParamType& retrieve_(const char *propTagName,
                                       const char *paramName,
                                       bool errorIfNotRegistered = true)
     {
@@ -748,7 +748,8 @@ private:
         }
 
         // retrieve actual parameter from the parameter tree
-        const ParamType defaultValue = GET_PROP_VALUE_(TypeTag, PropTag);
+        const ParamType defaultValue =
+            GET_PROP_VALUE_(TypeTag, PropTag);
         static ParamType value =
             ParamsMeta::tree().template get<ParamType>(canonicalName, defaultValue);
 
@@ -757,7 +758,7 @@ private:
 };
 
 template <class TypeTag, class ParamType, class PropTag>
-const ParamType &get(const char *propTagName, const char *paramName,
+const ParamType& get(const char *propTagName, const char *paramName,
                      bool errorIfNotRegistered)
 {
     return Param<TypeTag>::template get<ParamType, PropTag>(propTagName,
@@ -815,7 +816,7 @@ void endParamRegistration()
     // loop over all parameters and retrieve their values to make sure
     // that there is no syntax error
     auto pIt = ParamsMeta::registrationFinalizers().begin();
-    const auto &pEndIt = ParamsMeta::registrationFinalizers().end();
+    const auto& pEndIt = ParamsMeta::registrationFinalizers().end();
     for (; pIt != pEndIt; ++pIt) {
         (*pIt)->retrieve();
         delete *pIt;

--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -552,11 +552,11 @@ public:
     PropertyRegistryKey()
     {}
 
-    PropertyRegistryKey(const std::string &effTypeTagName,
-                        const std::string &propertyKind,
-                        const std::string &propertyName,
-                        const std::string &propertyValue,
-                        const std::string &fileDefined,
+    PropertyRegistryKey(const std::string& effTypeTagName,
+                        const std::string& propertyKind,
+                        const std::string& propertyName,
+                        const std::string& propertyValue,
+                        const std::string& fileDefined,
                         int lineDefined)
         : effTypeTagName_(effTypeTagName)
         , propertyKind_(propertyKind)
@@ -564,28 +564,21 @@ public:
         , propertyValue_(propertyValue)
         , fileDefined_(fileDefined)
         , lineDefined_(lineDefined)
-    {
-    }
+    { }
 
     // copy constructor
-    PropertyRegistryKey(const PropertyRegistryKey &v)
-        : effTypeTagName_(v.effTypeTagName_)
-        , propertyKind_(v.propertyKind_)
-        , propertyName_(v.propertyName_)
-        , propertyValue_(v.propertyValue_)
-        , fileDefined_(v.fileDefined_)
-        , lineDefined_(v.lineDefined_)
-    {}
+    PropertyRegistryKey(const PropertyRegistryKey&) = default;
+    PropertyRegistryKey& operator=(const PropertyRegistryKey&) = default;
 
-    const std::string &effTypeTagName() const
+    const std::string& effTypeTagName() const
     { return effTypeTagName_; }
-    const std::string &propertyKind() const
+    const std::string& propertyKind() const
     { return propertyKind_; }
-    const std::string &propertyName() const
+    const std::string& propertyName() const
     { return propertyName_; }
-    const std::string &propertyValue() const
+    const std::string& propertyValue() const
     { return propertyValue_; }
-    const std::string &fileDefined() const
+    const std::string& fileDefined() const
     { return fileDefined_; }
     int lineDefined() const
     { return lineDefined_; }
@@ -607,7 +600,7 @@ class TypeTagRegistry
 {
 public:
     struct SpliceRegistryEntryBase {
-        virtual ~SpliceRegistryEntryBase() {};
+        virtual ~SpliceRegistryEntryBase() {}
         virtual std::string propertyName() const = 0;
     };
 
@@ -659,10 +652,10 @@ public:
         addSplices<TypeTag, RemainingSplices...>();
     }
 
-    static const SpliceList &splices(const std::string &typeTagName)
+    static const SpliceList& splices(const std::string& typeTagName)
     { return splices_[typeTagName]; }
 
-    static const ChildrenList &children(const std::string &typeTagName)
+    static const ChildrenList& children(const std::string& typeTagName)
     { return children_[typeTagName]; }
 
 private:
@@ -679,50 +672,50 @@ public:
     typedef std::map<std::string, PropertyRegistryKey> KeyList;
     typedef std::map<std::string, KeyList> KeyListMap;
 
-    static void addKey(const PropertyRegistryKey &key)
+    static void addKey(const PropertyRegistryKey& key)
     {
         keys_[key.effTypeTagName()][key.propertyName()] = key;
     }
 
-    static const std::string &getSpliceTypeTagName(const std::string &typeTagName,
-                                                   const std::string &propertyName)
+    static const std::string& getSpliceTypeTagName(const std::string& typeTagName,
+                                                   const std::string& propertyName)
     {
-        const auto &keyIt = keys_.find(typeTagName);
-        const auto &keyEndIt = keys_.end();
+        const auto& keyIt = keys_.find(typeTagName);
+        const auto& keyEndIt = keys_.end();
         if (keyIt == keyEndIt)
             OPM_THROW(std::runtime_error,
                       "Unknown type tag key '" << typeTagName << "'");
 
         // check whether the propery is directly defined for the type tag currently
         // checked, ...
-        const auto &propIt = keyIt->second.find(propertyName);
-        const auto &propEndIt = keyIt->second.end();
+        const auto& propIt = keyIt->second.find(propertyName);
+        const auto& propEndIt = keyIt->second.end();
         if (propIt != propEndIt)
             return propIt->second.propertyValue();
 
         // ..., if not, check all splices,  ...
         typedef TypeTagRegistry::SpliceList SpliceList;
-        const SpliceList &splices = TypeTagRegistry::splices(typeTagName);
+        const SpliceList& splices = TypeTagRegistry::splices(typeTagName);
         SpliceList::const_iterator spliceIt = splices.begin();
         for (; spliceIt != splices.end(); ++spliceIt) {
-            const auto &spliceTypeTagName =
+            const auto& spliceTypeTagName =
                 PropertyRegistry::getSpliceTypeTagName(typeTagName,
                                                        (*spliceIt)->propertyName());
 
             if (spliceTypeTagName == "")
                 continue;
 
-            const auto &tmp = getSpliceTypeTagName(spliceTypeTagName, propertyName);
+            const auto& tmp = getSpliceTypeTagName(spliceTypeTagName, propertyName);
             if (tmp != "")
                 return tmp;
         }
 
         // .. if still not, check all normal children.
         typedef TypeTagRegistry::ChildrenList ChildrenList;
-        const ChildrenList &children = TypeTagRegistry::children(typeTagName);
+        const ChildrenList& children = TypeTagRegistry::children(typeTagName);
         ChildrenList::const_iterator ttagIt = children.begin();
         for (; ttagIt != children.end(); ++ttagIt) {
-            const auto &tmp = getSpliceTypeTagName(*ttagIt, propertyName);
+            const auto& tmp = getSpliceTypeTagName(*ttagIt, propertyName);
             if (tmp != "")
                 return tmp;
         }
@@ -733,13 +726,13 @@ public:
         return tmp;
     }
 
-    static const PropertyRegistryKey &getKey(const std::string &effTypeTagName,
-                                             const std::string &propertyName)
+    static const PropertyRegistryKey& getKey(const std::string& effTypeTagName,
+                                             const std::string& propertyName)
     {
         return keys_[effTypeTagName][propertyName];
     }
 
-    static const KeyList &getKeys(const std::string &effTypeTagName)
+    static const KeyList& getKeys(const std::string& effTypeTagName)
     {
         return keys_[effTypeTagName];
     }
@@ -962,9 +955,12 @@ public:
 };
 
 #if !defined NO_PROPERTY_INTROSPECTION
-int myReplaceAll_(std::string &s,
-                   const std::string &pattern,
-                   const std::string &replacement)
+int myReplaceAll_(std::string& s,
+                  const std::string& pattern,
+                  const std::string& replacement);
+int myReplaceAll_(std::string& s,
+                  const std::string& pattern,
+                  const std::string& replacement)
 {
     size_t pos;
     int i = 0;
@@ -975,7 +971,8 @@ int myReplaceAll_(std::string &s,
     return i;
 }
 
-std::string canonicalTypeTagNameToName_(const std::string &canonicalName)
+std::string canonicalTypeTagNameToName_(const std::string& canonicalName);
+std::string canonicalTypeTagNameToName_(const std::string& canonicalName)
 {
     std::string result(canonicalName);
     myReplaceAll_(result, "Ewoms::Properties::TTag::", "TTAG(");
@@ -984,14 +981,14 @@ std::string canonicalTypeTagNameToName_(const std::string &canonicalName)
     return result;
 }
 
-inline bool getDiagnostic_(const std::string &typeTagName,
-                           const std::string &propTagName,
-                           std::string &result,
+inline bool getDiagnostic_(const std::string& typeTagName,
+                           const std::string& propTagName,
+                           std::string& result,
                            const std::string indent)
 {
     const PropertyRegistryKey *key = 0;
 
-    const PropertyRegistry::KeyList &keys =
+    const PropertyRegistry::KeyList& keys =
         PropertyRegistry::getKeys(typeTagName);
     PropertyRegistry::KeyList::const_iterator it = keys.begin();
     for (; it != keys.end(); ++it) {
@@ -1014,7 +1011,7 @@ inline bool getDiagnostic_(const std::string &typeTagName,
 
     // print properties defined on children
     typedef TypeTagRegistry::ChildrenList ChildrenList;
-    const ChildrenList &children = TypeTagRegistry::children(typeTagName);
+    const ChildrenList& children = TypeTagRegistry::children(typeTagName);
     ChildrenList::const_iterator ttagIt = children.begin();
     std::string newIndent = indent + "  ";
     for (; ttagIt != children.end(); ++ttagIt) {
@@ -1035,19 +1032,19 @@ const std::string getDiagnostic(std::string propTagName)
     std::string TypeTagName(Opm::className<TypeTag>());
 
     propTagName.replace(0, strlen("PTag("), "");
-    int n = propTagName.length();
+    auto n = propTagName.length();
     propTagName.replace(n - 1, 1, "");
     //TypeTagName.replace(0, strlen("Ewoms::Properties::TTag::"), "");
 
     return result;
 }
 
-inline void print_(const std::string &rootTypeTagName,
-                   const std::string &curTypeTagName,
-                   const std::string &splicePropName,
-                   std::ostream &os,
+inline void print_(const std::string& rootTypeTagName,
+                   const std::string& curTypeTagName,
+                   const std::string& splicePropName,
+                   std::ostream& os,
                    const std::string indent,
-                   std::set<std::string> &printedProperties)
+                   std::set<std::string>& printedProperties)
 {
     if (indent == "") {
         os << indent << "###########\n";
@@ -1059,12 +1056,12 @@ inline void print_(const std::string &rootTypeTagName,
         os << indent << "Inherited from splice " << splicePropName << " (set to " << canonicalTypeTagNameToName_(curTypeTagName) << "):";
     else
         os << indent << "Inherited from " << canonicalTypeTagNameToName_(curTypeTagName) << ":";
-    const PropertyRegistry::KeyList &keys =
+    const PropertyRegistry::KeyList& keys =
         PropertyRegistry::getKeys(curTypeTagName);
     PropertyRegistry::KeyList::const_iterator it = keys.begin();
     bool somethingPrinted = false;
     for (; it != keys.end(); ++it) {
-        const PropertyRegistryKey &key = it->second;
+        const PropertyRegistryKey& key = it->second;
         if (printedProperties.count(key.propertyName()) > 0)
             continue; // property already printed
         if (!somethingPrinted) {
@@ -1097,17 +1094,17 @@ inline void print_(const std::string &rootTypeTagName,
 
     // first, iterate over the splices, ...
     typedef TypeTagRegistry::SpliceList SpliceList;
-    const SpliceList &splices = TypeTagRegistry::splices(curTypeTagName);
+    const SpliceList& splices = TypeTagRegistry::splices(curTypeTagName);
     SpliceList::const_iterator spliceIt = splices.begin();
     for (; spliceIt != splices.end(); ++ spliceIt) {
-        const auto &spliceTypeTagName = PropertyRegistry::getSpliceTypeTagName(rootTypeTagName,
+        const auto& spliceTypeTagName = PropertyRegistry::getSpliceTypeTagName(rootTypeTagName,
                                                                                (*spliceIt)->propertyName());
         print_(rootTypeTagName, spliceTypeTagName, (*spliceIt)->propertyName(), os, newIndent, printedProperties);
     }
 
     // ... then, over the children
     typedef TypeTagRegistry::ChildrenList ChildrenList;
-    const ChildrenList &children = TypeTagRegistry::children(curTypeTagName);
+    const ChildrenList& children = TypeTagRegistry::children(curTypeTagName);
     ChildrenList::const_iterator ttagIt = children.begin();
     for (; ttagIt != children.end(); ++ttagIt) {
         print_(rootTypeTagName, *ttagIt, /*splicePropName=*/"", os, newIndent, printedProperties);
@@ -1115,14 +1112,14 @@ inline void print_(const std::string &rootTypeTagName,
 }
 
 template <class TypeTag>
-void printValues(std::ostream &os = std::cout)
+void printValues(std::ostream& os = std::cout)
 {
     std::set<std::string> printedProps;
     print_(Opm::className<TypeTag>(), Opm::className<TypeTag>(), /*splicePropertyName=*/"", os, /*indent=*/"", printedProps);
 }
 #else // !defined NO_PROPERTY_INTROSPECTION
 template <class TypeTag>
-void printValues(std::ostream &os = std::cout)
+void printValues(std::ostream& os = std::cout)
 {
     std::cout <<
         "The eWoms property system was compiled with the macro\n"

--- a/ewoms/common/quad.hh
+++ b/ewoms/common/quad.hh
@@ -246,13 +246,13 @@ struct is_convertible<quad, OtherType>
     : public is_arithmetic<OtherType>
 { };
 
-inline std::ostream &operator<<(std::ostream &os, const quad &val)
+inline std::ostream& operator<<(std::ostream& os, const quad& val)
 { return (os << double(val)); }
 
-inline std::istream &operator>>(std::istream &is, quad &val)
+inline std::istream& operator>>(std::istream& is, quad& val)
 {
     double tmp;
-    std::istream &ret = (is >> tmp);
+    std::istream& ret = (is >> tmp);
     val = tmp;
     return ret;
 }
@@ -323,7 +323,7 @@ std::string className()
 { return Opm::className<T>(); }
 
 template <class T>
-std::string className(const T &)
+std::string className(const T& )
 { return Opm::className<T>(); }
 } // namespace Dune
 

--- a/ewoms/common/quadraturegeometries.hh
+++ b/ewoms/common/quadraturegeometries.hh
@@ -35,7 +35,7 @@ namespace Ewoms {
 /*!
  * \brief Quadrature geometry for quadrilaterals.
  */
-template <class Scalar, int dim>
+template <class Scalar, unsigned dim>
 class QuadrialteralQuadratureGeometry
 {
 public:
@@ -48,11 +48,11 @@ public:
     { return Dune::GeometryType(Dune::GeometryType::cube, dim); }
 
     template <class CornerContainer>
-    void setCorners(const CornerContainer &corners, unsigned numCorners)
+    void setCorners(const CornerContainer& corners, unsigned numCorners)
     {
         unsigned cornerIdx;
         for (cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx) {
-            for (int j = 0; j < dim; ++j)
+            for (unsigned j = 0; j < dim; ++j)
                 corners_[cornerIdx][j] = corners[cornerIdx][j];
         }
         assert(cornerIdx == numCorners);
@@ -66,17 +66,17 @@ public:
     /*!
      * \brief Returns the center of weight of the polyhedron.
      */
-    const GlobalPosition &center() const
+    const GlobalPosition& center() const
     { return center_; }
 
     /*!
      * \brief Convert a local coordinate into a global one.
      */
-    GlobalPosition global(const LocalPosition &localPos) const
+    GlobalPosition global(const LocalPosition& localPos) const
     {
         GlobalPosition globalPos(0.0);
 
-        for (int cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx)
+        for (unsigned cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx)
             globalPos.axpy(cornerWeight(localPos, cornerIdx),
                            corners_[cornerIdx]);
 
@@ -87,16 +87,16 @@ public:
      * \brief Returns the Jacobian matrix of the local to global
      *        mapping at a given local position.
      */
-    void jacobian(Dune::FieldMatrix<Scalar, dim, dim> &jac,
-                  const LocalPosition &localPos) const
+    void jacobian(Dune::FieldMatrix<Scalar, dim, dim>& jac,
+                  const LocalPosition& localPos) const
     {
         jac = 0.0;
-        for (int cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx) {
-            for (int k = 0; k < dim; ++k) {
-                Scalar dWeight_dk = (cornerIdx & (1 << k)) ? 1 : -1;
-                for (int j = 0; j < dim; ++j) {
+        for (unsigned cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx) {
+            for (unsigned k = 0; k < dim; ++k) {
+                Scalar dWeight_dk = (cornerIdx&  (1 << k)) ? 1 : -1;
+                for (unsigned j = 0; j < dim; ++j) {
                     if (k != j) {
-                        if (cornerIdx & (1 << j))
+                        if (cornerIdx&  (1 << j))
                             dWeight_dk *= localPos[j];
                         else
                             dWeight_dk *= 1 - localPos[j];
@@ -114,7 +114,7 @@ public:
      *        from local to global coordinates at a given local
      *        position.
      */
-    Scalar integrationElement(const LocalPosition &localPos) const
+    Scalar integrationElement(const LocalPosition& localPos) const
     {
         Dune::FieldMatrix<Scalar, dim, dim> jac;
         jacobian(jac, localPos);
@@ -124,22 +124,22 @@ public:
     /*!
      * \brief Return the position of the corner with a given index
      */
-    const GlobalPosition &corner(int cornerIdx) const
+    const GlobalPosition& corner(unsigned cornerIdx) const
     { return corners_[cornerIdx]; }
 
     /*!
      * \brief Return the weight of an individual corner for the local
      *        to global mapping.
      */
-    Scalar cornerWeight(const LocalPosition &localPos, int cornerIdx) const
+    Scalar cornerWeight(const LocalPosition& localPos, unsigned cornerIdx) const
     {
         GlobalPosition globalPos(0.0);
 
         // this code is based on the Q1 finite element code from
         // dune-localfunctions
         Scalar weight = 1.0;
-        for (int j = 0; j < dim; ++j)
-            weight *= (cornerIdx & (1 << j)) ? localPos[j] : (1 - localPos[j]);
+        for (unsigned j = 0; j < dim; ++j)
+            weight *= (cornerIdx&  (1 << j)) ? localPos[j] : (1 - localPos[j]);
 
         return weight;
     }

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -77,7 +77,7 @@ class Simulator
 
 public:
     // do not allow to copy simulators around
-    Simulator(const Simulator &) = delete;
+    Simulator(const Simulator& ) = delete;
 
     Simulator(bool verbose = true)
     {
@@ -145,51 +145,51 @@ public:
     /*!
      * \brief Return a reference to the grid manager of simulation
      */
-    GridManager &gridManager()
+    GridManager& gridManager()
     { return *gridManager_; }
 
     /*!
      * \brief Return a reference to the grid manager of simulation
      */
-    const GridManager &gridManager() const
+    const GridManager& gridManager() const
     { return *gridManager_; }
 
     /*!
      * \brief Return the grid view for which the simulation is done
      */
-    GridView &gridView()
+    GridView& gridView()
     { return gridManager_->gridView(); }
 
     /*!
      * \brief Return the grid view for which the simulation is done
      */
-    const GridView &gridView() const
+    const GridView& gridView() const
     { return gridManager_->gridView(); }
 
     /*!
      * \brief Return the physical model used in the simulation
      */
-    Model &model()
+    Model& model()
     { return *model_; }
 
     /*!
      * \brief Return the physical model used in the simulation
      */
-    const Model &model() const
+    const Model& model() const
     { return *model_; }
 
     /*!
      * \brief Return the object which specifies the pysical setup of
      *        the simulation
      */
-    Problem &problem()
+    Problem& problem()
     { return *problem_; }
 
     /*!
      * \brief Return the object which specifies the pysical setup of
      *        the simulation
      */
-    const Problem &problem() const
+    const Problem& problem() const
     { return *problem_; }
 
     /*!
@@ -221,7 +221,7 @@ public:
      * \param t The time \f$\mathrm{[s]}\f$ which should be jumped to
      * \param stepIdx The new time step index
      */
-    void setTime(Scalar t, int stepIdx)
+    void setTime(Scalar t, unsigned stepIdx)
     {
         time_ = t;
         timeStepIdx_ = stepIdx;
@@ -289,7 +289,7 @@ public:
      *
      * \param timeStepIndex The new value for the time step index
      */
-    void setTimeStepIndex(int value)
+    void setTimeStepIndex(unsigned value)
     { timeStepIdx_ = value; }
 
     /*!
@@ -649,8 +649,8 @@ public:
         if (isAmendment)
             oss << " (";
         if (timeInSeconds >= 365.25*24*60*60) {
-            int years = timeInSeconds/(365.25*24*60*60);
-            int days = (timeInSeconds - years*(365.25*24*60*60))/(24*60*60);
+            int years = static_cast<int>(timeInSeconds/(365.25*24*60*60));
+            int days = static_cast<int>((timeInSeconds - years*(365.25*24*60*60))/(24*60*60));
 
             double accuracy = 1e-2;
             double hours =
@@ -663,8 +663,8 @@ public:
             oss << years << " years, " << days << " days, "  << hours << " hours";
         }
         else if (timeInSeconds >= 24.0*60*60) {
-            int days = timeInSeconds/(24*60*60);
-            int hours = (timeInSeconds - days*(24*60*60))/(60*60);
+            int days = static_cast<int>(timeInSeconds/(24*60*60));
+            int hours = static_cast<int>((timeInSeconds - days*(24*60*60))/(60*60));
 
             double accuracy = 1e-2;
             double minutes =
@@ -677,8 +677,8 @@ public:
             oss << days << " days, " << hours << " hours, " << minutes << " minutes";
         }
         else if (timeInSeconds >= 60.0*60) {
-            int hours = timeInSeconds/(60*60);
-            int minutes = (timeInSeconds - hours*(60*60))/60;
+            int hours = static_cast<int>(timeInSeconds/(60*60));
+            int minutes = static_cast<int>((timeInSeconds - hours*(60*60))/60);
 
             double accuracy = 1e-2;
             double seconds =
@@ -691,7 +691,7 @@ public:
             oss << hours << " hours, " << minutes << " minutes, "  << seconds << " seconds";
         }
         else if (timeInSeconds >= 60.0) {
-            int minutes = timeInSeconds/60;
+            int minutes = static_cast<int>(timeInSeconds/60);
 
             double accuracy = 1e-3;
             double seconds =
@@ -750,7 +750,7 @@ public:
      * \param restarter The serializer object
      */
     template <class Restarter>
-    void serialize(Restarter &restarter)
+    void serialize(Restarter& restarter)
     {
         restarter.serializeSectionBegin("Simulator");
         restarter.serializeStream()
@@ -771,7 +771,7 @@ public:
      * \param restarter The deserializer object
      */
     template <class Restarter>
-    void deserialize(Restarter &restarter)
+    void deserialize(Restarter& restarter)
     {
         restarter.deserializeSectionBegin("Simulator");
         restarter.deserializeStream()

--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -301,14 +301,14 @@ static inline int start(int argc, char **argv)
         }
         return 0;
     }
-    catch (std::exception &e)
+    catch (std::exception& e)
     {
         if (myRank == 0)
             std::cout << e.what() << ". Abort!\n" << std::flush;
         return 1;
     }
 #if ! DUNE_VERSION_NEWER(DUNE_COMMON,3,0)
-    catch (Dune::Exception &e)
+    catch (Dune::Exception& e)
     {
         if (myRank == 0)
             std::cout << "Dune reported an error: " << e.what() << std::endl  << std::flush;

--- a/ewoms/common/timer.hh
+++ b/ewoms/common/timer.hh
@@ -106,8 +106,8 @@ public:
         if (!isStopped_)
             measure_(stopTime);
 
-        const auto &t1 = startTime_.realtimeData;
-        const auto &t2 = stopTime.realtimeData;
+        const auto& t1 = startTime_.realtimeData;
+        const auto& t2 = stopTime.realtimeData;
 
 #if defined(CLOCK_MONOTONIC) && defined(CLOCK_PROCESS_CPUTIME_ID)
         return
@@ -133,8 +133,8 @@ public:
         if (!isStopped_)
             measure_(stopTime);
 
-        const auto &t1 = startTime_.cputimeData;
-        const auto &t2 = stopTime.cputimeData;
+        const auto& t1 = startTime_.cputimeData;
+        const auto& t2 = stopTime.cputimeData;
 
 #if defined(CLOCK_MONOTONIC) && defined(CLOCK_PROCESS_CPUTIME_ID)
         return

--- a/ewoms/disc/common/fvbaseboundarycontext.hh
+++ b/ewoms/disc/common/fvbaseboundarycontext.hh
@@ -30,6 +30,8 @@
 
 #include "fvbaseproperties.hh"
 
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/common/fvector.hh>
 
 namespace Ewoms {
@@ -67,7 +69,7 @@ public:
     /*!
      * \brief The constructor.
      */
-    explicit FvBaseBoundaryContext(const ElementContext &elemCtx)
+    explicit FvBaseBoundaryContext(const ElementContext& elemCtx)
         : elemCtx_(elemCtx)
         , intersectionIt_(gridView().ibegin(element()))
     { }
@@ -75,67 +77,67 @@ public:
     /*!
      * \copydoc Ewoms::ElementContext::problem()
      */
-    const Problem &problem() const
+    const Problem& problem() const
     { return elemCtx_.problem(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::model()
      */
-    const Model &model() const
+    const Model& model() const
     { return elemCtx_.model(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::gridView()
      */
-    const GridView &gridView() const
+    const GridView& gridView() const
     { return elemCtx_.gridView(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::element()
      */
-    const Element &element() const
+    const Element& element() const
     { return elemCtx_.element(); }
 
     /*!
      * \brief Returns a reference to the element context object.
      */
-    const ElementContext &elementContext() const
+    const ElementContext& elementContext() const
     { return elemCtx_; }
 
     /*!
      * \brief Returns a reference to the current gradient calculator.
      */
-    const GradientCalculator &gradientCalculator() const
+    const GradientCalculator& gradientCalculator() const
     { return elemCtx_.gradientCalculator(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::numDof()
      */
-    unsigned numDof(unsigned timeIdx) const
+    size_t numDof(unsigned timeIdx) const
     { return elemCtx_.numDof(timeIdx); }
 
     /*!
      * \copydoc Ewoms::ElementContext::numPrimaryDof()
      */
-    unsigned numPrimaryDof(unsigned timeIdx) const
+    size_t numPrimaryDof(unsigned timeIdx) const
     { return elemCtx_.numPrimaryDof(timeIdx); }
 
     /*!
      * \copydoc Ewoms::ElementContext::numInteriorFaces()
      */
-    unsigned numInteriorFaces(unsigned timeIdx) const
+    size_t numInteriorFaces(unsigned timeIdx) const
     { return elemCtx_.numInteriorFaces(timeIdx); }
 
     /*!
      * \brief Return the number of boundary segments of the current element
      */
-    unsigned numBoundaryFaces(unsigned timeIdx) const
+    size_t numBoundaryFaces(unsigned timeIdx) const
     { return elemCtx_.stencil(timeIdx).numBoundaryFaces(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::stencil()
      */
-    const Stencil &stencil(unsigned timeIdx) const
+    const Stencil& stencil(unsigned timeIdx) const
     { return elemCtx_.stencil(timeIdx); }
 
     /*!
@@ -163,7 +165,7 @@ public:
      * \param boundaryFaceIdx The local index of the boundary segment
      * \param timeIdx The index of the solution used by the time discretization
      */
-    const GlobalPosition &pos(unsigned boundaryFaceIdx, unsigned timeIdx) const
+    const GlobalPosition& pos(unsigned boundaryFaceIdx, unsigned timeIdx) const
     { return stencil(timeIdx).boundaryFace(boundaryFaceIdx).integrationPos(); }
 
     /*!
@@ -172,7 +174,7 @@ public:
      * \param boundaryFaceIdx The local index of the boundary segment
      * \param timeIdx The index of the solution used by the time discretization
      */
-    const GlobalPosition &cvCenter(unsigned boundaryFaceIdx, unsigned timeIdx) const
+    const GlobalPosition& cvCenter(unsigned boundaryFaceIdx, unsigned timeIdx) const
     {
         unsigned scvIdx = stencil(timeIdx).boundaryFace(boundaryFaceIdx).interiorIndex();
         return stencil(timeIdx).subControlVolume(scvIdx).globalPos();
@@ -207,7 +209,7 @@ public:
      * \param boundaryFaceIdx The local index of the boundary segment
      * \param timeIdx The index of the solution used by the time discretization
      */
-    const IntensiveQuantities &intensiveQuantities(unsigned boundaryFaceIdx, unsigned timeIdx) const
+    const IntensiveQuantities& intensiveQuantities(unsigned boundaryFaceIdx, unsigned timeIdx) const
     {
         unsigned interiorScvIdx = this->interiorScvIndex(boundaryFaceIdx, timeIdx);
         return elemCtx_.intensiveQuantities(interiorScvIdx, timeIdx);
@@ -219,7 +221,7 @@ public:
      * \param boundaryFaceIdx The local index of the boundary segment
      * \param timeIdx The index of the solution used by the time discretization
      */
-    const ExtensiveQuantities &extensiveQuantities(unsigned boundaryFaceIdx, unsigned timeIdx) const
+    const ExtensiveQuantities& extensiveQuantities(unsigned boundaryFaceIdx, unsigned timeIdx) const
     { return elemCtx_.boundaryExtensiveQuantities(boundaryFaceIdx, timeIdx); }
 
     /*!
@@ -231,7 +233,7 @@ public:
      *
      * \param boundaryFaceIdx The local index of the boundary segment
      */
-    const Intersection &intersection(unsigned boundaryFaceIdx) const
+    const Intersection& intersection(unsigned OPM_UNUSED boundaryFaceIdx) const
     { return *intersectionIt_; }
 
     /*!
@@ -242,11 +244,11 @@ public:
      * context classes should not store any indices. it is done this
      * way for performance reasons
      */
-    IntersectionIterator &intersectionIt()
+    IntersectionIterator& intersectionIt()
     { return intersectionIt_; }
 
 protected:
-    const ElementContext &elemCtx_;
+    const ElementContext& elemCtx_;
     IntersectionIterator intersectionIt_;
 };
 

--- a/ewoms/disc/common/fvbaseconstraintscontext.hh
+++ b/ewoms/disc/common/fvbaseconstraintscontext.hh
@@ -57,32 +57,32 @@ public:
     /*!
      * \brief The constructor.
      */
-    explicit FvBaseConstraintsContext(const ElementContext &elemCtx)
+    explicit FvBaseConstraintsContext(const ElementContext& elemCtx)
         : elemCtx_(elemCtx)
     { }
 
     /*!
      * \copydoc Ewoms::ElementContext::problem()
      */
-    const Problem &problem() const
+    const Problem& problem() const
     { return elemCtx_.problem(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::model()
      */
-    const Model &model() const
+    const Model& model() const
     { return elemCtx_.model(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::gridView()
      */
-    const GridView &gridView() const
+    const GridView& gridView() const
     { return elemCtx_.gridView(); }
 
     /*!
      * \copydoc Ewoms::ElementContext::element()
      */
-    const Element &element() const
+    const Element& element() const
     { return elemCtx_.element(); }
 
     /*!
@@ -110,7 +110,7 @@ public:
     { return elemCtx_.pos(dofIdx, timeIdx); }
 
 protected:
-    const ElementContext &elemCtx_;
+    const ElementContext& elemCtx_;
 };
 
 } // namespace Ewoms

--- a/ewoms/disc/common/fvbaseelementcontext.hh
+++ b/ewoms/disc/common/fvbaseelementcontext.hh
@@ -32,6 +32,10 @@
 
 #include <ewoms/common/alignedallocator.hh>
 
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <dune/common/fvector.hh>
 
 #include <vector>
@@ -73,23 +77,22 @@ class FvBaseElementContext
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GridView::template Codim<0>::Entity Element;
 
-    static const int dim = GridView::dimension;
-    static const int numEq = GET_PROP_VALUE(TypeTag, NumEq);
-    static const int requireScvCenterGradients =
+    static const unsigned dim = GridView::dimension;
+    static const unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    static const unsigned requireScvCenterGradients =
         GET_PROP_VALUE(TypeTag, RequireScvCenterGradients);
 
     typedef typename GridView::ctype CoordScalar;
     typedef Dune::FieldVector<CoordScalar, dim> GlobalPosition;
 
     // we don't allow copies of element contexts!
-    FvBaseElementContext(const FvBaseElementContext &context)
-    {}
+    FvBaseElementContext(const FvBaseElementContext& ) = delete;
 
 public:
     /*!
      * \brief The constructor.
      */
-    explicit FvBaseElementContext(const Simulator &simulator)
+    explicit FvBaseElementContext(const Simulator& simulator)
         : gridView_(simulator.gridView())
         , stencil_(gridView_, simulator.model().dofMapper() )
     {
@@ -114,7 +117,7 @@ public:
      * \param elem The DUNE Codim<0> entity for which the volume
      *             variables ought to be calculated
      */
-    void updateAll(const Element &elem)
+    void updateAll(const Element& elem)
     {
         updateStencil(elem);
         updateAllIntensiveQuantities();
@@ -127,7 +130,7 @@ public:
      * \param elem The grid element for which the finite volume geometry ought to be
      *             computed.
      */
-    void updateStencil(const Element &elem)
+    void updateStencil(const Element& elem)
     {
         // remember the current element
         elemPtr_ = &elem;
@@ -157,7 +160,7 @@ public:
      * \param elem The grid element for which the finite volume geometry ought to be
      *             computed.
      */
-    void updatePrimaryStencil(const Element &elem)
+    void updatePrimaryStencil(const Element& elem)
     {
         // remember the current element
         elemPtr_ = &elem;
@@ -174,7 +177,7 @@ public:
      * \param elem The grid element for which the finite volume geometry ought to be
      *             computed.
      */
-    void updateStencilTopology(const Element &elem)
+    void updateStencilTopology(const Element& elem)
     {
         // remember the current element
         elemPtr_ = &elem;
@@ -232,12 +235,12 @@ public:
      *               which should be updated.
      * \param timeIdx The index of the solution vector used by the time discretization.
      */
-    void updateIntensiveQuantities(const PrimaryVariables &priVars, unsigned dofIdx, unsigned timeIdx)
+    void updateIntensiveQuantities(const PrimaryVariables& priVars, unsigned dofIdx, unsigned timeIdx)
     {
         updateSingleIntQuants_(priVars, dofIdx, timeIdx);
 
         // update gradients inside a sub control volume
-        unsigned nDof = numDof(timeIdx);
+        size_t nDof = numDof(timeIdx);
         for (unsigned gradDofIdx = 0; gradDofIdx < nDof; gradDofIdx++) {
             dofVars_[gradDofIdx].intensiveQuantities[timeIdx].updateScvGradients(/*context=*/*this,
                                                                                  gradDofIdx,
@@ -275,57 +278,57 @@ public:
     /*!
      * \brief Return a reference to the simulator.
      */
-    const Simulator &simulator() const
+    const Simulator& simulator() const
     { return *simulatorPtr_; }
 
     /*!
      * \brief Return a reference to the problem.
      */
-    const Problem &problem() const
+    const Problem& problem() const
     { return simulatorPtr_->problem(); }
 
     /*!
      * \brief Return a reference to the model.
      */
-    const Model &model() const
+    const Model& model() const
     { return simulatorPtr_->model(); }
 
     /*!
      * \brief Return a reference to the grid view.
      */
-    const GridView &gridView() const
+    const GridView& gridView() const
     { return gridView_; }
 
     /*!
      * \brief Return the current element.
      */
-    const Element &element() const
+    const Element& element() const
     { return *elemPtr_; }
 
     /*!
      * \brief Return the number of sub-control volumes of the current element.
      */
-    unsigned numDof(unsigned timeIdx) const
+    size_t numDof(unsigned timeIdx) const
     { return stencil(timeIdx).numDof(); }
 
     /*!
      * \brief Return the number of primary degrees of freedom of the current element.
      */
-    unsigned numPrimaryDof(unsigned timeIdx) const
+    size_t numPrimaryDof(unsigned timeIdx) const
     { return stencil(timeIdx).numPrimaryDof(); }
 
     /*!
      * \brief Return the number of non-boundary faces which need to be
      *        considered for the flux apporixmation.
      */
-    unsigned numInteriorFaces(unsigned timeIdx) const
+    size_t numInteriorFaces(unsigned timeIdx) const
     { return stencil(timeIdx).numInteriorFaces(); }
 
     /*!
      * \brief Return the number of boundary faces which need to be
      *        considered for the flux apporixmation.
      */
-    unsigned numBoundaryFaces(unsigned timeIdx) const
+    size_t numBoundaryFaces(unsigned timeIdx) const
     { return stencil(timeIdx).numBoundaryFaces(); }
 
     /*!
@@ -334,7 +337,7 @@ public:
      * \param timeIdx The index of the solution vector used by the
      *                time discretization.
      */
-    const Stencil &stencil(unsigned timeIdx) const
+    const Stencil& stencil(unsigned OPM_UNUSED timeIdx) const
     { return stencil_; }
 
     /*!
@@ -345,7 +348,7 @@ public:
      * \param timeIdx The index of the solution vector used by the
      *                time discretization.
      */
-    const GlobalPosition &pos(unsigned dofIdx, unsigned timeIdx) const
+    const GlobalPosition& pos(unsigned dofIdx, unsigned OPM_UNUSED timeIdx) const
     { return stencil_.subControlVolume(dofIdx).globalPos(); }
 
     /*!
@@ -356,7 +359,7 @@ public:
      * \param timeIdx The index of the solution vector used by the
      *                time discretization.
      */
-    int globalSpaceIndex(unsigned dofIdx, unsigned timeIdx) const
+    unsigned globalSpaceIndex(unsigned dofIdx, unsigned timeIdx) const
     { return stencil(timeIdx).globalSpaceIndex(dofIdx); }
 
 
@@ -402,7 +405,7 @@ public:
      * \param dofIdx The local index of the degree of freedom in the current element.
      * \param timeIdx The index of the solution vector used by the time discretization.
      */
-    const IntensiveQuantities &intensiveQuantities(unsigned dofIdx, unsigned timeIdx) const
+    const IntensiveQuantities& intensiveQuantities(unsigned dofIdx, unsigned timeIdx) const
     {
 #ifndef NDEBUG
         assert(0 <= dofIdx && dofIdx < numDof(timeIdx));
@@ -432,7 +435,7 @@ public:
     /*!
      * \copydoc intensiveQuantities()
      */
-    IntensiveQuantities &intensiveQuantities(unsigned dofIdx, unsigned timeIdx)
+    IntensiveQuantities& intensiveQuantities(unsigned dofIdx, unsigned timeIdx)
     {
         assert(0 <= dofIdx && dofIdx < numDof(timeIdx));
         return dofVars_[dofIdx].intensiveQuantities[timeIdx];
@@ -446,7 +449,7 @@ public:
      * \param timeIdx The index of the solution vector used by the
      *                time discretization.
      */
-    PrimaryVariables &primaryVars(unsigned dofIdx, unsigned timeIdx)
+    PrimaryVariables& primaryVars(unsigned dofIdx, unsigned timeIdx)
     {
         assert(0 <= dofIdx && dofIdx < numDof(timeIdx));
         return dofVars_[dofIdx].priVars[timeIdx];
@@ -454,7 +457,7 @@ public:
     /*!
      * \copydoc primaryVars()
      */
-    const PrimaryVariables &primaryVars(unsigned dofIdx, unsigned timeIdx) const
+    const PrimaryVariables& primaryVars(unsigned dofIdx, unsigned timeIdx) const
     {
         assert(0 <= dofIdx && dofIdx < numDof(timeIdx));
         return dofVars_[dofIdx].priVars[timeIdx];
@@ -489,7 +492,7 @@ public:
 
         intensiveQuantitiesStashed_ = dofVars_[dofIdx].intensiveQuantities[/*timeIdx=*/0];
         priVarsStashed_ = dofVars_[dofIdx].priVars[/*timeIdx=*/0];
-        stashedDofIdx_ = dofIdx;
+        stashedDofIdx_ = static_cast<int>(dofIdx);
     }
 
     /*!
@@ -519,7 +522,7 @@ public:
      *               extensive quantities are requested
      * \param timeIdx The index of the solution vector used by the time discretization.
      */
-    const ExtensiveQuantities &extensiveQuantities(unsigned fluxIdx, unsigned timeIdx) const
+    const ExtensiveQuantities& extensiveQuantities(unsigned fluxIdx, unsigned OPM_UNUSED timeIdx) const
     { return extensiveQuantities_[fluxIdx]; }
 
     /*!
@@ -543,10 +546,10 @@ protected:
      *
      * This method considers the intensive quantities cache.
      */
-    void updateIntensiveQuantities_(unsigned timeIdx, unsigned numDof)
+    void updateIntensiveQuantities_(unsigned timeIdx, size_t numDof)
     {
         // update the intensive quantities for the whole history
-        const SolutionVector &globalSol = model().solution(timeIdx);
+        const SolutionVector& globalSol = model().solution(timeIdx);
 
         // update the non-gradient quantities
         for (unsigned dofIdx = 0; dofIdx < numDof; dofIdx++) {
@@ -577,7 +580,7 @@ protected:
         }
     }
 
-    void updateSingleIntQuants_(const PrimaryVariables &priVars, unsigned dofIdx, unsigned timeIdx)
+    void updateSingleIntQuants_(const PrimaryVariables& priVars, unsigned dofIdx, unsigned timeIdx)
     {
 #ifndef NDEBUG
         if (enableStorageCache_ && timeIdx != 0)

--- a/ewoms/disc/common/fvbaseextensivequantities.hh
+++ b/ewoms/disc/common/fvbaseextensivequantities.hh
@@ -31,6 +31,7 @@
 #include "fvbaseproperties.hh"
 
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 namespace Ewoms {
 /*!
@@ -61,9 +62,9 @@ public:
      *                extensive quantities should be calculated.
      * \param timeIdx The index used by the time discretization.
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
-        const auto &scvf = elemCtx.stencil(timeIdx).interiorFace(scvfIdx);
+        const auto& scvf = elemCtx.stencil(timeIdx).interiorFace(scvfIdx);
         interiorScvIdx_ = scvf.interiorIndex();
         exteriorScvIdx_ = scvf.exteriorIndex();
 
@@ -86,15 +87,15 @@ public:
      * \param paramCache The FluidSystem's parameter cache.
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context,
-                        int bfIdx,
-                        int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& OPM_UNUSED fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& OPM_UNUSED paramCache)
     {
-        int dofIdx = context.interiorScvIndex(bfIdx, timeIdx);
-        interiorScvIdx_ = dofIdx;
-        exteriorScvIdx_ = dofIdx;
+        unsigned dofIdx = context.interiorScvIndex(bfIdx, timeIdx);
+        interiorScvIdx_ = static_cast<unsigned short>(dofIdx);
+        exteriorScvIdx_ = static_cast<unsigned short>(dofIdx);
 
         extrusionFactor_ = context.intensiveQuantities(bfIdx, timeIdx).extrusionFactor();
         Valgrind::CheckDefined(extrusionFactor_);
@@ -111,20 +112,20 @@ public:
      * \brief Return the local index of the control volume which is on the "interior" of
      *        the sub-control volume face.
      */
-    short interiorIndex() const
+    unsigned short interiorIndex() const
     { return interiorScvIdx_; }
 
     /*!
      * \brief Return the local index of the control volume which is on the "exterior" of
      *        the sub-control volume face.
      */
-    short exteriorIndex() const
+    unsigned short exteriorIndex() const
     { return exteriorScvIdx_; }
 
 private:
     // local indices of the interior and the exterior sub-control-volumes
-    short interiorScvIdx_;
-    short exteriorScvIdx_;
+    unsigned short interiorScvIdx_;
+    unsigned short exteriorScvIdx_;
 
     Scalar extrusionFactor_;
 };

--- a/ewoms/disc/common/fvbasefdlocallinearizer.hh
+++ b/ewoms/disc/common/fvbasefdlocallinearizer.hh
@@ -188,7 +188,7 @@ public:
      *
      * \param simulator The simulator object of the simulation.
      */
-    void init(Simulator &simulator)
+    void init(Simulator& simulator)
     {
         simulatorPtr_ = &simulator;
         delete internalElemContext_;
@@ -206,7 +206,7 @@ public:
      * \param element The grid element for which the local residual and its local
      *                Jacobian should be calculated.
      */
-    void linearize(const Element &element)
+    void linearize(const Element& element)
     {
         internalElemContext_->updateAll(element);
 
@@ -227,7 +227,7 @@ public:
      * \param elemCtx The element execution context for which the local residual and its
      *                local Jacobian should be calculated.
      */
-    void linearize(ElementContext &elemCtx)
+    void linearize(ElementContext& elemCtx)
     {
         // update the weights of the primary variables for the context
         model_().updatePVWeights(elemCtx);
@@ -239,9 +239,9 @@ public:
         localResidual_.eval(residual_, elemCtx);
 
         // calculate the local jacobian matrix
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-        for (int dofIdx = 0; dofIdx < numPrimaryDof; dofIdx++) {
-            for (int pvIdx = 0; pvIdx < numEq; pvIdx++) {
+        size_t numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        for (unsigned dofIdx = 0; dofIdx < numPrimaryDof; dofIdx++) {
+            for (unsigned pvIdx = 0; pvIdx < numEq; pvIdx++) {
                 asImp_().evalPartialDerivative_(elemCtx, dofIdx, pvIdx);
 
                 // incorporate the partial derivatives into the local Jacobian matrix
@@ -268,11 +268,11 @@ public:
      *                   which the local derivative ought to be calculated.
      * \param pvIdx      The index of the primary variable which gets varied
      */
-    Scalar numericEpsilon(const ElementContext &elemCtx,
-                          int dofIdx,
-                          int pvIdx) const
+    Scalar numericEpsilon(const ElementContext& elemCtx,
+                          unsigned dofIdx,
+                          unsigned pvIdx) const
     {
-        int globalIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+        unsigned globalIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
         Scalar pvWeight = elemCtx.model().primaryVarWeight(globalIdx, pvIdx);
         assert(pvWeight > 0 && std::isfinite(pvWeight));
         Valgrind::CheckDefined(pvWeight);
@@ -283,13 +283,13 @@ public:
     /*!
      * \brief Return reference to the local residual.
      */
-    LocalResidual &localResidual()
+    LocalResidual& localResidual()
     { return localResidual_; }
 
     /*!
      * \brief Return reference to the local residual.
      */
-    const LocalResidual &localResidual() const
+    const LocalResidual& localResidual() const
     { return localResidual_; }
 
     /*!
@@ -300,7 +300,7 @@ public:
      * \param rangeScvIdx The local index of the sub control volume
      *                    which contains the local residual
      */
-    const ScalarMatrixBlock &jacobian(int domainScvIdx, int rangeScvIdx) const
+    const ScalarMatrixBlock& jacobian(unsigned domainScvIdx, unsigned rangeScvIdx) const
     { return jacobian_[domainScvIdx][rangeScvIdx]; }
 
     /*!
@@ -308,20 +308,20 @@ public:
      *
      * \param dofIdx The local index of the sub control volume
      */
-    const ScalarVectorBlock &residual(int dofIdx) const
+    const ScalarVectorBlock& residual(unsigned dofIdx) const
     { return residual_[dofIdx]; }
 
 protected:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-    const Simulator &simulator_() const
+    const Simulator& simulator_() const
     { return *simulatorPtr_; }
-    const Problem &problem_() const
+    const Problem& problem_() const
     { return simulatorPtr_->problem(); }
-    const Model &model_() const
+    const Model& model_() const
     { return simulatorPtr_->model(); }
 
     /*!
@@ -334,10 +334,10 @@ protected:
      * \brief Resize all internal attributes to the size of the
      *        element.
      */
-    void resize_(const ElementContext &elemCtx)
+    void resize_(const ElementContext& elemCtx)
     {
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        size_t numDof = elemCtx.numDof(/*timeIdx=*/0);
+        size_t numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
 
         residual_.resize(numDof);
         jacobian_.setSize(numDof, numPrimaryDof);
@@ -348,15 +348,15 @@ protected:
     /*!
      * \brief Reset the all relevant internal attributes to 0
      */
-    void reset_(const ElementContext &elemCtx)
+    void reset_(const ElementContext& elemCtx)
     {
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        int numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
-        for (int primaryDofIdx = 0; primaryDofIdx < numPrimaryDof; ++ primaryDofIdx)
-            for (int dof2Idx = 0; dof2Idx < numDof; ++ dof2Idx)
+        size_t numDof = elemCtx.numDof(/*timeIdx=*/0);
+        size_t numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        for (unsigned primaryDofIdx = 0; primaryDofIdx < numPrimaryDof; ++ primaryDofIdx)
+            for (unsigned dof2Idx = 0; dof2Idx < numDof; ++ dof2Idx)
                 jacobian_[dof2Idx][primaryDofIdx] = 0.0;
 
-        for (int primaryDofIdx = 0; primaryDofIdx < numDof; ++ primaryDofIdx)
+        for (unsigned primaryDofIdx = 0; primaryDofIdx < numDof; ++ primaryDofIdx)
             residual_[primaryDofIdx] = 0.0;
     }
 
@@ -402,9 +402,9 @@ protected:
      *              for which the partial derivative ought to be
      *              calculated
      */
-    void evalPartialDerivative_(ElementContext &elemCtx,
-                                int dofIdx,
-                                int pvIdx)
+    void evalPartialDerivative_(ElementContext& elemCtx,
+                                unsigned dofIdx,
+                                unsigned pvIdx)
     {
         // save all quantities which depend on the specified primary
         // variable at the given sub control volume
@@ -478,14 +478,14 @@ protected:
      *        partial derivatives of all equations in regard to the
      *        primary variable 'pvIdx' at vertex 'dofIdx' .
      */
-    void updateLocalJacobian_(const ElementContext &elemCtx,
-                              int primaryDofIdx,
-                              int pvIdx)
+    void updateLocalJacobian_(const ElementContext& elemCtx,
+                              unsigned primaryDofIdx,
+                              unsigned pvIdx)
     {
-        int numDof = elemCtx.numDof(/*timeIdx=*/0);
-        for (int dofIdx = 0; dofIdx < numDof; dofIdx++)
+        size_t numDof = elemCtx.numDof(/*timeIdx=*/0);
+        for (unsigned dofIdx = 0; dofIdx < numDof; dofIdx++)
         {
-            for (int eqIdx = 0; eqIdx < numEq; eqIdx++) {
+            for (unsigned eqIdx = 0; eqIdx < numEq; eqIdx++) {
                 // A[dofIdx][primaryDofIdx][eqIdx][pvIdx] is the partial derivative of
                 // the residual function 'eqIdx' for the degree of freedom 'dofIdx' with
                 // regard to the primary variable 'pvIdx' of the degree of freedom

--- a/ewoms/disc/common/fvbasegradientcalculator.hh
+++ b/ewoms/disc/common/fvbasegradientcalculator.hh
@@ -30,6 +30,8 @@
 
 #include "fvbaseproperties.hh"
 
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/common/fvector.hh>
 
 namespace Ewoms {
@@ -84,14 +86,14 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <bool prepareValues = true, bool prepareGradients = true>
-    void prepare(const ElementContext &elemCtx, unsigned timeIdx)
+    void prepare(const ElementContext& elemCtx, unsigned timeIdx)
     {
-        const auto &stencil = elemCtx.stencil(timeIdx);
+        const auto& stencil = elemCtx.stencil(timeIdx);
         for (unsigned fapIdx = 0; fapIdx < stencil.numInteriorFaces(); ++ fapIdx) {
-            const auto &scvf = stencil.interiorFace(fapIdx);
-            const auto &normal = scvf.normal();
-            const auto &interiorPos = stencil.subControlVolume(scvf.interiorIndex()).globalPos();
-            const auto &exteriorPos = stencil.subControlVolume(scvf.exteriorIndex()).globalPos();
+            const auto& scvf = stencil.interiorFace(fapIdx);
+            const auto& normal = scvf.normal();
+            const auto& interiorPos = stencil.subControlVolume(scvf.interiorIndex()).globalPos();
+            const auto& exteriorPos = stencil.subControlVolume(scvf.exteriorIndex()).globalPos();
 
             interiorDistance_[fapIdx] = 0;
             exteriorDistance_[fapIdx] = 0;
@@ -123,12 +125,12 @@ public:
      *               freedom
      */
     template <class QuantityCallback>
-    auto calculateValue(const ElementContext &elemCtx,
+    auto calculateValue(const ElementContext& elemCtx,
                         unsigned fapIdx,
-                        const QuantityCallback &quantityCallback) const
+                        const QuantityCallback& quantityCallback) const
         -> typename std::remove_reference<decltype(quantityCallback.operator()(0))>::type
     {
-        const auto &face = elemCtx.stencil(/*timeIdx=*/0).interiorFace(fapIdx);
+        const auto& face = elemCtx.stencil(/*timeIdx=*/0).interiorFace(fapIdx);
 
         // average weighted by distance to DOF coordinate...
         auto value(quantityCallback(face.interiorIndex()));
@@ -153,13 +155,13 @@ public:
      *               freedom
      */
     template <class QuantityCallback>
-    void calculateGradient(EvalDimVector &quantityGrad,
-                           const ElementContext &elemCtx,
+    void calculateGradient(EvalDimVector& quantityGrad,
+                           const ElementContext& elemCtx,
                            unsigned fapIdx,
-                           const QuantityCallback &quantityCallback) const
+                           const QuantityCallback& quantityCallback) const
     {
-        const auto &stencil = elemCtx.stencil(/*timeIdx=*/0);
-        const auto &face = stencil.interiorFace(fapIdx);
+        const auto& stencil = elemCtx.stencil(/*timeIdx=*/0);
+        const auto& face = stencil.interiorFace(fapIdx);
 
         const auto& exteriorPos = stencil.subControlVolume(face.exteriorIndex()).center();
         const auto& interiorPos = stencil.subControlVolume(face.interiorIndex()).center();
@@ -208,9 +210,9 @@ public:
      *               freedom
      */
     template <class QuantityCallback>
-    auto calculateBoundaryValue(const ElementContext &elemCtx,
-                                unsigned fapIdx,
-                                const QuantityCallback &quantityCallback)
+    auto calculateBoundaryValue(const ElementContext& OPM_UNUSED elemCtx,
+                                unsigned OPM_UNUSED fapIdx,
+                                const QuantityCallback& quantityCallback)
         -> decltype(quantityCallback.boundaryValue())
     { return quantityCallback.boundaryValue(); }
 
@@ -229,13 +231,13 @@ public:
      *               freedom
      */
     template <class QuantityCallback>
-    void calculateBoundaryGradient(EvalDimVector &quantityGrad,
-                                   const ElementContext &elemCtx,
+    void calculateBoundaryGradient(EvalDimVector& quantityGrad,
+                                   const ElementContext& elemCtx,
                                    unsigned faceIdx,
-                                   const QuantityCallback &quantityCallback) const
+                                   const QuantityCallback& quantityCallback) const
     {
-        const auto &stencil = elemCtx.stencil(/*timeIdx=*/0);
-        const auto &face = stencil.boundaryFace(faceIdx);
+        const auto& stencil = elemCtx.stencil(/*timeIdx=*/0);
+        const auto& face = stencil.boundaryFace(faceIdx);
 
         auto deltay = quantityCallback.boundaryValue() - quantityCallback(face.interiorIndex());
 

--- a/ewoms/disc/common/fvbaseintensivequantities.hh
+++ b/ewoms/disc/common/fvbaseintensivequantities.hh
@@ -31,6 +31,7 @@
 #include "fvbaseproperties.hh"
 
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 namespace Ewoms {
 
@@ -53,7 +54,7 @@ public:
     { evalPoint_ = 0; }
 
     // copy constructor
-    FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities &v)
+    FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities& v)
     {
         evalPoint_ = 0;
         extrusionFactor_ = v.extrusionFactor_;
@@ -62,7 +63,7 @@ public:
     /*!
      * \brief Assignment operator
      */
-    FvBaseIntensiveQuantities &operator=(const FvBaseIntensiveQuantities &v)
+    FvBaseIntensiveQuantities& operator=(const FvBaseIntensiveQuantities& v)
     {
         evalPoint_ = 0;
         extrusionFactor_ = v.extrusionFactor_;
@@ -94,15 +95,15 @@ public:
      *
      * The evaluation point is only used by semi-smooth models.
      */
-    const Implementation &evalPoint() const
+    const Implementation& evalPoint() const
     { return (evalPoint_ == 0)?asImp_():*evalPoint_; }
 
     /*!
      * \brief Update all quantities for a given control volume.
      */
-    void update(const ElementContext &elemCtx,
-                int dofIdx,
-                int timeIdx)
+    void update(const ElementContext& elemCtx,
+                unsigned dofIdx,
+                unsigned timeIdx)
     { extrusionFactor_ = elemCtx.problem().extrusionFactor(elemCtx, dofIdx, timeIdx); }
 
     /*!
@@ -114,9 +115,9 @@ public:
      * \param timeIdx The index for the time discretization for which
      *                the intensive quantities should be calculated
      */
-    void updateScvGradients(const ElementContext &elemCtx,
-                            int dofIdx,
-                            int timeIdx)
+    void updateScvGradients(const ElementContext& OPM_UNUSED elemCtx,
+                            unsigned OPM_UNUSED dofIdx,
+                            unsigned OPM_UNUSED timeIdx)
     { }
 
     /*!
@@ -145,9 +146,9 @@ public:
     }
 
 private:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
     // the evaluation point of the local jacobian

--- a/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
+++ b/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
@@ -64,7 +64,7 @@ class FvBaseNewtonConvergenceWriter
     typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
 
 public:
-    FvBaseNewtonConvergenceWriter(NewtonMethod &nm)
+    FvBaseNewtonConvergenceWriter(NewtonMethod& nm)
         : newtonMethod_(nm)
     {
         timeStepIdx_ = 0;
@@ -107,8 +107,8 @@ public:
      * \param deltaU The negative difference between the solution
      *        vectors of the previous and the current iteration.
      */
-    void writeFields(const SolutionVector &uLastIter,
-                     const GlobalEqVector &deltaU)
+    void writeFields(const SolutionVector& uLastIter,
+                     const GlobalEqVector& deltaU)
     {
         try {
             newtonMethod_.problem().model().addConvergenceVtkFields(*vtkMultiWriter_,
@@ -143,7 +143,7 @@ private:
     int timeStepIdx_;
     int iteration_;
     VtkMultiWriter *vtkMultiWriter_;
-    NewtonMethod &newtonMethod_;
+    NewtonMethod& newtonMethod_;
 };
 
 } // namespace Ewoms

--- a/ewoms/disc/common/fvbasenewtonmethod.hh
+++ b/ewoms/disc/common/fvbasenewtonmethod.hh
@@ -101,7 +101,7 @@ class FvBaseNewtonMethod : public NewtonMethod<TypeTag>
 
 
 public:
-    FvBaseNewtonMethod(Simulator &simulator)
+    FvBaseNewtonMethod(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -125,10 +125,10 @@ protected:
      *                       equations. This parameter also stores the updated solution.
      * \param currentResidual The residual (i.e., right-hand-side) of the current solution.
      */
-    void update_(SolutionVector &nextSolution,
-                 const SolutionVector &currentSolution,
-                 const GlobalEqVector &solutionUpdate,
-                 const GlobalEqVector &currentResidual)
+    void update_(SolutionVector& nextSolution,
+                 const SolutionVector& currentSolution,
+                 const GlobalEqVector& solutionUpdate,
+                 const GlobalEqVector& currentResidual)
     {
         ParentType::update_(nextSolution, currentSolution, solutionUpdate, currentResidual);
 
@@ -155,20 +155,20 @@ protected:
     /*!
      * \brief Returns a reference to the model.
      */
-    Model &model_()
+    Model& model_()
     { return ParentType::model(); }
 
     /*!
      * \brief Returns a reference to the model.
      */
-    const Model &model_() const
+    const Model& model_() const
     { return ParentType::model(); }
 
 private:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 };
 } // namespace Ewoms

--- a/ewoms/disc/common/fvbaseprimaryvariables.hh
+++ b/ewoms/disc/common/fvbaseprimaryvariables.hh
@@ -28,9 +28,14 @@
 #ifndef EWOMS_FV_BASE_PRIMARY_VARIABLES_HH
 #define EWOMS_FV_BASE_PRIMARY_VARIABLES_HH
 
-#include <dune/common/fvector.hh>
-
 #include "fvbaseproperties.hh"
+
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
+#include <dune/common/fvector.hh>
 
 namespace Ewoms {
 
@@ -67,9 +72,12 @@ public:
     /*!
      * \brief Assignment from another primary variables object
      */
-    FvBasePrimaryVariables(const FvBasePrimaryVariables &value)
-        : ParentType(value)
-    { }
+    FvBasePrimaryVariables(const FvBasePrimaryVariables& value) = default;
+
+    /*!
+     * \brief Assignment from another primary variables object
+     */
+    FvBasePrimaryVariables& operator=(const FvBasePrimaryVariables& value) = default;
 
     /*!
      * \brief Return a primary variable intensive evaluation.
@@ -78,7 +86,7 @@ public:
      * it represents the a constant f = x_i. (the difference is that in the first case,
      * the derivative w.r.t. x_i is 1, while it is 0 in the second case.
      */
-    Evaluation makeEvaluation(int varIdx, int timeIdx) const
+    Evaluation makeEvaluation(unsigned varIdx, unsigned timeIdx) const
     {
         if (timeIdx == 0)
             return Toolbox::createVariable((*this)[varIdx], varIdx);
@@ -97,7 +105,7 @@ public:
      * from the primary variables.)
      */
     template <class FluidState>
-    void assignNaive(const FluidState &fluidState)
+    void assignNaive(const FluidState& OPM_UNUSED fluidState)
     {
         OPM_THROW(std::runtime_error,
                   "The PrimaryVariables class does not define a assignNaive() method");

--- a/ewoms/disc/common/restrictprolong.hh
+++ b/ewoms/disc/common/restrictprolong.hh
@@ -23,6 +23,8 @@
 #ifndef EWOMS_COPYRESTRICTPROLONG_HH
 #define EWOMS_COPYRESTRICTPROLONG_HH
 
+#include <opm/material/common/Unused.hpp>
+
 #if HAVE_DUNE_FEM
 #include <dune/fem/space/common/restrictprolonginterface.hh>
 #endif
@@ -62,13 +64,12 @@ namespace Ewoms
        *  \note If this ratio is set, it is assume to be constant.
        */
       template <class Field>
-      void setFatherChildWeight ( const Field &weight ) const
-      {
-      }
+      void setFatherChildWeight(const Field& OPM_UNUSED weight) const
+      {}
 
       //! restrict data to father
       template< class Entity >
-      void restrictLocal ( const Entity &father, const Entity &son, bool initialize ) const
+      void restrictLocal ( const Entity& father, const Entity& son, bool initialize ) const
       {
         container_.resize();
         assert( container_.codimension() == 0 );
@@ -81,16 +82,17 @@ namespace Ewoms
 
       //! restrict data to father
       template< class Entity, class LocalGeometry >
-      void restrictLocal ( const Entity &father, const Entity &son,
-                           const LocalGeometry &geometryInFather,
-                           bool initialize ) const
-      {
-        restrictLocal( father, son, initialize );
-      }
+      void restrictLocal(const Entity& father,
+                         const Entity& son,
+                         const LocalGeometry& OPM_UNUSED geometryInFather,
+                         bool initialize) const
+      { restrictLocal(father, son, initialize); }
 
       //! prolong data to children
       template< class Entity >
-      void prolongLocal ( const Entity &father, const Entity &son, bool initialize ) const
+      void prolongLocal(const Entity& father,
+                        const Entity& son,
+                        bool OPM_UNUSED initialize) const
       {
         container_.resize();
         assert( container_.codimension() == 0 );
@@ -100,18 +102,17 @@ namespace Ewoms
 
       //! prolong data to children
       template< class Entity, class LocalGeometry >
-      void prolongLocal ( const Entity &father, const Entity &son,
-                          const LocalGeometry &geometryInFather,
-                          bool initialize ) const
-      {
-        prolongLocal( father, son, initialize );
-      }
+      void prolongLocal(const Entity& father,
+                        const Entity& son,
+                        const LocalGeometry& OPM_UNUSED geometryInFather,
+                        bool initialize) const
+      { prolongLocal(father, son, initialize); }
 
       /** \brief add discrete function to communicator
        *  \param[in]  comm  Communicator to add the discrete functions to
        */
       template< class Communicator >
-      void addToList ( Communicator &comm )
+      void addToList(Communicator& OPM_UNUSED comm)
       {
         // TODO
       }
@@ -120,7 +121,7 @@ namespace Ewoms
        *  \param[in]  lb LoadBalancer to add the discrete functions to
        */
       template< class LoadBalancer >
-      void addToLoadBalancer ( LoadBalancer &lb )
+      void addToLoadBalancer(LoadBalancer& OPM_UNUSED lb)
       {
         // TODO
       }
@@ -151,53 +152,52 @@ namespace Ewoms
        *  \note If this ratio is set, it is assume to be constant.
        */
       template <class Field>
-      void setFatherChildWeight ( const Field &weight ) const
-      {
-      }
+      void setFatherChildWeight(const Field& OPM_UNUSED weight) const
+      { }
 
       //! restrict data to father
       template< class Entity >
-      void restrictLocal ( const Entity &father, const Entity &son, bool initialize ) const
-      {
-      }
+      void restrictLocal(const Entity& OPM_UNUSED father,
+                         const Entity& OPM_UNUSED son,
+                         bool OPM_UNUSED initialize) const
+      { }
 
       //! restrict data to father
       template< class Entity, class LocalGeometry >
-      void restrictLocal ( const Entity &father, const Entity &son,
-                           const LocalGeometry &geometryInFather,
-                           bool initialize ) const
-      {
-      }
+      void restrictLocal(const Entity& OPM_UNUSED father,
+                         const Entity& OPM_UNUSED son,
+                         const LocalGeometry& OPM_UNUSED geometryInFather,
+                         bool OPM_UNUSED initialize ) const
+      { }
 
       //! prolong data to children
       template< class Entity >
-      void prolongLocal ( const Entity &father, const Entity &son, bool initialize ) const
-      {
-      }
+      void prolongLocal(const Entity& OPM_UNUSED father,
+                        const Entity& OPM_UNUSED son,
+                        bool OPM_UNUSED initialize) const
+      { }
 
       //! prolong data to children
       template< class Entity, class LocalGeometry >
-      void prolongLocal ( const Entity &father, const Entity &son,
-                          const LocalGeometry &geometryInFather,
-                          bool initialize ) const
-      {
-      }
+      void prolongLocal(const Entity& OPM_UNUSED father,
+                        const Entity& OPM_UNUSED son,
+                        const LocalGeometry& OPM_UNUSED geometryInFather,
+                        bool OPM_UNUSED initialize) const
+      { }
 
       /** \brief add discrete function to communicator
        *  \param[in]  comm  Communicator to add the discrete functions to
        */
       template< class Communicator >
-      void addToList ( Communicator &comm )
-      {
-      }
+      void addToList(Communicator& OPM_UNUSED comm)
+      { }
 
       /** \brief add discrete function to load balancer
        *  \param[in]  lb LoadBalancer to add the discrete functions to
        */
       template< class LoadBalancer >
-      void addToLoadBalancer ( LoadBalancer &lb )
-      {
-      }
+      void addToLoadBalancer(LoadBalancer& OPM_UNUSED lb)
+      { }
     };
 
 } // namespace Ewoms

--- a/ewoms/disc/ecfv/ecfvbaseoutputmodule.hh
+++ b/ewoms/disc/ecfv/ecfvbaseoutputmodule.hh
@@ -52,27 +52,27 @@ public:
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachScalarDofData_(BaseOutputWriter &baseWriter,
-                                     ScalarBuffer &buffer,
-                                     const std::string &name)
+    static void attachScalarDofData_(BaseOutputWriter& baseWriter,
+                                     ScalarBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachScalarElementData(buffer, name.c_str()); }
 
     /*!
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachVectorDofData_(BaseOutputWriter &baseWriter,
-                                     VectorBuffer &buffer,
-                                     const std::string &name)
+    static void attachVectorDofData_(BaseOutputWriter& baseWriter,
+                                     VectorBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachVectorElementData(buffer, name.c_str()); }
 
     /*!
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachTensorDofData_(BaseOutputWriter &baseWriter,
-                                     TensorBuffer &buffer,
-                                     const std::string &name)
+    static void attachTensorDofData_(BaseOutputWriter& baseWriter,
+                                     TensorBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachTensorElementData(buffer, name.c_str()); }
 };
 

--- a/ewoms/disc/ecfv/ecfvdiscretization.hh
+++ b/ewoms/disc/ecfv/ecfvdiscretization.hh
@@ -136,7 +136,7 @@ class EcfvDiscretization : public FvBaseDiscretization<TypeTag>
 
 
 public:
-    EcfvDiscretization(Simulator &simulator)
+    EcfvDiscretization(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -150,13 +150,13 @@ public:
      * \brief Returns the number of global degrees of freedom (DOFs) due to the grid
      */
     size_t numGridDof() const
-    { return this->gridView_.size(/*codim=*/0); }
+    { return static_cast<size_t>(this->gridView_.size(/*codim=*/0)); }
 
     /*!
      * \brief Mapper to convert the Dune entities of the
      *        discretization's degrees of freedoms are to indices.
      */
-    const DofMapper &dofMapper() const
+    const DofMapper& dofMapper() const
     { return this->simulator_.problem().elementMapper(); }
 
     /*!
@@ -191,7 +191,7 @@ public:
      * \param res The serializer object
      */
     template <class Restarter>
-    void serialize(Restarter &res)
+    void serialize(Restarter& res)
     { res.template serializeEntities</*codim=*/0>(asImp_(), this->gridView_); }
 
     /*!
@@ -202,16 +202,16 @@ public:
      * \param res The serializer object
      */
     template <class Restarter>
-    void deserialize(Restarter &res)
+    void deserialize(Restarter& res)
     {
         res.template deserializeEntities</*codim=*/0>(asImp_(), this->gridView_);
         this->solution(/*timeIdx=*/1) = this->solution(/*timeIdx=*/0);
     }
 
 private:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 };
 } // namespace Ewoms

--- a/ewoms/disc/vcfv/p1fegradientcalculator.hh
+++ b/ewoms/disc/vcfv/p1fegradientcalculator.hh
@@ -45,6 +45,12 @@
 
 #include <vector>
 
+#ifdef HAVE_DUNE_LOCALFUNCTIONS
+#define EWOMS_NO_LOCALFUNCTIONS_UNUSED
+#else
+#define EWOMS_NO_LOCALFUNCTIONS_UNUSED OPM_UNUSED
+#endif
+
 namespace Ewoms {
 /*!
  * \ingroup FiniteElementDiscretizations
@@ -89,26 +95,27 @@ public:
      * \param elemCtx The current execution context
      */
     template <bool prepareValues = true, bool prepareGradients = true, class Dummy = unsigned>
-    void prepare(const ElementContext &elemCtx,
+    void prepare(const ElementContext& EWOMS_NO_LOCALFUNCTIONS_UNUSED elemCtx,
                  typename std::enable_if<GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
-                                         Dummy>::type timeIdx)
+                                         Dummy>::type EWOMS_NO_LOCALFUNCTIONS_UNUSED  timeIdx)
     {
 #if !HAVE_DUNE_LOCALFUNCTIONS
         // The dune-localfunctions module is required for P1 finite element gradients
-        assert(false);
+        OPM_THROW(std::logic_error, "The dune-localfunctions module is required in oder to use"
+                  " finite element gradients");
 #else
         static_assert(std::is_same<Dummy, unsigned>::value,
                       "The 'Dummy' template parameter must _not_ be specified explicitly."
                       "It is only required to conditionally disable this method!");
 
-        const auto &stencil = elemCtx.stencil(timeIdx);
+        const auto& stencil = elemCtx.stencil(timeIdx);
 
         const LocalFiniteElement& localFE = feCache_.get(elemCtx.element().type());
         localFiniteElement_ = &localFE;
 
         // loop over all face centeres
         for (unsigned faceIdx = 0; faceIdx < stencil.numInteriorFaces(); ++faceIdx) {
-            const auto &localFacePos = stencil.interiorFace(faceIdx).localPos();
+            const auto& localFacePos = stencil.interiorFace(faceIdx).localPos();
 
             // Evaluate the P1 shape functions and their gradients at all
             // flux approximation points.
@@ -123,11 +130,11 @@ public:
                 // convert to a gradient in global space by
                 // multiplying with the inverse transposed jacobian of
                 // the position
-                const auto &geom = elemCtx.element().geometry();
-                const auto &jacInvT =
+                const auto& geom = elemCtx.element().geometry();
+                const auto& jacInvT =
                     geom.jacobianInverseTransposed(localFacePos);
 
-                unsigned numVertices = elemCtx.numDof(timeIdx);
+                size_t numVertices = elemCtx.numDof(timeIdx);
                 for (unsigned vertIdx = 0; vertIdx < numVertices; vertIdx++) {
                     jacInvT.mv(/*xVector=*/localGradient[vertIdx][0],
                                /*destVector=*/p1Gradient_[faceIdx][vertIdx]);
@@ -138,7 +145,7 @@ public:
     }
 
     template <bool prepareValues = true, bool prepareGradients = true, class Dummy = unsigned>
-    void prepare(const ElementContext &elemCtx,
+    void prepare(const ElementContext& elemCtx,
                  typename std::enable_if<!GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
                                          Dummy>::type timeIdx)
     {
@@ -160,19 +167,19 @@ public:
      *               of the quantity at an index of a degree of
      *               freedom
      */
-    template <class QuantityCallback, class Dummy=int>
-    auto calculateValue(const ElementContext &elemCtx,
+    template <class QuantityCallback, class Dummy=unsigned>
+    auto calculateValue(const ElementContext& EWOMS_NO_LOCALFUNCTIONS_UNUSED elemCtx,
                         typename std::enable_if<GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
-                                                Dummy>::type fapIdx,
-                        const QuantityCallback& quantityCallback) const
+                                                Dummy>::type EWOMS_NO_LOCALFUNCTIONS_UNUSED fapIdx,
+                        const QuantityCallback& EWOMS_NO_LOCALFUNCTIONS_UNUSED quantityCallback) const
         ->  typename std::remove_reference<typename QuantityCallback::ResultType>::type
     {
 #if !HAVE_DUNE_LOCALFUNCTIONS
         // The dune-localfunctions module is required for P1 finite element gradients
-        assert(false);
-        return 0.0;
+        OPM_THROW(std::logic_error, "The dune-localfunctions module is required in oder to use"
+                  " finite element gradients");
 #else
-        static_assert(std::is_same<Dummy, int>::value,
+        static_assert(std::is_same<Dummy, unsigned>::value,
                       "The 'Dummy' template parameter must _not_ be specified explicitly."
                       "It is only required to conditionally disable this method!");
 
@@ -192,14 +199,14 @@ public:
 #endif
     }
 
-    template <class QuantityCallback, class Dummy = int>
-    auto calculateValue(const ElementContext &elemCtx,
+    template <class QuantityCallback, class Dummy = unsigned>
+    auto calculateValue(const ElementContext& elemCtx,
                         typename std::enable_if<!GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
                                                 Dummy>::type fapIdx,
                         const QuantityCallback& quantityCallback) const
         ->  decltype(ParentType::calculateValue(elemCtx, fapIdx, quantityCallback))
     {
-        static_assert(std::is_same<Dummy, int>::value,
+        static_assert(std::is_same<Dummy, unsigned>::value,
                       "The 'Dummy' template parameter must _not_ be specified explicitly."
                       "It is only required to conditionally disable this method!");
 
@@ -217,19 +224,19 @@ public:
      *               of the quantity at an index of a degree of
      *               freedom
      */
-    template <class QuantityCallback, class EvalDimVector, class Dummy = int>
-    void calculateGradient(EvalDimVector &quantityGrad,
-                           const ElementContext &elemCtx,
+    template <class QuantityCallback, class EvalDimVector, class Dummy = unsigned>
+    void calculateGradient(EvalDimVector& EWOMS_NO_LOCALFUNCTIONS_UNUSED quantityGrad,
+                           const ElementContext& EWOMS_NO_LOCALFUNCTIONS_UNUSED elemCtx,
                            typename std::enable_if<GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
-                                                   Dummy>::type fapIdx,
-                           const QuantityCallback& quantityCallback) const
+                                                   Dummy>::type EWOMS_NO_LOCALFUNCTIONS_UNUSED fapIdx,
+                           const QuantityCallback& EWOMS_NO_LOCALFUNCTIONS_UNUSED quantityCallback) const
     {
 #if !HAVE_DUNE_LOCALFUNCTIONS
         // The dune-localfunctions module is required for P1 finite element gradients
-        assert(false);
-        quantityGrad = 0.0;
+        OPM_THROW(std::logic_error, "The dune-localfunctions module is required in oder to use"
+                  " finite element gradients");
 #else
-        static_assert(std::is_same<Dummy, int>::value,
+        static_assert(std::is_same<Dummy, unsigned>::value,
                       "The 'Dummy' template parameter must _not_ be specified explicitly."
                       "It is only required to conditionally disable this method!");
 
@@ -246,14 +253,14 @@ public:
 #endif
     }
 
-    template <class QuantityCallback, class EvalDimVector, class Dummy=int>
-    void calculateGradient(EvalDimVector &quantityGrad,
-                           const ElementContext &elemCtx,
+    template <class QuantityCallback, class EvalDimVector, class Dummy=unsigned>
+    void calculateGradient(EvalDimVector& quantityGrad,
+                           const ElementContext& elemCtx,
                            typename std::enable_if<!GET_PROP_VALUE(TypeTag, UseP1FiniteElementGradients),
                                                    Dummy>::type fapIdx,
                            const QuantityCallback& quantityCallback) const
     {
-        static_assert(std::is_same<Dummy, int>::value,
+        static_assert(std::is_same<Dummy, unsigned>::value,
                       "The 'Dummy' template parameter must _not_ be specified explicitly."
                       "It is only required to conditionally disable this method!");
 
@@ -275,9 +282,9 @@ public:
      *               freedom
      */
     template <class QuantityCallback>
-    auto calculateBoundaryValue(const ElementContext &elemCtx,
+    auto calculateBoundaryValue(const ElementContext& elemCtx,
                                 unsigned fapIdx,
-                                const QuantityCallback &quantityCallback)
+                                const QuantityCallback& quantityCallback)
         ->  decltype(ParentType::calculateBoundaryValue(elemCtx, fapIdx, quantityCallback))
     { return ParentType::calculateBoundaryValue(elemCtx, fapIdx, quantityCallback); }
 
@@ -296,10 +303,10 @@ public:
      *               freedom
      */
     template <class QuantityCallback, class EvalDimVector>
-    void calculateBoundaryGradient(EvalDimVector &quantityGrad,
-                                   const ElementContext &elemCtx,
+    void calculateBoundaryGradient(EvalDimVector& quantityGrad,
+                                   const ElementContext& elemCtx,
                                    unsigned fapIdx,
-                                   const QuantityCallback &quantityCallback) const
+                                   const QuantityCallback& quantityCallback) const
     { ParentType::calculateBoundaryGradient(quantityGrad, elemCtx, fapIdx, quantityCallback); }
 
 #if HAVE_DUNE_LOCALFUNCTIONS
@@ -323,5 +330,7 @@ typename P1FeGradientCalculator<TypeTag>::LocalFiniteElementCache
 P1FeGradientCalculator<TypeTag>::feCache_;
 #endif
 } // namespace Ewoms
+
+#undef EWOMS_NO_LOCALFUNCTIONS_UNUSED
 
 #endif

--- a/ewoms/disc/vcfv/vcfvbaseoutputmodule.hh
+++ b/ewoms/disc/vcfv/vcfvbaseoutputmodule.hh
@@ -55,18 +55,18 @@ public:
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachScalarDofData_(BaseOutputWriter &baseWriter,
-                                     ScalarBuffer &buffer,
-                                     const std::string &name)
+    static void attachScalarDofData_(BaseOutputWriter& baseWriter,
+                                     ScalarBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachScalarVertexData(buffer, name.c_str()); }
 
     /*!
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachVectorDofData_(BaseOutputWriter &baseWriter,
-                                     VectorBuffer &buffer,
-                                     const std::string &name)
+    static void attachVectorDofData_(BaseOutputWriter& baseWriter,
+                                     VectorBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachVectorVertexData(buffer, name.c_str()); }
 
 
@@ -74,9 +74,9 @@ public:
      * \brief Add a buffer where the data is associated with the
      *        degrees of freedom to the current VTK output file.
      */
-    static void attachTensorDofData_(BaseOutputWriter &baseWriter,
-                                     TensorBuffer &buffer,
-                                     const std::string &name)
+    static void attachTensorDofData_(BaseOutputWriter& baseWriter,
+                                     TensorBuffer& buffer,
+                                     const std::string& name)
     { baseWriter.attachTensorVertexData(buffer, name.c_str()); }
 };
 

--- a/ewoms/disc/vcfv/vcfvdiscretization.hh
+++ b/ewoms/disc/vcfv/vcfvdiscretization.hh
@@ -134,7 +134,7 @@ class VcfvDiscretization : public FvBaseDiscretization<TypeTag>
 
 
 public:
-    VcfvDiscretization(Simulator &simulator)
+    VcfvDiscretization(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -148,13 +148,13 @@ public:
      * \brief Returns the number of global degrees of freedom (DOFs) due to the grid
      */
     size_t numGridDof() const
-    { return this->gridView_.size(/*codim=*/dim); }
+    { return static_cast<size_t>(this->gridView_.size(/*codim=*/dim)); }
 
     /*!
      * \brief Mapper to convert the Dune entities of the
      *        discretization's degrees of freedoms are to indices.
      */
-    const DofMapper &dofMapper() const
+    const DofMapper& dofMapper() const
     { return this->simulator_.problem().vertexMapper(); }
 
     /*!
@@ -165,7 +165,7 @@ public:
      * \param res The serializer object
      */
     template <class Restarter>
-    void serialize(Restarter &res)
+    void serialize(Restarter& res)
     { res.template serializeEntities</*codim=*/dim>(asImp_(), this->gridView_); }
 
     /*!
@@ -176,16 +176,16 @@ public:
      * \param res The serializer object
      */
     template <class Restarter>
-    void deserialize(Restarter &res)
+    void deserialize(Restarter& res)
     {
         res.template deserializeEntities</*codim=*/dim>(asImp_(), this->gridView_);
         this->solution(/*timeIdx=*/1) = this->solution(/*timeIdx=*/0);
     }
 
 private:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 };
 } // namespace Ewoms

--- a/ewoms/disc/vcfv/vcfvstencil.hh
+++ b/ewoms/disc/vcfv/vcfvstencil.hh
@@ -30,6 +30,8 @@
 
 #include <ewoms/common/quadraturegeometries.hh>
 
+#include <opm/material/common/Unused.hpp>
+
 #include <opm/common/Exceptions.hpp>
 #include <opm/common/ErrorMacros.hpp>
 
@@ -50,7 +52,7 @@ namespace Ewoms {
 /*!
  * \cond SKIP_THIS
  */
-template <class Scalar, unsigned dim, int basicGeomType>
+template <class Scalar, unsigned dim, unsigned basicGeomType>
 class VcfvScvGeometries;
 
 ////////////////////
@@ -84,7 +86,7 @@ public:
             scvGeoms_[scvIdx].setCorners(scvCorners[scvIdx], ScvLocalGeometry::numCorners);
     }
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
+    static const ScvLocalGeometry& get(unsigned scvIdx)
     { return scvGeoms_[scvIdx]; }
 
 private:
@@ -106,10 +108,11 @@ class VcfvScvGeometries<Scalar, /*dim=*/1, Dune::GeometryType::simplex>
 public:
     typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> ScvLocalGeometry;
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
-    { OPM_THROW(std::logic_error,
-                "Not implemented: "
-                "VcfvScvGeometries<Scalar, 1, Dune::GeometryType::simplex>"); }
+    static const ScvLocalGeometry& get(unsigned OPM_UNUSED scvIdx)
+    {
+        OPM_THROW(std::logic_error,
+                "Not implemented: VcfvScvGeometries<Scalar, 1, Dune::GeometryType::simplex>");
+    }
 };
 
 ////////////////////
@@ -125,7 +128,7 @@ class VcfvScvGeometries<Scalar, /*dim=*/2, Dune::GeometryType::simplex>
 public:
     typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> ScvLocalGeometry;
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
+    static const ScvLocalGeometry& get(unsigned scvIdx)
     { return scvGeoms_[scvIdx]; }
 
     static void init()
@@ -178,7 +181,7 @@ class VcfvScvGeometries<Scalar, /*dim=*/2, Dune::GeometryType::cube>
 public:
     typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> ScvLocalGeometry;
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
+    static const ScvLocalGeometry& get(unsigned scvIdx)
     { return scvGeoms_[scvIdx]; }
 
     static void init()
@@ -240,7 +243,7 @@ class VcfvScvGeometries<Scalar, /*dim=*/3, Dune::GeometryType::simplex>
 public:
     typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> ScvLocalGeometry;
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
+    static const ScvLocalGeometry& get(unsigned scvIdx)
     { return scvGeoms_[scvIdx]; }
 
     static void init()
@@ -320,7 +323,7 @@ class VcfvScvGeometries<Scalar, /*dim=*/3, Dune::GeometryType::cube>
 public:
     typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> ScvLocalGeometry;
 
-    static const ScvLocalGeometry &get(unsigned scvIdx)
+    static const ScvLocalGeometry& get(unsigned scvIdx)
     { return scvGeoms_[scvIdx]; }
 
     static void init()
@@ -474,7 +477,7 @@ class VcfvStencil
 public:
     typedef typename GridView::Traits::template Codim<dim>::Entity          Entity;
 private:
-#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
     typedef typename GridView::Traits::template Codim<0>::EntityPointer     ElementPointer;
     typedef typename GridView::Traits::template Codim<dim>::EntityPointer   EntityPointer;
 #endif
@@ -570,7 +573,7 @@ private:
             + prismVolume(p0,p2,p3,p4,p6,p7);
     }
 
-    void normalOfQuadrilateral3D(DimVector &normal,
+    void normalOfQuadrilateral3D(DimVector& normal,
                                  const GlobalPosition& p0,
                                  const GlobalPosition& p1,
                                  const GlobalPosition& p2,
@@ -702,20 +705,20 @@ private:
 
         switch (numElemVertices) {
         case 4:
-            leftEdge = faceAndVertexToLeftEdgeTet[face][vert];
-            rightEdge = faceAndVertexToRightEdgeTet[face][vert];
+            leftEdge = static_cast<unsigned>(faceAndVertexToLeftEdgeTet[face][vert]);
+            rightEdge = static_cast<unsigned>(faceAndVertexToRightEdgeTet[face][vert]);
             break;
         case 5:
-            leftEdge = faceAndVertexToLeftEdgePyramid[face][vert];
-            rightEdge = faceAndVertexToRightEdgePyramid[face][vert];
+            leftEdge = static_cast<unsigned>(faceAndVertexToLeftEdgePyramid[face][vert]);
+            rightEdge = static_cast<unsigned>(faceAndVertexToRightEdgePyramid[face][vert]);
             break;
         case 6:
-            leftEdge = faceAndVertexToLeftEdgePrism[face][vert];
-            rightEdge = faceAndVertexToRightEdgePrism[face][vert];
+            leftEdge = static_cast<unsigned>(faceAndVertexToLeftEdgePrism[face][vert]);
+            rightEdge = static_cast<unsigned>(faceAndVertexToRightEdgePrism[face][vert]);
             break;
         case 8:
-            leftEdge = faceAndVertexToLeftEdgeHex[face][vert];
-            rightEdge = faceAndVertexToRightEdgeHex[face][vert];
+            leftEdge = static_cast<unsigned>(faceAndVertexToLeftEdgeHex[face][vert]);
+            rightEdge = static_cast<unsigned>(faceAndVertexToRightEdgeHex[face][vert]);
             break;
         default:
             OPM_THROW(std::logic_error,
@@ -740,10 +743,10 @@ public:
         const GlobalPosition corner(unsigned cornerIdx) const
         { return global(localGeometry_->corner(cornerIdx)); }
 
-        const GlobalPosition global(const LocalPosition &localPos) const
+        const GlobalPosition global(const LocalPosition& localPos) const
         { return element_->geometry().global(localPos); }
 
-        const ScvLocalGeometry &localGeometry() const
+        const ScvLocalGeometry& localGeometry() const
         { return *localGeometry_; }
 
         const ScvLocalGeometry *localGeometry_;
@@ -752,7 +755,7 @@ public:
 
     struct SubControlVolume //! finite volume intersected with element
     {
-        const GlobalPosition &globalPos() const
+        const GlobalPosition& globalPos() const
         { return global; }
 
         const GlobalPosition center() const
@@ -761,10 +764,10 @@ public:
         Scalar volume() const
         { return volume_; }
 
-        const ScvLocalGeometry &localGeometry() const
+        const ScvLocalGeometry& localGeometry() const
         { return geometry_.localGeometry(); }
 
-        const ScvGeometry &geometry() const
+        const ScvGeometry& geometry() const
         { return geometry_; }
 
         //! local vertex position
@@ -782,26 +785,26 @@ public:
 
     struct SubControlVolumeFace //! interior face of a sub control volume
     {
-        const DimVector &normal() const
+        const DimVector& normal() const
         { return normal_; }
 
-        unsigned interiorIndex() const
+        unsigned short interiorIndex() const
         { return i; }
 
-        unsigned exteriorIndex() const
+        unsigned short exteriorIndex() const
         { return j; }
 
         Scalar area() const
         { return area_; }
 
-        const LocalPosition &localPos() const
+        const LocalPosition& localPos() const
         { return ipLocal_; }
 
-        const GlobalPosition &integrationPos() const
+        const GlobalPosition& integrationPos() const
         { return ipGlobal_; }
 
         //! scvf seperates corner i and j of elem
-        unsigned i,j;
+        unsigned short i,j;
         //! integration point in local coords
         LocalPosition ipLocal_;
         //! integration point in global coords
@@ -815,10 +818,10 @@ public:
     //! compatibility typedef
     typedef SubControlVolumeFace BoundaryFace;
 
-    VcfvStencil(const GridView &gridView, const VertexMapper& vertexMapper)
+    VcfvStencil(const GridView& gridView, const VertexMapper& vertexMapper)
         : gridView_(gridView)
         , vertexMapper_( vertexMapper )
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         , element_(*gridView.template begin</*codim=*/0>())
 #else
         , elementPtr_(gridView.template begin</*codim=*/0>())
@@ -843,7 +846,7 @@ public:
      */
     void updateTopology(const Element& e)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         element_ = e;
 
         numVertices = e.subEntities(/*codim=*/dim);
@@ -865,12 +868,12 @@ public:
         const typename Dune::ReferenceElementContainer<CoordScalar,dim>::value_type&
             referenceElement = Dune::ReferenceElements<CoordScalar,dim>::general(geometryType_);
         for (unsigned vertexIdx = 0; vertexIdx < numVertices; vertexIdx++) {
-            subContVol[vertexIdx].local = referenceElement.position(vertexIdx, dim);
-            subContVol[vertexIdx].global = geometry.corner(vertexIdx);
+            subContVol[vertexIdx].local = referenceElement.position(static_cast<int>(vertexIdx), dim);
+            subContVol[vertexIdx].global = geometry.corner(static_cast<int>(vertexIdx));
         }
     }
 
-    void updatePrimaryTopology(const Element &element)
+    void updatePrimaryTopology(const Element& element)
     {
         // since all degrees of freedom in a stencil are "primary" DOFs for the
         // vertex-centered finite volume method, there's no difference to
@@ -894,18 +897,18 @@ public:
 
         // corners:
         for (unsigned vert = 0; vert < numVertices; vert++) {
-            subContVol[vert].local = referenceElement.position(vert, dim);
+            subContVol[vert].local = referenceElement.position(static_cast<int>(vert), dim);
             subContVol[vert].global = geometry.global(subContVol[vert].local);
         }
 
         // edges:
         for (unsigned edge = 0; edge < numEdges; edge++) {
-            edgeCoord[edge] = geometry.global(referenceElement.position(edge, dim-1));
+            edgeCoord[edge] = geometry.global(referenceElement.position(static_cast<int>(edge), dim-1));
         }
 
         // faces:
         for (unsigned face = 0; face < numFaces; face++) {
-            faceCoord[face] = geometry.global(referenceElement.position(face, 1));
+            faceCoord[face] = geometry.global(referenceElement.position(static_cast<int>(face), 1));
         }
 
         // fill sub control volume data use specialization for this
@@ -917,8 +920,8 @@ public:
 
         // fill sub control volume face data:
         for (unsigned k = 0; k < numEdges; k++) { // begin loop over edges / sub control volume faces
-            unsigned i = referenceElement.subEntity(k, dim-1, 0, dim);
-            unsigned j = referenceElement.subEntity(k, dim-1, 1, dim);
+            unsigned short i = static_cast<unsigned short>(referenceElement.subEntity(static_cast<int>(k), dim-1, 0, dim));
+            unsigned short j = static_cast<unsigned short>(referenceElement.subEntity(static_cast<int>(k), dim-1, 1, dim));
             if (numEdges == 4 && (i == 2 || j == 2))
                 std::swap(i, j);
             subContVolFace[k].i = i;
@@ -938,7 +941,7 @@ public:
                 ipLocal_ = subContVolFace[k].ipLocal_;
             }
             else if (dim==2) {
-                ipLocal_ = referenceElement.position(k, dim-1) + elementLocal;
+                ipLocal_ = referenceElement.position(static_cast<int>(k), dim-1) + elementLocal;
                 ipLocal_ *= 0.5;
                 subContVolFace[k].ipLocal_ = ipLocal_;
                 for (unsigned m = 0; m < dimWorld; ++m)
@@ -959,9 +962,9 @@ public:
                 unsigned leftFace;
                 unsigned rightFace;
                 getFaceIndices(numVertices, k, leftFace, rightFace);
-                ipLocal_ = referenceElement.position(k, dim-1) + elementLocal
-                    + referenceElement.position(leftFace, 1)
-                    + referenceElement.position(rightFace, 1);
+                ipLocal_ = referenceElement.position(static_cast<int>(k), dim-1) + elementLocal
+                    + referenceElement.position(static_cast<int>(leftFace), 1)
+                    + referenceElement.position(static_cast<int>(rightFace), 1);
                 ipLocal_ *= 0.25;
                 subContVolFace[k].ipLocal_ = ipLocal_;
                 normalOfQuadrilateral3D(subContVolFace[k].normal_,
@@ -983,21 +986,21 @@ public:
             if ( ! intersection.boundary())
                 continue;
 
-            unsigned face = intersection.indexInInside();
-            unsigned numVerticesOfFace = referenceElement.size(face, 1, dim);
+            unsigned face = static_cast<unsigned>(intersection.indexInInside());
+            unsigned numVerticesOfFace = static_cast<unsigned>(referenceElement.size(static_cast<int>(face), 1, dim));
             for (unsigned vertInFace = 0; vertInFace < numVerticesOfFace; vertInFace++)
             {
-                unsigned vertInElement = referenceElement.subEntity(face, 1, vertInFace, dim);
+                unsigned short vertInElement = static_cast<unsigned short>(referenceElement.subEntity(static_cast<int>(face), 1, static_cast<int>(vertInFace), dim));
                 unsigned bfIdx = numBoundarySegments_;
                 ++numBoundarySegments_;
 
                 if (dim == 1) {
-                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(vertInElement, dim);
+                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(static_cast<int>(vertInElement), dim);
                     boundaryFace_[bfIdx].area_ = 1.0;
                 }
                 else if (dim == 2) {
-                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(vertInElement, dim)
-                        + referenceElement.position(face, 1);
+                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(static_cast<int>(vertInElement), dim)
+                        + referenceElement.position(static_cast<int>(face), 1);
                     boundaryFace_[bfIdx].ipLocal_ *= 0.5;
                     boundaryFace_[bfIdx].area_ = 0.5 * intersection.geometry().volume();
                 }
@@ -1005,10 +1008,10 @@ public:
                     unsigned leftEdge;
                     unsigned rightEdge;
                     getEdgeIndices(numVertices, face, vertInElement, leftEdge, rightEdge);
-                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(vertInElement, dim)
-                        + referenceElement.position(face, 1)
-                        + referenceElement.position(leftEdge, dim-1)
-                        + referenceElement.position(rightEdge, dim-1);
+                    boundaryFace_[bfIdx].ipLocal_ = referenceElement.position(static_cast<int>(vertInElement), dim)
+                        + referenceElement.position(static_cast<int>(face), 1)
+                        + referenceElement.position(static_cast<int>(leftEdge), dim-1)
+                        + referenceElement.position(static_cast<int>(rightEdge), dim-1);
                     boundaryFace_[bfIdx].ipLocal_ *= 0.25;
                     boundaryFace_[bfIdx].area_ =
                         quadrilateralArea3D(subContVol[vertInElement].global,
@@ -1031,7 +1034,7 @@ public:
         updateScvGeometry(e);
     }
 
-    void updateScvGeometry(const Element &element)
+    void updateScvGeometry(const Element& element)
     {
         auto geomType = element.geometry().type();
 
@@ -1058,20 +1061,20 @@ public:
 #if HAVE_DUNE_LOCALFUNCTIONS
     void updateCenterGradients()
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        const auto &localFiniteElement = feCache_.get(element_.type());
-        const auto &geom = element_.geometry();
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+        const auto& localFiniteElement = feCache_.get(element_.type());
+        const auto& geom = element_.geometry();
 #else
-        const auto &localFiniteElement = feCache_.get(elementPtr_->type());
-        const auto &geom = elementPtr_->geometry();
+        const auto& localFiniteElement = feCache_.get(elementPtr_->type());
+        const auto& geom = elementPtr_->geometry();
 #endif
 
         std::vector<ShapeJacobian> localJac;
 
         for (unsigned scvIdx = 0; scvIdx < numVertices; ++ scvIdx) {
-            const auto &localCenter = subContVol[scvIdx].localGeometry().center();
+            const auto& localCenter = subContVol[scvIdx].localGeometry().center();
             localFiniteElement.localBasis().evaluateJacobian(localCenter, localJac);
-            const auto &globalPos = subContVol[scvIdx].geometry().center();
+            const auto& globalPos = subContVol[scvIdx].geometry().center();
 
             const auto jacInvT = geom.jacobianInverseTransposed(globalPos);
             for (unsigned vert = 0; vert < numVertices; vert++) {
@@ -1088,13 +1091,13 @@ public:
     { return numDof(); }
 
     Dune::PartitionType partitionType(unsigned scvIdx) const
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
     { return element_.template subEntity</*codim=*/dim>(scvIdx)->partitionType(); }
 #else
     { return elementPtr_->template subEntity</*codim=*/dim>(scvIdx)->partitionType(); }
 #endif
 
-    const SubControlVolume &subControlVolume(unsigned scvIdx) const
+    const SubControlVolume& subControlVolume(unsigned scvIdx) const
     {
         assert(0 <= scvIdx && scvIdx < numDof());
         return subContVol[scvIdx];
@@ -1106,10 +1109,10 @@ public:
     unsigned numBoundaryFaces() const
     { return numBoundarySegments_; }
 
-    const SubControlVolumeFace &interiorFace(unsigned faceIdx) const
+    const SubControlVolumeFace& interiorFace(unsigned faceIdx) const
     { return subContVolFace[faceIdx]; }
 
-    const BoundaryFace &boundaryFace(unsigned bfIdx) const
+    const BoundaryFace& boundaryFace(unsigned bfIdx) const
     { return boundaryFace_[bfIdx]; }
 
     /*!
@@ -1120,10 +1123,10 @@ public:
     {
         assert(0 <= dofIdx && dofIdx < numDof());
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        return vertexMapper_.subIndex(element_, dofIdx, /*codim=*/dim);
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+        return static_cast<unsigned>(vertexMapper_.subIndex(element_, static_cast<int>(dofIdx), /*codim=*/dim));
 #else
-        return vertexMapper_.map(*elementPtr_, dofIdx, /*codim=*/dim);
+        return static_cast<unsigned>(vertexMapper_.map(*elementPtr_, static_cast<int>(dofIdx), /*codim=*/dim));
 #endif
     }
 
@@ -1131,7 +1134,7 @@ public:
      * \brief Return the global space index given the index of a degree of
      *        freedom.
      */
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
     Entity
 #else
     EntityPointer
@@ -1139,14 +1142,19 @@ public:
     entity(unsigned dofIdx) const
     {
         assert(0 <= dofIdx && dofIdx < numDof());
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        return element_.template subEntity< dim > ( dofIdx );
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+        return element_.template subEntity<dim>(static_cast<int>(dofIdx));
 #else
-        return (*elementPtr_).template subEntity< dim > ( dofIdx );
+        return elementPtr_->template subEntity<dim>(static_cast<int>(dofIdx));
 #endif
     }
 
 private:
+#if __GNUC__ || __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     void fillSubContVolData_()
     {
         if (dim == 1) {
@@ -1196,38 +1204,42 @@ private:
                     subContVol[k].volume_ = elementVolume / 4.0;
                 break;
             case 5: // 3D, pyramid
-                subContVol[0].volume_ = hexahedronVolume(subContVol[0].global,
-                                                        edgeCoord[2],
-                                                        faceCoord[0],
-                                                        edgeCoord[0],
-                                                        edgeCoord[4],
-                                                        faceCoord[3],
-                                                        elementGlobal,
-                                                        faceCoord[1]);
-                subContVol[1].volume_ = hexahedronVolume(subContVol[1].global,
-                                                        edgeCoord[1],
-                                                        faceCoord[0],
-                                                        edgeCoord[2],
-                                                        edgeCoord[5],
-                                                        faceCoord[2],
-                                                        elementGlobal,
-                                                        faceCoord[3]);
-                subContVol[2].volume_ = hexahedronVolume(subContVol[2].global,
-                                                        edgeCoord[0],
-                                                        faceCoord[0],
-                                                        edgeCoord[3],
-                                                        edgeCoord[6],
-                                                        faceCoord[1],
-                                                        elementGlobal,
-                                                        faceCoord[4]);
-                subContVol[3].volume_ = hexahedronVolume(subContVol[3].global,
-                                                        edgeCoord[3],
-                                                        faceCoord[0],
-                                                        edgeCoord[1],
-                                                        edgeCoord[7],
-                                                        faceCoord[4],
-                                                        elementGlobal,
-                                                        faceCoord[2]);
+                subContVol[0].volume_ =
+                    hexahedronVolume(subContVol[0].global,
+                                     edgeCoord[2],
+                                     faceCoord[0],
+                                     edgeCoord[0],
+                                     edgeCoord[4],
+                                     faceCoord[3],
+                                     elementGlobal,
+                                     faceCoord[1]);
+                subContVol[1].volume_ =
+                    hexahedronVolume(subContVol[1].global,
+                                     edgeCoord[1],
+                                     faceCoord[0],
+                                     edgeCoord[2],
+                                     edgeCoord[5],
+                                     faceCoord[2],
+                                     elementGlobal,
+                                     faceCoord[3]);
+                subContVol[2].volume_ =
+                    hexahedronVolume(subContVol[2].global,
+                                     edgeCoord[0],
+                                     faceCoord[0],
+                                     edgeCoord[3],
+                                     edgeCoord[6],
+                                     faceCoord[1],
+                                     elementGlobal,
+                                     faceCoord[4]);
+                subContVol[3].volume_ =
+                    hexahedronVolume(subContVol[3].global,
+                                     edgeCoord[3],
+                                     faceCoord[0],
+                                     edgeCoord[1],
+                                     edgeCoord[7],
+                                     faceCoord[4],
+                                     elementGlobal,
+                                     faceCoord[2]);
                 subContVol[4].volume_ = elementVolume -
                     subContVol[0].volume_ -
                     subContVol[1].volume_ -
@@ -1235,120 +1247,134 @@ private:
                     subContVol[3].volume_;
                 break;
             case 6: // 3D, prism
-                subContVol[0].volume_ = hexahedronVolume(subContVol[0].global,
-                                                        edgeCoord[3],
-                                                        faceCoord[3],
-                                                        edgeCoord[4],
-                                                        edgeCoord[0],
-                                                        faceCoord[0],
-                                                        elementGlobal,
-                                                        faceCoord[1]);
-                subContVol[1].volume_ = hexahedronVolume(subContVol[1].global,
-                                                        edgeCoord[5],
-                                                        faceCoord[3],
-                                                        edgeCoord[3],
-                                                        edgeCoord[1],
-                                                        faceCoord[2],
-                                                        elementGlobal,
-                                                        faceCoord[0]);
-                subContVol[2].volume_ = hexahedronVolume(subContVol[2].global,
-                                                        edgeCoord[4],
-                                                        faceCoord[3],
-                                                        edgeCoord[5],
-                                                        edgeCoord[2],
-                                                        faceCoord[1],
-                                                        elementGlobal,
-                                                        faceCoord[2]);
-                subContVol[3].volume_ = hexahedronVolume(edgeCoord[0],
-                                                        faceCoord[0],
-                                                        elementGlobal,
-                                                        faceCoord[1],
-                                                        subContVol[3].global,
-                                                        edgeCoord[6],
-                                                        faceCoord[4],
-                                                        edgeCoord[7]);
-                subContVol[4].volume_ = hexahedronVolume(edgeCoord[1],
-                                                        faceCoord[2],
-                                                        elementGlobal,
-                                                        faceCoord[0],
-                                                        subContVol[4].global,
-                                                        edgeCoord[8],
-                                                        faceCoord[4],
-                                                        edgeCoord[6]);
-                subContVol[5].volume_ = hexahedronVolume(edgeCoord[2],
-                                                        faceCoord[1],
-                                                        elementGlobal,
-                                                        faceCoord[2],
-                                                        subContVol[5].global,
-                                                        edgeCoord[7],
-                                                        faceCoord[4],
-                                                        edgeCoord[8]);
+                subContVol[0].volume_ =
+                    hexahedronVolume(subContVol[0].global,
+                                     edgeCoord[3],
+                                     faceCoord[3],
+                                     edgeCoord[4],
+                                     edgeCoord[0],
+                                     faceCoord[0],
+                                     elementGlobal,
+                                     faceCoord[1]);
+                subContVol[1].volume_ =
+                    hexahedronVolume(subContVol[1].global,
+                                     edgeCoord[5],
+                                     faceCoord[3],
+                                     edgeCoord[3],
+                                     edgeCoord[1],
+                                     faceCoord[2],
+                                     elementGlobal,
+                                     faceCoord[0]);
+                subContVol[2].volume_ =
+                    hexahedronVolume(subContVol[2].global,
+                                     edgeCoord[4],
+                                     faceCoord[3],
+                                     edgeCoord[5],
+                                     edgeCoord[2],
+                                     faceCoord[1],
+                                     elementGlobal,
+                                     faceCoord[2]);
+                subContVol[3].volume_ =
+                    hexahedronVolume(edgeCoord[0],
+                                     faceCoord[0],
+                                     elementGlobal,
+                                     faceCoord[1],
+                                     subContVol[3].global,
+                                     edgeCoord[6],
+                                     faceCoord[4],
+                                     edgeCoord[7]);
+                subContVol[4].volume_ =
+                    hexahedronVolume(edgeCoord[1],
+                                     faceCoord[2],
+                                     elementGlobal,
+                                     faceCoord[0],
+                                     subContVol[4].global,
+                                     edgeCoord[8],
+                                     faceCoord[4],
+                                     edgeCoord[6]);
+                subContVol[5].volume_ =
+                    hexahedronVolume(edgeCoord[2],
+                                     faceCoord[1],
+                                     elementGlobal,
+                                     faceCoord[2],
+                                     subContVol[5].global,
+                                     edgeCoord[7],
+                                     faceCoord[4],
+                                     edgeCoord[8]);
                 break;
             case 8: // 3D, hexahedron
-                subContVol[0].volume_ = hexahedronVolume(subContVol[0].global,
-                                                        edgeCoord[6],
-                                                        faceCoord[4],
-                                                        edgeCoord[4],
-                                                        edgeCoord[0],
-                                                        faceCoord[2],
-                                                        elementGlobal,
-                                                        faceCoord[0]);
-                subContVol[1].volume_ = hexahedronVolume(subContVol[1].global,
-                                                        edgeCoord[5],
-                                                        faceCoord[4],
-                                                        edgeCoord[6],
-                                                        edgeCoord[1],
-                                                        faceCoord[1],
-                                                        elementGlobal,
-                                                        faceCoord[2]);
-                subContVol[2].volume_ = hexahedronVolume(subContVol[2].global,
-                                                        edgeCoord[4],
-                                                        faceCoord[4],
-                                                        edgeCoord[7],
-                                                        edgeCoord[2],
-                                                        faceCoord[0],
-                                                        elementGlobal,
-                                                        faceCoord[3]);
-                subContVol[3].volume_ = hexahedronVolume(subContVol[3].global,
-                                                        edgeCoord[7],
-                                                        faceCoord[4],
-                                                        edgeCoord[5],
-                                                        edgeCoord[3],
-                                                        faceCoord[3],
-                                                        elementGlobal,
-                                                        faceCoord[1]);
-                subContVol[4].volume_ = hexahedronVolume(edgeCoord[0],
-                                                        faceCoord[2],
-                                                        elementGlobal,
-                                                        faceCoord[0],
-                                                        subContVol[4].global,
-                                                        edgeCoord[10],
-                                                        faceCoord[5],
-                                                        edgeCoord[8]);
-                subContVol[5].volume_ = hexahedronVolume(edgeCoord[1],
-                                                        faceCoord[1],
-                                                        elementGlobal,
-                                                        faceCoord[2],
-                                                        subContVol[5].global,
-                                                        edgeCoord[9],
-                                                        faceCoord[5],
-                                                        edgeCoord[10]);
-                subContVol[6].volume_ = hexahedronVolume(edgeCoord[2],
-                                                        faceCoord[0],
-                                                        elementGlobal,
-                                                        faceCoord[3],
-                                                        subContVol[6].global,
-                                                        edgeCoord[8],
-                                                        faceCoord[5],
-                                                        edgeCoord[11]);
-                subContVol[7].volume_ = hexahedronVolume(edgeCoord[3],
-                                                        faceCoord[3],
-                                                        elementGlobal,
-                                                        faceCoord[1],
-                                                        subContVol[7].global,
-                                                        edgeCoord[11],
-                                                        faceCoord[5],
-                                                        edgeCoord[9]);
+                subContVol[0].volume_ =
+                    hexahedronVolume(subContVol[0].global,
+                                     edgeCoord[6],
+                                     faceCoord[4],
+                                     edgeCoord[4],
+                                     edgeCoord[0],
+                                     faceCoord[2],
+                                     elementGlobal,
+                                     faceCoord[0]);
+                subContVol[1].volume_ =
+                    hexahedronVolume(subContVol[1].global,
+                                     edgeCoord[5],
+                                     faceCoord[4],
+                                     edgeCoord[6],
+                                     edgeCoord[1],
+                                     faceCoord[1],
+                                     elementGlobal,
+                                     faceCoord[2]);
+                subContVol[2].volume_ =
+                    hexahedronVolume(subContVol[2].global,
+                                     edgeCoord[4],
+                                     faceCoord[4],
+                                     edgeCoord[7],
+                                     edgeCoord[2],
+                                     faceCoord[0],
+                                     elementGlobal,
+                                     faceCoord[3]);
+                subContVol[3].volume_ =
+                    hexahedronVolume(subContVol[3].global,
+                                     edgeCoord[7],
+                                     faceCoord[4],
+                                     edgeCoord[5],
+                                     edgeCoord[3],
+                                     faceCoord[3],
+                                     elementGlobal,
+                                     faceCoord[1]);
+                subContVol[4].volume_ =
+                    hexahedronVolume(edgeCoord[0],
+                                     faceCoord[2],
+                                     elementGlobal,
+                                     faceCoord[0],
+                                     subContVol[4].global,
+                                     edgeCoord[10],
+                                     faceCoord[5],
+                                     edgeCoord[8]);
+                subContVol[5].volume_ =
+                    hexahedronVolume(edgeCoord[1],
+                                     faceCoord[1],
+                                     elementGlobal,
+                                     faceCoord[2],
+                                     subContVol[5].global,
+                                     edgeCoord[9],
+                                     faceCoord[5],
+                                     edgeCoord[10]);
+                subContVol[6].volume_ =
+                    hexahedronVolume(edgeCoord[2],
+                                     faceCoord[0],
+                                     elementGlobal,
+                                     faceCoord[3],
+                                     subContVol[6].global,
+                                     edgeCoord[8],
+                                     faceCoord[5],
+                                     edgeCoord[11]);
+                subContVol[7].volume_ =
+                    hexahedronVolume(edgeCoord[3],
+                                     faceCoord[3],
+                                     elementGlobal,
+                                     faceCoord[1],
+                                     subContVol[7].global,
+                                     edgeCoord[11],
+                                     faceCoord[5],
+                                     edgeCoord[9]);
                 break;
             default:
                 OPM_THROW(std::logic_error,
@@ -1359,11 +1385,14 @@ private:
         else
             OPM_THROW(std::logic_error, "Not implemented:VcfvStencil for dim = " << dim);
     }
+#if __GNUC__ || __clang__
+#pragma GCC diagnostic pop
+#endif
 
     const GridView&     gridView_;
     const VertexMapper& vertexMapper_;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
     Element element_;
 #else
     ElementPointer elementPtr_;

--- a/ewoms/io/basegridmanager.hh
+++ b/ewoms/io/basegridmanager.hh
@@ -67,33 +67,33 @@ class BaseGridManager
 #endif
 
 public:
-    BaseGridManager(Simulator &simulator)
+    BaseGridManager(Simulator& simulator)
         : simulator_(simulator)
     {}
 
     /*!
      * \brief Returns a reference to the grid view to be used.
      */
-    GridView &gridView()
+    GridView& gridView()
     { return *gridView_; }
 
     /*!
      * \brief Returns a reference to the grid view to be used.
      */
-    const GridView &gridView() const
+    const GridView& gridView() const
     { return *gridView_; }
 
 #if HAVE_DUNE_FEM
     /*!
      * \brief Returns a reference to the grid part to be used.
      */
-    const GridPart &gridPart() const
+    const GridPart& gridPart() const
     { return *gridPart_; }
 
     /*!
      * \brief Returns a reference to the grid part to be used.
      */
-    GridPart &gridPart()
+    GridPart& gridPart()
     { return *gridPart_; }
 #endif
 
@@ -134,13 +134,13 @@ protected:
     }
 
 private:
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-    Simulator &simulator_;
+    Simulator& simulator_;
     std::unique_ptr<GridView> gridView_;
 #if HAVE_DUNE_FEM
     std::unique_ptr<GridPart> gridPart_;

--- a/ewoms/io/baseoutputmodule.hh
+++ b/ewoms/io/baseoutputmodule.hh
@@ -32,7 +32,9 @@
 #include <ewoms/common/parametersystem.hh>
 
 #include <ewoms/common/propertysystem.hh>
+
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/istl/bvector.hh>
 #include <dune/common/fvector.hh>
@@ -43,7 +45,6 @@
 #include <array>
 
 #include <cstdio>
-
 
 namespace Ewoms {
 namespace Properties {
@@ -61,6 +62,12 @@ NEW_PROP_TAG(ElementContext);
 NEW_PROP_TAG(FluidSystem);
 NEW_PROP_TAG(DiscBaseOutputModule);
 } // namespace Properties
+
+#if __GNUC__ || __clang__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#endif
 
 /*!
  * \brief The base class for writer modules.
@@ -100,7 +107,7 @@ public:
 
     typedef std::array<VectorBuffer, numPhases> PhaseVectorBuffer;
 
-    BaseOutputModule(const Simulator &simulator)
+    BaseOutputModule(const Simulator& simulator)
         : simulator_(simulator)
     {}
 
@@ -125,12 +132,12 @@ public:
      * concrete class. If the writer is incompatible with the module,
      * this method should become a no-op.
      */
-    virtual void processElement(const ElementContext &elemCtx) = 0;
+    virtual void processElement(const ElementContext& elemCtx) = 0;
 
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    virtual void commitBuffers(BaseOutputWriter &writer) = 0;
+    virtual void commitBuffers(BaseOutputWriter& writer) = 0;
 
     /*!
      * \brief Returns true iff the module needs to access the extensive quantities of a
@@ -160,14 +167,14 @@ protected:
     /*!
      * \brief Allocate the space for a buffer storing a scalar quantity
      */
-    void resizeScalarBuffer_(ScalarBuffer &buffer,
+    void resizeScalarBuffer_(ScalarBuffer& buffer,
                              BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
@@ -180,14 +187,14 @@ protected:
     /*!
      * \brief Allocate the space for a buffer storing a tensorial quantity
      */
-    void resizeTensorBuffer_(TensorBuffer &buffer,
+    void resizeTensorBuffer_(TensorBuffer& buffer,
                              BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
@@ -202,20 +209,20 @@ protected:
      * \brief Allocate the space for a buffer storing a equation specific
      *        quantity
      */
-    void resizeEqBuffer_(EqBuffer &buffer,
+    void resizeEqBuffer_(EqBuffer& buffer,
                          BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
             OPM_THROW(std::logic_error, "bufferType must be one of Dof, Vertex or Element");
 
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             buffer[i].resize(n);
             std::fill(buffer[i].begin(), buffer[i].end(), 0.0);
         }
@@ -225,20 +232,20 @@ protected:
      * \brief Allocate the space for a buffer storing a phase-specific
      *        quantity
      */
-    void resizePhaseBuffer_(PhaseBuffer &buffer,
+    void resizePhaseBuffer_(PhaseBuffer& buffer,
                             BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
             OPM_THROW(std::logic_error, "bufferType must be one of Dof, Vertex or Element");
 
-        for (int i = 0; i < numPhases; ++i) {
+        for (unsigned i = 0; i < numPhases; ++i) {
             buffer[i].resize(n);
             std::fill(buffer[i].begin(), buffer[i].end(), 0.0);
         }
@@ -248,20 +255,20 @@ protected:
      * \brief Allocate the space for a buffer storing a component
      *        specific quantity
      */
-    void resizeComponentBuffer_(ComponentBuffer &buffer,
+    void resizeComponentBuffer_(ComponentBuffer& buffer,
                                 BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
             OPM_THROW(std::logic_error, "bufferType must be one of Dof, Vertex or Element");
 
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             buffer[i].resize(n);
             std::fill(buffer[i].begin(), buffer[i].end(), 0.0);
         }
@@ -271,21 +278,21 @@ protected:
      * \brief Allocate the space for a buffer storing a phase and
      *        component specific buffer
      */
-    void resizePhaseComponentBuffer_(PhaseComponentBuffer &buffer,
+    void resizePhaseComponentBuffer_(PhaseComponentBuffer& buffer,
                                      BufferType bufferType = DofBuffer)
     {
-        Scalar n;
+        size_t n;
         if (bufferType == VertexBuffer)
-            n = simulator_.gridView().size(dim);
+            n = static_cast<size_t>(simulator_.gridView().size(dim));
         else if (bufferType == ElementBuffer)
-            n = simulator_.gridView().size(0);
+            n = static_cast<size_t>(simulator_.gridView().size(0));
         else if (bufferType == DofBuffer)
             n = simulator_.model().numGridDof();
         else
             OPM_THROW(std::logic_error, "bufferType must be one of Dof, Vertex or Element");
 
-        for (int i = 0; i < numPhases; ++i) {
-            for (int j = 0; j < numComponents; ++j) {
+        for (unsigned i = 0; i < numPhases; ++i) {
+            for (unsigned j = 0; j < numComponents; ++j) {
                 buffer[i][j].resize(n);
                 std::fill(buffer[i][j].begin(), buffer[i][j].end(), 0.0);
             }
@@ -295,9 +302,9 @@ protected:
     /*!
      * \brief Add a buffer containing scalar quantities to the result file.
      */
-    void commitScalarBuffer_(BaseOutputWriter &baseWriter,
+    void commitScalarBuffer_(BaseOutputWriter& baseWriter,
                              const char *name,
-                             ScalarBuffer &buffer,
+                             ScalarBuffer& buffer,
                              BufferType bufferType = DofBuffer)
     {
         if (bufferType == DofBuffer)
@@ -313,9 +320,9 @@ protected:
     /*!
      * \brief Add a buffer containing vectorial quantities to the result file.
      */
-    void commitVectorBuffer_(BaseOutputWriter &baseWriter,
+    void commitVectorBuffer_(BaseOutputWriter& baseWriter,
                              const char *name,
-                             VectorBuffer &buffer,
+                             VectorBuffer& buffer,
                              BufferType bufferType = DofBuffer)
     {
         if (bufferType == DofBuffer)
@@ -331,9 +338,9 @@ protected:
     /*!
      * \brief Add a buffer containing tensorial quantities to the result file.
      */
-    void commitTensorBuffer_(BaseOutputWriter &baseWriter,
+    void commitTensorBuffer_(BaseOutputWriter& baseWriter,
                              const char *name,
-                             TensorBuffer &buffer,
+                             TensorBuffer& buffer,
                              BufferType bufferType = DofBuffer)
     {
         if (bufferType == DofBuffer)
@@ -349,13 +356,13 @@ protected:
     /*!
      * \brief Add a buffer with as many variables as PDEs to the result file.
      */
-    void commitPriVarsBuffer_(BaseOutputWriter &baseWriter,
+    void commitPriVarsBuffer_(BaseOutputWriter& baseWriter,
                               const char *pattern,
-                              EqBuffer &buffer,
+                              EqBuffer& buffer,
                               BufferType bufferType = DofBuffer)
     {
         char name[512];
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             std::string eqName = simulator_.model().primaryVarName(i);
             snprintf(name, 512, pattern, eqName.c_str());
 
@@ -373,13 +380,13 @@ protected:
     /*!
      * \brief Add a buffer with as many variables as PDEs to the result file.
      */
-    void commitEqBuffer_(BaseOutputWriter &baseWriter,
+    void commitEqBuffer_(BaseOutputWriter& baseWriter,
                          const char *pattern,
-                         EqBuffer &buffer,
+                         EqBuffer& buffer,
                          BufferType bufferType = DofBuffer)
     {
         char name[512];
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             std::ostringstream oss;
             oss << i;
             snprintf(name, 512, pattern, oss.str().c_str());
@@ -398,13 +405,13 @@ protected:
     /*!
      * \brief Add a phase-specific buffer to the result file.
      */
-    void commitPhaseBuffer_(BaseOutputWriter &baseWriter,
+    void commitPhaseBuffer_(BaseOutputWriter& baseWriter,
                             const char *pattern,
-                            PhaseBuffer &buffer,
+                            PhaseBuffer& buffer,
                             BufferType bufferType = DofBuffer)
     {
         char name[512];
-        for (int i = 0; i < numPhases; ++i) {
+        for (unsigned i = 0; i < numPhases; ++i) {
             snprintf(name, 512, pattern, FluidSystem::phaseName(i));
 
             if (bufferType == DofBuffer)
@@ -421,13 +428,13 @@ protected:
     /*!
      * \brief Add a component-specific buffer to the result file.
      */
-    void commitComponentBuffer_(BaseOutputWriter &baseWriter,
+    void commitComponentBuffer_(BaseOutputWriter& baseWriter,
                                 const char *pattern,
-                                ComponentBuffer &buffer,
+                                ComponentBuffer& buffer,
                                 BufferType bufferType = DofBuffer)
     {
         char name[512];
-        for (int i = 0; i < numComponents; ++i) {
+        for (unsigned i = 0; i < numComponents; ++i) {
             snprintf(name, 512, pattern, FluidSystem::componentName(i));
 
             if (bufferType == DofBuffer)
@@ -444,14 +451,14 @@ protected:
     /*!
      * \brief Add a phase and component specific quantities to the output.
      */
-    void commitPhaseComponentBuffer_(BaseOutputWriter &baseWriter,
+    void commitPhaseComponentBuffer_(BaseOutputWriter& baseWriter,
                                      const char *pattern,
-                                     PhaseComponentBuffer &buffer,
+                                     PhaseComponentBuffer& buffer,
                                      BufferType bufferType = DofBuffer)
     {
         char name[512];
-        for (int i= 0; i < numPhases; ++i) {
-            for (int j = 0; j < numComponents; ++j) {
+        for (unsigned i= 0; i < numPhases; ++i) {
+            for (unsigned j = 0; j < numComponents; ++j) {
                 snprintf(name, 512, pattern,
                          FluidSystem::phaseName(i),
                          FluidSystem::componentName(j));
@@ -469,38 +476,42 @@ protected:
         }
     }
 
-    void attachScalarElementData_(BaseOutputWriter &baseWriter,
-                                  ScalarBuffer &buffer,
+    void attachScalarElementData_(BaseOutputWriter& baseWriter,
+                                  ScalarBuffer& buffer,
                                   const char *name)
     { baseWriter.attachScalarElementData(buffer, name); }
 
-    void attachScalarVertexData_(BaseOutputWriter &baseWriter,
-                                 ScalarBuffer &buffer,
+    void attachScalarVertexData_(BaseOutputWriter& baseWriter,
+                                 ScalarBuffer& buffer,
                                  const char *name)
     { baseWriter.attachScalarVertexData(buffer, name); }
 
-    void attachVectorElementData_(BaseOutputWriter &baseWriter,
-                                  VectorBuffer &buffer,
+    void attachVectorElementData_(BaseOutputWriter& baseWriter,
+                                  VectorBuffer& buffer,
                                   const char *name)
     { baseWriter.attachVectorElementData(buffer, name); }
 
-    void attachVectorVertexData_(BaseOutputWriter &baseWriter,
-                                 VectorBuffer &buffer,
+    void attachVectorVertexData_(BaseOutputWriter& baseWriter,
+                                 VectorBuffer& buffer,
                                  const char *name)
     { baseWriter.attachVectorVertexData(buffer, name); }
 
-    void attachTensorElementData_(BaseOutputWriter &baseWriter,
-                                  TensorBuffer &buffer,
+    void attachTensorElementData_(BaseOutputWriter& baseWriter,
+                                  TensorBuffer& buffer,
                                   const char *name)
     { baseWriter.attachTensorElementData(buffer, name); }
 
-    void attachTensorVertexData_(BaseOutputWriter &baseWriter,
-                                 TensorBuffer &buffer,
+    void attachTensorVertexData_(BaseOutputWriter& baseWriter,
+                                 TensorBuffer& buffer,
                                  const char *name)
     { baseWriter.attachTensorVertexData(buffer, name); }
 
-    const Simulator &simulator_;
+    const Simulator& simulator_;
 };
+
+#if __GNUC__ || __clang__
+#pragma GCC diagnostic pop
+#endif
 
 } // namespace Ewoms
 

--- a/ewoms/io/baseoutputwriter.hh
+++ b/ewoms/io/baseoutputwriter.hh
@@ -65,32 +65,32 @@ public:
     /*!
      * \brief Add a scalar vertex centered vector field to the output.
      */
-    virtual void attachScalarVertexData(ScalarBuffer &buf, std::string name) = 0;
+    virtual void attachScalarVertexData(ScalarBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Add a scalar element centered quantity to the output.
      */
-    virtual void attachScalarElementData(ScalarBuffer &buf, std::string name) = 0;
+    virtual void attachScalarElementData(ScalarBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Add a vectorial vertex centered vector field to the output.
      */
-    virtual void attachVectorVertexData(VectorBuffer &buf, std::string name) = 0;
+    virtual void attachVectorVertexData(VectorBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Add a vectorial element centered quantity to the output.
      */
-    virtual void attachVectorElementData(VectorBuffer &buf, std::string name) = 0;
+    virtual void attachVectorElementData(VectorBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Add a tensorial vertex centered tensor field to the output.
      */
-    virtual void attachTensorVertexData(TensorBuffer &buf, std::string name) = 0;
+    virtual void attachTensorVertexData(TensorBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Add a tensorial element centered quantity to the output.
      */
-    virtual void attachTensorElementData(TensorBuffer &buf, std::string name) = 0;
+    virtual void attachTensorElementData(TensorBuffer& buf, std::string name) = 0;
 
     /*!
      * \brief Finalizes the current writer.

--- a/ewoms/io/cubegridmanager.hh
+++ b/ewoms/io/cubegridmanager.hh
@@ -104,7 +104,7 @@ public:
     /*!
      * \brief Create the grid
      */
-    CubeGridManager(Simulator &simulator)
+    CubeGridManager(Simulator& simulator)
         : ParentType(simulator)
     {
         Dune::array<unsigned int, dimWorld> cellRes;
@@ -115,21 +115,19 @@ public:
             cellRes[i] = 0;
 
         upperRight[0] = EWOMS_GET_PARAM(TypeTag, Scalar, DomainSizeX);
-        cellRes[0] = EWOMS_GET_PARAM(TypeTag, int, CellsX);
+        cellRes[0] = EWOMS_GET_PARAM(TypeTag, unsigned, CellsX);
         if (dimWorld > 1) {
             upperRight[1] = EWOMS_GET_PARAM(TypeTag, Scalar, DomainSizeY);
-            cellRes[1] = EWOMS_GET_PARAM(TypeTag, int, CellsY);
+            cellRes[1] = EWOMS_GET_PARAM(TypeTag, unsigned, CellsY);
         }
         if (dimWorld > 2) {
             upperRight[2] = EWOMS_GET_PARAM(TypeTag, Scalar, DomainSizeZ);
-            cellRes[2] = EWOMS_GET_PARAM(TypeTag, int, CellsZ);
+            cellRes[2] = EWOMS_GET_PARAM(TypeTag, unsigned, CellsZ);
         }
 
         unsigned numRefinements = EWOMS_GET_PARAM(TypeTag, unsigned, GridGlobalRefinements);
-        cubeGrid_ = Dune::StructuredGridFactory<Grid>::createCubeGrid(lowerLeft,
-                                                                      upperRight,
-                                                                      cellRes);
-        cubeGrid_->globalRefine(numRefinements);
+        cubeGrid_ = Dune::StructuredGridFactory<Grid>::createCubeGrid(lowerLeft, upperRight, cellRes);
+        cubeGrid_->globalRefine(static_cast<int>(numRefinements));
 
         this->finalizeInit_();
     }

--- a/ewoms/io/restart.hh
+++ b/ewoms/io/restart.hh
@@ -47,7 +47,7 @@ class Restart
      *        unlikely to load a restart file for an incorrectly.
      */
     template <class GridView>
-    static const std::string magicRestartCookie_(const GridView &gridView)
+    static const std::string magicRestartCookie_(const GridView& gridView)
     {
         static const std::string gridName = "blubb"; // gridView.grid().name();
         static const int dim = GridView::dimension;
@@ -73,8 +73,8 @@ class Restart
      * \brief Return the restart file name.
      */
     template <class GridView>
-    static const std::string restartFileName_(const GridView &gridView,
-                                              const std::string &simName,
+    static const std::string restartFileName_(const GridView& gridView,
+                                              const std::string& simName,
                                               double t)
     {
         int rank = gridView.comm().rank();
@@ -87,14 +87,14 @@ public:
     /*!
      * \brief Returns the name of the file which is (de-)serialized.
      */
-    const std::string &fileName() const
+    const std::string& fileName() const
     { return fileName_; }
 
     /*!
      * \brief Write the current state of the model to disk.
      */
     template <class Simulator>
-    void serializeBegin(Simulator &simulator)
+    void serializeBegin(Simulator& simulator)
     {
         const std::string magicCookie = magicRestartCookie_(simulator.gridView());
         fileName_ = restartFileName_(simulator.gridView(),
@@ -112,13 +112,13 @@ public:
     /*!
      * \brief The output stream to write the serialized data.
      */
-    std::ostream &serializeStream()
+    std::ostream& serializeStream()
     { return outStream_; }
 
     /*!
      * \brief Start a new section in the serialized output.
      */
-    void serializeSectionBegin(const std::string &cookie)
+    void serializeSectionBegin(const std::string& cookie)
     { outStream_ << cookie << "\n"; }
 
     /*!
@@ -133,7 +133,7 @@ public:
      * The actual work is done by Serializer::serialize(Entity)
      */
     template <int codim, class Serializer, class GridView>
-    void serializeEntities(Serializer &serializer, const GridView &gridView)
+    void serializeEntities(Serializer& serializer, const GridView& gridView)
     {
         std::ostringstream oss;
         oss << "Entities: Codim " << codim;
@@ -144,7 +144,7 @@ public:
         typedef typename GridView::template Codim<codim>::Iterator Iterator;
 
         Iterator it = gridView.template begin<codim>();
-        const Iterator &endIt = gridView.template end<codim>();
+        const Iterator& endIt = gridView.template end<codim>();
         for (; it != endIt; ++it) {
             serializer.serializeEntity(outStream_, *it);
             outStream_ << "\n";
@@ -164,7 +164,7 @@ public:
      *        time.
      */
     template <class Simulator>
-    void deserializeBegin(Simulator &simulator, double t)
+    void deserializeBegin(Simulator& simulator, double t)
     {
         fileName_ = restartFileName_(simulator.gridView(), simulator.problem().name(), t);
 
@@ -177,7 +177,7 @@ public:
 
         // make sure that we don't open an empty file
         inStream_.seekg(0, std::ios::end);
-        int pos = inStream_.tellg();
+        auto pos = inStream_.tellg();
         if (pos == 0) {
             OPM_THROW(std::runtime_error,
                       "Restart file '" << fileName_ << "' is empty");
@@ -194,13 +194,13 @@ public:
      * \brief The input stream to read the data which ought to be
      *        deserialized.
      */
-    std::istream &deserializeStream()
+    std::istream& deserializeStream()
     { return inStream_; }
 
     /*!
      * \brief Start reading a new section of the restart file.
      */
-    void deserializeSectionBegin(const std::string &cookie)
+    void deserializeSectionBegin(const std::string& cookie)
     {
         if (!inStream_.good())
             OPM_THROW(std::runtime_error,
@@ -233,7 +233,7 @@ public:
      * The actual work is done by Deserializer::deserialize(Entity)
      */
     template <int codim, class Deserializer, class GridView>
-    void deserializeEntities(Deserializer &deserializer, const GridView &gridView)
+    void deserializeEntities(Deserializer& deserializer, const GridView& gridView)
     {
         std::ostringstream oss;
         oss << "Entities: Codim " << codim;
@@ -245,7 +245,7 @@ public:
         // read entity data
         typedef typename GridView::template Codim<codim>::Iterator Iterator;
         Iterator it = gridView.template begin<codim>();
-        const Iterator &endIt = gridView.template end<codim>();
+        const Iterator& endIt = gridView.template end<codim>();
         for (; it != endIt; ++it) {
             if (!inStream_.good()) {
                 OPM_THROW(std::runtime_error, "Restart file is corrupted");

--- a/ewoms/io/simplexgridmanager.hh
+++ b/ewoms/io/simplexgridmanager.hh
@@ -99,7 +99,7 @@ public:
     /*!
      * \brief Create the Grid
      */
-    SimplexGridManager(Simulator &simulator)
+    SimplexGridManager(Simulator& simulator)
         : ParentType(simulator)
     {
         Dune::array<unsigned, dimWorld> cellRes;

--- a/ewoms/io/structuredgridmanager.hh
+++ b/ewoms/io/structuredgridmanager.hh
@@ -131,7 +131,7 @@ public:
     /*!
      * \brief Create the grid for the lens problem
      */
-    StructuredGridManager(Simulator &simulator)
+    StructuredGridManager(Simulator& simulator)
         : ParentType(simulator)
     {
         Dune::FieldVector<int, dim> cellRes;
@@ -167,7 +167,7 @@ public:
         gridPtr_.reset( Dune::GridPtr< Grid >( dgffile ).release() );
 
         unsigned numRefinements = EWOMS_GET_PARAM(TypeTag, unsigned, GridGlobalRefinements);
-        gridPtr_->globalRefine(numRefinements);
+        gridPtr_->globalRefine(static_cast<int>(numRefinements));
 
         this->finalizeInit_();
     }

--- a/ewoms/io/vtkblackoilmodule.hh
+++ b/ewoms/io/vtkblackoilmodule.hh
@@ -112,7 +112,7 @@ class VtkBlackOilModule : public BaseOutputModule<TypeTag>
     typedef typename ParentType::ScalarBuffer ScalarBuffer;
 
 public:
-    VtkBlackOilModule(const Simulator &simulator)
+    VtkBlackOilModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -201,7 +201,7 @@ public:
      * \brief Modify the internal buffers according to the intensive quantities relevant for
      *        an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
@@ -209,13 +209,13 @@ public:
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
-            const auto &fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
+            const auto& fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
             typedef typename std::remove_const<typename std::remove_reference<decltype(fs)>::type>::type FluidState;
-            int globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+            unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
 
             const auto& primaryVars = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0);
 
-            int pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
+            unsigned pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
             Scalar SoMax = elemCtx.model().maxOilSaturation(globalDofIdx);
             Scalar x_oG = Toolbox::value(fs.moleFraction(oilPhaseIdx, gasCompIdx));
             Scalar x_gO = Toolbox::value(fs.moleFraction(gasPhaseIdx, oilCompIdx));
@@ -290,7 +290,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter)

--- a/ewoms/io/vtkcompositionmodule.hh
+++ b/ewoms/io/vtkcompositionmodule.hh
@@ -95,7 +95,7 @@ class VtkCompositionModule : public BaseOutputModule<TypeTag>
     typedef typename ParentType::PhaseComponentBuffer PhaseComponentBuffer;
 
 public:
-    VtkCompositionModule(const Simulator &simulator)
+    VtkCompositionModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -147,7 +147,7 @@ public:
      * \brief Modify the internal buffers according to the intensive quantities relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
@@ -155,12 +155,12 @@ public:
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
-            const auto &intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
-            const auto &fs = intQuants.fluidState();
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            const auto& intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
+            const auto& fs = intQuants.fluidState();
 
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     if (moleFracOutput_())
                         moleFrac_[phaseIdx][compIdx][I] = Toolbox::value(fs.moleFraction(phaseIdx, compIdx));
                     if (massFracOutput_())
@@ -174,11 +174,11 @@ public:
                 }
             }
 
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 if (totalMassFracOutput_()) {
                     Scalar compMass = 0;
                     Scalar totalMass = 0;
-                    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                         totalMass += Toolbox::value(fs.density(phaseIdx)) * Toolbox::value(fs.saturation(phaseIdx));
                         compMass +=
                             Toolbox::value(fs.density(phaseIdx))
@@ -190,7 +190,7 @@ public:
                 if (totalMoleFracOutput_()) {
                     Scalar compMoles = 0;
                     Scalar totalMoles = 0;
-                    for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                    for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                         totalMoles +=
                             Toolbox::value(fs.molarDensity(phaseIdx))
                             *Toolbox::value(fs.saturation(phaseIdx));
@@ -210,7 +210,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtkdiffusionmodule.hh
+++ b/ewoms/io/vtkdiffusionmodule.hh
@@ -91,7 +91,7 @@ class VtkDiffusionModule : public BaseOutputModule<TypeTag>
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
 
 public:
-    VtkDiffusionModule(const Simulator &simulator)
+    VtkDiffusionModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -130,14 +130,14 @@ public:
      * \brief Modify the internal buffers according to the intensive quanties relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
-            const auto &intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            const auto& intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
 
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (tortuosityOutput_())
@@ -157,7 +157,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtkenergymodule.hh
+++ b/ewoms/io/vtkenergymodule.hh
@@ -90,7 +90,7 @@ class VtkEnergyModule : public BaseOutputModule<TypeTag>
     typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
 
 public:
-    VtkEnergyModule(const Simulator &simulator)
+    VtkEnergyModule(const Simulator& simulator)
         : ParentType(simulator)
     {
     }
@@ -135,15 +135,15 @@ public:
      * \brief Modify the internal buffers according to the intensive quanties relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
-            const auto &intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
-            const auto &fs = intQuants.fluidState();
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            const auto& intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
+            const auto& fs = intQuants.fluidState();
 
             if (solidHeatCapacityOutput_())
                 solidHeatCapacity_[I] = Toolbox::value(intQuants.heatCapacitySolid());
@@ -162,7 +162,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtkphasepresencemodule.hh
+++ b/ewoms/io/vtkphasepresencemodule.hh
@@ -70,7 +70,7 @@ class VtkPhasePresenceModule : public BaseOutputModule<TypeTag>
 
 
 public:
-    VtkPhasePresenceModule(const Simulator &simulator)
+    VtkPhasePresenceModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -97,7 +97,7 @@ public:
      * \brief Modify the internal buffers according to the intensive quanties relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
@@ -105,7 +105,7 @@ public:
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
             // calculate the phase presence
             int phasePresence = elemCtx.primaryVars(i, /*timeIdx=*/0).phasePresence();
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
 
             if (phasePresenceOutput_())
                 phasePresence_[I] = phasePresence;
@@ -115,7 +115,7 @@ public:
     /*!
      * \brief Add all buffers to the output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtkprimaryvarsmodule.hh
+++ b/ewoms/io/vtkprimaryvarsmodule.hh
@@ -74,7 +74,7 @@ class VtkPrimaryVarsModule : public BaseOutputModule<TypeTag>
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
 
 public:
-    VtkPrimaryVarsModule(const Simulator &simulator)
+    VtkPrimaryVarsModule(const Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -110,28 +110,28 @@ public:
      * \brief Modify the internal buffers according to the intensive quantities relevant for
      *        an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
 
-        const auto &elementMapper = elemCtx.model().elementMapper();
+        const auto& elementMapper = elemCtx.model().elementMapper();
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int elemIdx = elementMapper.index(elemCtx.element());
+        unsigned elemIdx = static_cast<unsigned>(elementMapper.index(elemCtx.element()));
 #else
-        int elemIdx = elementMapper .map(elemCtx.element());
+        unsigned elemIdx = static_cast<unsigned>(elementMapper .map(elemCtx.element()));
 #endif
         if (processRankOutput_() && !processRank_.empty())
-            processRank_[elemIdx] = this->simulator_.gridView().comm().rank();
+            processRank_[elemIdx] = static_cast<unsigned>(this->simulator_.gridView().comm().rank());
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
-            const auto &priVars = elemCtx.primaryVars(i, /*timeIdx=*/0);
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            const auto& priVars = elemCtx.primaryVars(i, /*timeIdx=*/0);
 
             if (dofIndexOutput_())
                 dofIndex_[I] = I;
 
-            for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
                 if (primaryVarsOutput_() && !primaryVars_[eqIdx].empty())
                     primaryVars_[eqIdx][I] = priVars[eqIdx];
             }
@@ -141,7 +141,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtktemperaturemodule.hh
+++ b/ewoms/io/vtktemperaturemodule.hh
@@ -72,7 +72,7 @@ class VtkTemperatureModule : public BaseOutputModule<TypeTag>
     typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
 
 public:
-    VtkTemperatureModule(const Simulator &simulator)
+    VtkTemperatureModule(const Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -98,7 +98,7 @@ public:
      * \brief Modify the internal buffers according to the intensive quantities relevant
      *        for an element
      */
-    void processElement(const ElementContext &elemCtx)
+    void processElement(const ElementContext& elemCtx)
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
@@ -106,9 +106,9 @@ public:
             return;
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
-            int I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
-            const auto &intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
-            const auto &fs = intQuants.fluidState();
+            unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);
+            const auto& intQuants = elemCtx.intensiveQuantities(i, /*timeIdx=*/0);
+            const auto& fs = intQuants.fluidState();
 
             if (temperatureOutput_())
                 temperature_[I] = Toolbox::value(fs.temperature(/*phaseIdx=*/0));
@@ -118,7 +118,7 @@ public:
     /*!
      * \brief Add all buffers to the VTK output writer.
      */
-    void commitBuffers(BaseOutputWriter &baseWriter)
+    void commitBuffers(BaseOutputWriter& baseWriter)
     {
         VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
         if (!vtkWriter) {

--- a/ewoms/io/vtktensorfunction.hh
+++ b/ewoms/io/vtktensorfunction.hh
@@ -56,11 +56,11 @@ class VtkTensorFunction : public Dune::VTKFunction<GridView>
 
 public:
     VtkTensorFunction(std::string name,
-                      const GridView &gridView,
-                      const Mapper &mapper,
-                      const TensorBuffer &buf,
-                      int codim,
-                      int matrixColumnIdx)
+                      const GridView& gridView,
+                      const Mapper& mapper,
+                      const TensorBuffer& buf,
+                      unsigned codim,
+                      unsigned matrixColumnIdx)
         : name_(name)
         , gridView_(gridView)
         , mapper_(mapper)
@@ -73,19 +73,19 @@ public:
     { return name_; }
 
     virtual int ncomps() const
-    { return buf_[0].M(); }
+    { return static_cast<int>(buf_[0].M()); }
 
     virtual double evaluate(int mycomp,
-                            const Element &e,
-                            const Dune::FieldVector<ctype, dim> &xi) const
+                            const Element& e,
+                            const Dune::FieldVector<ctype, dim>& xi) const
     {
-        int idx;
+        size_t idx;
         if (codim_ == 0) {
             // cells. map element to the index
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            idx = mapper_.index(e);
+            idx = static_cast<size_t>(mapper_.index(e));
 #else
-            idx = mapper_.map(e);
+            idx = static_cast<size_t>(mapper_.map(e));
 #endif
         }
         else if (codim_ == dim) {
@@ -95,9 +95,9 @@ public:
             int imin = -1;
             Dune::GeometryType gt = e.type();
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            int n = e.subEntities(dim);
+            int n = static_cast<int>(e.subEntities(dim));
 #else
-            int n = e.template count<dim>();
+            int n = static_cast<int>(e.template count<dim>());
 #endif
             for (int i = 0; i < n; ++i) {
                 Dune::FieldVector<ctype, dim> local =
@@ -112,31 +112,28 @@ public:
 
             // map vertex to an index
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            idx = mapper_.subIndex(e, imin, codim_);
+            idx = static_cast<size_t>(mapper_.subIndex(e, imin, codim_));
 #else
-            idx = mapper_.map(e, imin, codim_);
+            idx = static_cast<size_t>(mapper_.map(e, imin, codim_));
 #endif
         }
         else
             OPM_THROW(std::logic_error,
                       "Only element and vertex based tensor fields are supported so far.");
 
-        int i = mycomp; // mycomp / buf_[0].M();
-        int j = matrixColumnIdx_; // mycomp % buf_[0].M();
-        double val = buf_[idx][i][j];
-        if (std::abs(val) < std::numeric_limits<float>::min())
-            val = 0;
+        unsigned i = static_cast<unsigned>(mycomp);
+        unsigned j = static_cast<unsigned>(matrixColumnIdx_);
 
-        return val;
+        return static_cast<double>(static_cast<float>(buf_[idx][i][j]));
     }
 
 private:
     const std::string name_;
     const GridView gridView_;
-    const Mapper &mapper_;
-    const TensorBuffer &buf_;
-    int codim_;
-    int matrixColumnIdx_;
+    const Mapper& mapper_;
+    const TensorBuffer& buf_;
+    unsigned codim_;
+    unsigned matrixColumnIdx_;
 };
 
 } // namespace Ewoms

--- a/ewoms/io/vtkvectorfunction.hh
+++ b/ewoms/io/vtkvectorfunction.hh
@@ -58,10 +58,10 @@ class VtkVectorFunction : public Dune::VTKFunction<GridView>
 
 public:
     VtkVectorFunction(std::string name,
-                      const GridView &gridView,
-                      const Mapper &mapper,
-                      const VectorBuffer &buf,
-                      int codim)
+                      const GridView& gridView,
+                      const Mapper& mapper,
+                      const VectorBuffer& buf,
+                      unsigned codim)
         : name_(name)
         , gridView_(gridView)
         , mapper_(mapper)
@@ -73,19 +73,19 @@ public:
     { return name_; }
 
     virtual int ncomps() const
-    { return buf_[0].size(); }
+    { return static_cast<int>(buf_[0].size()); }
 
     virtual double evaluate(int mycomp,
-                            const Element &e,
-                            const Dune::FieldVector<ctype, dim> &xi) const
+                            const Element& e,
+                            const Dune::FieldVector<ctype, dim>& xi) const
     {
-        int idx;
+        unsigned idx;
         if (codim_ == 0) {
             // cells. map element to the index
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            idx = mapper_.index(e);
+            idx = static_cast<unsigned>(mapper_.index(e));
 #else
-            idx = mapper_.map(e);
+            idx = static_cast<unsigned>(mapper_.map(e));
 #endif
         }
         else if (codim_ == dim) {
@@ -95,9 +95,9 @@ public:
             int imin = -1;
             Dune::GeometryType gt = e.type();
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            int n = e.subEntities(dim);
+            int n = static_cast<int>(e.subEntities(dim));
 #else
-            int n = e.template count<dim>();
+            int n = static_cast<int>(e.template count<dim>());
 #endif
             for (int i = 0; i < n; ++i) {
                 Dune::FieldVector<ctype, dim> local =
@@ -112,28 +112,24 @@ public:
 
             // map vertex to an index
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-            idx = mapper_.subIndex(e, imin, codim_);
+            idx = static_cast<unsigned>(mapper_.subIndex(e, imin, codim_));
 #else
-            idx = mapper_.map(e, imin, codim_);
+            idx = static_cast<unsigned>(mapper_.map(e, imin, codim_));
 #endif
         }
         else
             OPM_THROW(std::logic_error, "Only element and vertex based vector "
                                         " fields are supported so far.");
 
-        double val = buf_[idx][mycomp];
-        if (std::abs(val) < std::numeric_limits<float>::min())
-            val = 0;
-
-        return val;
+        return static_cast<double>(static_cast<float>(buf_[idx][static_cast<unsigned>(mycomp)]));
     }
 
 private:
     const std::string name_;
     const GridView gridView_;
-    const Mapper &mapper_;
-    const VectorBuffer &buf_;
-    int codim_;
+    const Mapper& mapper_;
+    const VectorBuffer& buf_;
+    unsigned codim_;
 };
 
 } // namespace Ewoms

--- a/ewoms/linear/blacklist.hh
+++ b/ewoms/linear/blacklist.hh
@@ -77,7 +77,7 @@ public:
     { peerBlackLists_[peerRank] = peerBlackList; }
 
     template <class DomesticOverlap>
-    void updateNativeToDomesticMap(const DomesticOverlap &domesticOverlap)
+    void updateNativeToDomesticMap(const DomesticOverlap& domesticOverlap)
     {
 #if HAVE_MPI
         auto peerListIt = peerBlackLists_.begin();
@@ -105,7 +105,7 @@ public:
     {
         std::cout << "my own blacklisted indices:\n";
         auto idxIt = nativeBlackListedIndices_.begin();
-        const auto &idxEndIt = nativeBlackListedIndices_.end();
+        const auto& idxEndIt = nativeBlackListedIndices_.end();
         for (; idxIt != idxEndIt; ++idxIt)
             std::cout << " (native index: " << *idxIt
                       << ", domestic index: " << nativeToDomestic(*idxIt) << ")\n";
@@ -113,13 +113,13 @@ public:
         auto peerListIt = peerBlackLists_.begin();
         const auto& peerListEndIt = peerBlackLists_.end();
         for (; peerListIt != peerListEndIt; ++peerListIt) {
-            int peerRank = peerListIt->first;
+            ProcessRank peerRank = peerListIt->first;
             std::cout << " peer " << peerRank << ":\n";
-            auto idxIt = peerListIt->second.begin();
-            const auto& idxEndIt = peerListIt->second.end();
-            for (; idxIt != idxEndIt; ++ idxIt)
-                std::cout << "   (native index: " << idxIt->myOwnNativeIndex
-                          << ", native peer index: " << idxIt->nativeIndexOfPeer << ")\n";
+            auto idx2It = peerListIt->second.begin();
+            const auto& idx2EndIt = peerListIt->second.end();
+            for (; idx2It != idx2EndIt; ++ idx2It)
+                std::cout << "   (native index: " << idx2It->myOwnNativeIndex
+                          << ", native peer index: " << idx2It->nativeIndexOfPeer << ")\n";
         }
     }
 
@@ -134,7 +134,7 @@ private:
         auto& idxBuff = globalIdxSendBuff_[peerRank];
 
         numIdxBuff.resize(1);
-        numIdxBuff[0] = peerIndices.size();
+        numIdxBuff[0] = static_cast<unsigned>(peerIndices.size());
         numIdxBuff.send(peerRank);
 
         idxBuff.resize(2*peerIndices.size());
@@ -154,13 +154,13 @@ private:
     void receiveGlobalIndices_(ProcessRank peerRank,
                                const DomesticOverlap& domesticOverlap)
     {
-        MpiBuffer<int> numGlobalIdxBuf(1);
+        MpiBuffer<unsigned> numGlobalIdxBuf(1);
         numGlobalIdxBuf.receive(peerRank);
-        int numIndices = numGlobalIdxBuf[0];
+        unsigned numIndices = numGlobalIdxBuf[0];
 
         MpiBuffer<Index> globalIdxBuf(2*numIndices);
         globalIdxBuf.receive(peerRank);
-        for (int i = 0; i < numIndices; ++i) {
+        for (unsigned i = 0; i < numIndices; ++i) {
             Index globalIdx = globalIdxBuf[2*i + 0];
             Index nativeIdx = globalIdxBuf[2*i + 1];
 
@@ -172,7 +172,7 @@ private:
     std::set<Index> nativeBlackListedIndices_;
     std::map<Index, Index> nativeToDomesticMap_;
 #if HAVE_MPI
-    std::map<ProcessRank, MpiBuffer<int>> numGlobalIdxSendBuff_;
+    std::map<ProcessRank, MpiBuffer<unsigned>> numGlobalIdxSendBuff_;
     std::map<ProcessRank, MpiBuffer<Index>> globalIdxSendBuff_;
 #endif // HAVE_MPI
 

--- a/ewoms/linear/convergencecriterion.hh
+++ b/ewoms/linear/convergencecriterion.hh
@@ -27,6 +27,8 @@
 #ifndef EWOMS_ISTL_CONVERGENCE_CRITERION_HH
 #define EWOMS_ISTL_CONVERGENCE_CRITERION_HH
 
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 
@@ -84,7 +86,7 @@ public:
      * \param curResid The residual vector of the current iterative
      *                 solution of the linear system of equations
      */
-    virtual void setInitial(const Vector &curSol, const Vector &curResid) = 0;
+    virtual void setInitial(const Vector& curSol, const Vector& curResid) = 0;
 
     /*!
      * \brief Update the internal members of the convergence criterion
@@ -100,7 +102,7 @@ public:
      * \param curResid The residual vector of the current iterative
      *                 solution of the linear system of equations
      */
-    virtual void update(const Vector &curSol, const Vector &curResid) = 0;
+    virtual void update(const Vector& curSol, const Vector& curResid) = 0;
 
     /*!
      * \brief Returns true if and only if the convergence criterion is
@@ -125,7 +127,8 @@ public:
      *
      * \param os The output stream to which the message gets written.
      */
-    virtual void printInitial(std::ostream &os = std::cout) const {}
+    virtual void printInitial(std::ostream& OPM_UNUSED os = std::cout) const
+    {}
 
     /*!
      * \brief Prints the information about the convergence behaviour for
@@ -135,7 +138,8 @@ public:
      *             are chosen by the linear solver.
      * \param os The output stream to which the message gets written.
      */
-    virtual void print(Scalar iter, std::ostream &os = std::cout) const {}
+    virtual void print(Scalar OPM_UNUSED iter, std::ostream& OPM_UNUSED os = std::cout) const
+    {}
 };
 
 //! \} end documentation

--- a/ewoms/linear/fixpointcriterion.hh
+++ b/ewoms/linear/fixpointcriterion.hh
@@ -29,6 +29,8 @@
 
 #include "convergencecriterion.hh"
 
+#include <opm/material/common/Unused.hpp>
+
 namespace Ewoms {
 /*! \addtogroup Linear
  * \{
@@ -57,11 +59,11 @@ class FixPointCriterion : public ConvergenceCriterion<Vector>
     typedef typename Vector::block_type BlockType;
 
 public:
-    FixPointCriterion(const CollectiveCommunication &comm) : comm_(comm)
+    FixPointCriterion(const CollectiveCommunication& comm) : comm_(comm)
     {}
 
-    FixPointCriterion(const CollectiveCommunication &comm,
-                      const Vector &weightVec, Scalar reduction)
+    FixPointCriterion(const CollectiveCommunication& comm,
+                      const Vector& weightVec, Scalar reduction)
         : comm_(comm), weightVec_(weightVec), tolerance_(reduction)
     {}
 
@@ -81,7 +83,7 @@ public:
      * \param weightVec A Dune::BlockVector<Dune::FieldVector<Scalar, n> >
      *                  with the relative weights of the degrees of freedom
      */
-    void setWeight(const Vector &weightVec)
+    void setWeight(const Vector& weightVec)
     { weightVec_ = weightVec; }
 
     /*!
@@ -118,18 +120,18 @@ public:
     { return tolerance_; }
 
     /*!
-     * \copydoc ConvergenceCriterion::setInitial(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::setInitial(const Vector& , const Vector& )
      */
-    void setInitial(const Vector &curSol, const Vector &curResid)
+    void setInitial(const Vector& curSol, const Vector& OPM_UNUSED curResid)
     {
         lastSol_ = curSol;
         delta_ = 1000 * tolerance_;
     }
 
     /*!
-     * \copydoc ConvergenceCriterion::update(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::update(const Vector& , const Vector& )
      */
-    void update(const Vector &curSol, const Vector &curResid)
+    void update(const Vector& curSol, const Vector& OPM_UNUSED curResid)
     {
         assert(curSol.size() == lastSol_.size());
 
@@ -159,7 +161,7 @@ public:
     { return delta_; }
 
 private:
-    const CollectiveCommunication &comm_;
+    const CollectiveCommunication& comm_;
 
     Vector lastSol_;   // solution of the last iteration
     Vector weightVec_; // solution of the last iteration

--- a/ewoms/linear/nullborderlistmanager.hh
+++ b/ewoms/linear/nullborderlistmanager.hh
@@ -29,7 +29,9 @@
 
 #include "overlaptypes.hh"
 
+#include <opm/material/common/Unused.hpp>
 #include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/grid/common/datahandleif.hh>
 #include <dune/grid/common/gridenums.hh>
@@ -51,8 +53,8 @@ template <class GridView, class DofMapper>
 class NullBorderListCreator
 {
 public:
-    NullBorderListCreator(const GridView &gridView,
-                          const DofMapper &map)
+    NullBorderListCreator(const GridView& gridView,
+                          const DofMapper& OPM_UNUSED map)
     {
         if (gridView.comm().size() > 1)
             OPM_THROW(std::runtime_error,
@@ -60,7 +62,7 @@ public:
     }
 
     // Access to the border list.
-    const BorderList &borderList() const
+    const BorderList& borderList() const
     { return borderList_; }
 
 private:

--- a/ewoms/linear/overlappingblockvector.hh
+++ b/ewoms/linear/overlappingblockvector.hh
@@ -56,14 +56,14 @@ public:
      * \brief Given a domestic overlap object, create an overlapping
      *        block vector coherent to it.
      */
-    OverlappingBlockVector(const Overlap &overlap)
+    OverlappingBlockVector(const Overlap& overlap)
         : ParentType(overlap.numDomestic()), overlap_(&overlap)
     { createBuffers_(); }
 
     /*!
      * \brief Copy constructor.
      */
-    OverlappingBlockVector(const OverlappingBlockVector &obv)
+    OverlappingBlockVector(const OverlappingBlockVector& obv)
         : ParentType(obv)
         , numIndicesSendBuff_(obv.numIndicesSendBuff_)
         , indicesSendBuff_(obv.indicesSendBuff_)
@@ -89,7 +89,7 @@ public:
     /*!
      * \brief Assignment operator.
      */
-    OverlappingBlockVector &operator=(const OverlappingBlockVector &obv)
+    OverlappingBlockVector& operator=(const OverlappingBlockVector& obv)
     {
         ParentType::operator=(obv);
         numIndicesSendBuff_ = obv.numIndicesSendBuff_;
@@ -105,17 +105,17 @@ public:
      * \brief Assign an overlapping block vector from a
      *        non-overlapping one, border entries are added.
      */
-    void assignAddBorder(const BlockVector &nativeBlockVector)
+    void assignAddBorder(const BlockVector& nativeBlockVector)
     {
-        int numDomestic = overlap_->numDomestic();
+        size_t numDomestic = overlap_->numDomestic();
 
         // assign the local rows from the non-overlapping block vector
-        for (int domRowIdx = 0; domRowIdx < numDomestic; ++domRowIdx) {
-            int nativeRowIdx = overlap_->domesticToNative(domRowIdx);
+        for (unsigned domRowIdx = 0; domRowIdx < numDomestic; ++domRowIdx) {
+            Index nativeRowIdx = overlap_->domesticToNative(static_cast<Index>(domRowIdx));
             if (nativeRowIdx < 0)
-                (*this)[domRowIdx] = 0.0;
+                (*this)[static_cast<unsigned>(domRowIdx)] = 0.0;
             else
-                (*this)[domRowIdx] = nativeBlockVector[nativeRowIdx];
+                (*this)[static_cast<unsigned>(domRowIdx)] = nativeBlockVector[static_cast<unsigned>(nativeRowIdx)];
         }
 
         // add up the contents of border rows, for the remaining rows,
@@ -127,17 +127,17 @@ public:
      * \brief Assign an overlapping block vector from a non-overlapping one, border
      *        entries are assigned using their respective master ranks.
      */
-    void assign(const BlockVector &nativeBlockVector)
+    void assign(const BlockVector& nativeBlockVector)
     {
-        int numDomestic = overlap_->numDomestic();
+        size_t numDomestic = overlap_->numDomestic();
 
         // assign the local rows from the non-overlapping block vector
-        for (int domRowIdx = 0; domRowIdx < numDomestic; ++domRowIdx) {
-            int nativeRowIdx = overlap_->domesticToNative(domRowIdx);
+        for (Index domRowIdx = 0; domRowIdx < numDomestic; ++domRowIdx) {
+            Index nativeRowIdx = overlap_->domesticToNative(domRowIdx);
             if (nativeRowIdx < 0)
-                (*this)[domRowIdx] = 0.0;
+                (*this)[static_cast<unsigned>(domRowIdx)] = 0.0;
             else
-                (*this)[domRowIdx] = nativeBlockVector[nativeRowIdx];
+                (*this)[static_cast<unsigned>(domRowIdx)] = nativeBlockVector[static_cast<unsigned>(nativeRowIdx)];
         }
 
         // add up the contents of border rows, for the remaining rows,
@@ -149,18 +149,18 @@ public:
      * \brief Assign the local values to a non-overlapping block
      *        vector.
      */
-    void assignTo(BlockVector &nativeBlockVector) const
+    void assignTo(BlockVector& nativeBlockVector) const
     {
         // assign the local rows
-        int numNative = overlap_->numNative();
+        size_t numNative = overlap_->numNative();
         nativeBlockVector.resize(numNative);
-        for (int nativeRowIdx = 0; nativeRowIdx < numNative; ++nativeRowIdx) {
-            int domRowIdx = overlap_->nativeToDomestic(nativeRowIdx);
+        for (unsigned nativeRowIdx = 0; nativeRowIdx < numNative; ++nativeRowIdx) {
+            Index domRowIdx = overlap_->nativeToDomestic(static_cast<Index>(nativeRowIdx));
 
             if (domRowIdx < 0)
                 nativeBlockVector[nativeRowIdx] = 0.0;
             else
-                nativeBlockVector[nativeRowIdx] = (*this)[domRowIdx];
+                nativeBlockVector[nativeRowIdx] = (*this)[static_cast<unsigned>(domRowIdx)];
         }
     }
 
@@ -176,14 +176,14 @@ public:
         // send all entries to all peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             sendEntries_(peerRank);
         }
 
         // recieve all entries to the peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             receiveFromMaster_(peerRank);
         }
 
@@ -203,14 +203,14 @@ public:
         // send all entries to all peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             sendEntries_(peerRank);
         }
 
         // recieve all entries to the peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             receiveAdd_(peerRank);
         }
 
@@ -230,14 +230,14 @@ public:
         // send all entries to all peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             sendEntries_(peerRank);
         }
 
         // recieve all entries to the peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             receiveAddBorder_(peerRank);
         }
 
@@ -248,7 +248,7 @@ public:
 
     void print() const
     {
-        for (int i = 0; i < this->size(); ++i) {
+        for (unsigned i = 0; i < this->size(); ++i) {
             std::cout << "row " << i << (overlap_->isLocal(i) ? " " : "*")
                       << ": " << (*this)[i] << "\n" << std::flush;
         }
@@ -265,22 +265,22 @@ private:
         // send all indices to the peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
 
-            int numEntries = overlap_->foreignOverlapSize(peerRank);
-            numIndicesSendBuff_[peerRank] = std::make_shared<MpiBuffer<int> >(1);
+            size_t numEntries = overlap_->foreignOverlapSize(peerRank);
+            numIndicesSendBuff_[peerRank] = std::make_shared<MpiBuffer<unsigned> >(1);
             indicesSendBuff_[peerRank] = std::make_shared<MpiBuffer<Index> >(numEntries);
             valuesSendBuff_[peerRank] = std::make_shared<MpiBuffer<FieldVector> >(numEntries);
 
             // fill the indices buffer with global indices
-            MpiBuffer<Index> &indicesSendBuff = *indicesSendBuff_[peerRank];
-            for (int i = 0; i < numEntries; ++i) {
-                int domRowIdx = overlap_->foreignOverlapOffsetToDomesticIdx(peerRank, i);
+            MpiBuffer<Index>& indicesSendBuff = *indicesSendBuff_[peerRank];
+            for (unsigned i = 0; i < numEntries; ++i) {
+                Index domRowIdx = overlap_->foreignOverlapOffsetToDomesticIdx(peerRank, i);
                 indicesSendBuff[i] = overlap_->domesticToGlobal(domRowIdx);
             }
 
             // first, send the number of indices
-            (*numIndicesSendBuff_[peerRank])[0] = numEntries;
+            (*numIndicesSendBuff_[peerRank])[0] = static_cast<unsigned>(numEntries);
             numIndicesSendBuff_[peerRank]->send(peerRank);
 
             // then, send the indices themselfs
@@ -290,27 +290,27 @@ private:
         // receive the indices from the peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
 
             // receive size of overlap to peer
-            MpiBuffer<int> numRowsRecvBuff(1);
+            MpiBuffer<unsigned> numRowsRecvBuff(1);
             numRowsRecvBuff.receive(peerRank);
-            int numRows = numRowsRecvBuff[0];
+            unsigned numRows = numRowsRecvBuff[0];
 
             // then, create the MPI buffers
             indicesRecvBuff_[peerRank] = std::shared_ptr<MpiBuffer<Index> >(
                 new MpiBuffer<Index>(numRows));
             valuesRecvBuff_[peerRank] = std::shared_ptr<MpiBuffer<FieldVector> >(
                 new MpiBuffer<FieldVector>(numRows));
-            MpiBuffer<Index> &indicesRecvBuff = *indicesRecvBuff_[peerRank];
+            MpiBuffer<Index>& indicesRecvBuff = *indicesRecvBuff_[peerRank];
 
             // next, receive the actual indices
             indicesRecvBuff.receive(peerRank);
 
             // finally, translate the global indices to domestic ones
-            for (int i = 0; i != numRows; ++i) {
-                int globalRowIdx = indicesRecvBuff[i];
-                int domRowIdx = overlap_->globalToDomestic(globalRowIdx);
+            for (unsigned i = 0; i != numRows; ++i) {
+                Index globalRowIdx = indicesRecvBuff[i];
+                Index domRowIdx = overlap_->globalToDomestic(globalRowIdx);
 
                 indicesRecvBuff[i] = domRowIdx;
             }
@@ -319,13 +319,13 @@ private:
         // wait for all send operations to complete
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             numIndicesSendBuff_[peerRank]->wait();
             indicesSendBuff_[peerRank]->wait();
 
             // convert the global indices of the send buffer to
             // domestic ones
-            MpiBuffer<Index> &indicesSendBuff = *indicesSendBuff_[peerRank];
+            MpiBuffer<Index>& indicesSendBuff = *indicesSendBuff_[peerRank];
             for (unsigned i = 0; i < indicesSendBuff.size(); ++i) {
                 indicesSendBuff[i] = overlap_->globalToDomestic(indicesSendBuff[i]);
             }
@@ -333,13 +333,13 @@ private:
 #endif // HAVE_MPI
     }
 
-    void sendEntries_(int peerRank)
+    void sendEntries_(ProcessRank peerRank)
     {
         // copy the values into the send buffer
-        const MpiBuffer<Index> &indices = *indicesSendBuff_[peerRank];
-        MpiBuffer<FieldVector> &values = *valuesSendBuff_[peerRank];
+        const MpiBuffer<Index>& indices = *indicesSendBuff_[peerRank];
+        MpiBuffer<FieldVector>& values = *valuesSendBuff_[peerRank];
         for (unsigned i = 0; i < indices.size(); ++i)
-            values[i] = (*this)[indices[i]];
+            values[i] = (*this)[static_cast<unsigned>(indices[i])];
 
         values.send(peerRank);
     }
@@ -352,15 +352,15 @@ private:
         // send all entries to all peers
         peerIt = overlap_->peerSet().begin();
         for (; peerIt != peerEndIt; ++peerIt) {
-            int peerRank = *peerIt;
+            ProcessRank peerRank = *peerIt;
             valuesSendBuff_[peerRank]->wait();
         }
     }
 
-    void receiveFromMaster_(int peerRank)
+    void receiveFromMaster_(ProcessRank peerRank)
     {
-        const MpiBuffer<Index> &indices = *indicesRecvBuff_[peerRank];
-        MpiBuffer<FieldVector> &values = *valuesRecvBuff_[peerRank];
+        const MpiBuffer<Index>& indices = *indicesRecvBuff_[peerRank];
+        MpiBuffer<FieldVector>& values = *valuesRecvBuff_[peerRank];
 
         // receive the values from the peer
         values.receive(peerRank);
@@ -369,45 +369,45 @@ private:
         for (unsigned j = 0; j < indices.size(); ++j) {
             Index domRowIdx = indices[j];
             if (overlap_->masterRank(domRowIdx) == peerRank) {
-                (*this)[domRowIdx] = values[j];
+                (*this)[static_cast<unsigned>(domRowIdx)] = values[j];
             }
         }
     }
 
-    void receiveAddBorder_(int peerRank)
+    void receiveAddBorder_(ProcessRank peerRank)
     {
-        const MpiBuffer<Index> &indices = *indicesRecvBuff_[peerRank];
-        MpiBuffer<FieldVector> &values = *valuesRecvBuff_[peerRank];
+        const MpiBuffer<Index>& indices = *indicesRecvBuff_[peerRank];
+        MpiBuffer<FieldVector>& values = *valuesRecvBuff_[peerRank];
 
         // receive the values from the peer
         values.receive(peerRank);
 
         // add up the values of rows on the shared boundary
         for (unsigned j = 0; j < indices.size(); ++j) {
-            int domRowIdx = indices[j];
+            Index domRowIdx = indices[j];
             if (overlap_->isBorderWith(domRowIdx, peerRank))
-                (*this)[domRowIdx] += values[j];
+                (*this)[static_cast<unsigned>(domRowIdx)] += values[j];
             else
-                (*this)[domRowIdx] = values[j];
+                (*this)[static_cast<unsigned>(domRowIdx)] = values[j];
         }
     }
 
-    void receiveAdd_(int peerRank)
+    void receiveAdd_(ProcessRank peerRank)
     {
-        const MpiBuffer<Index> &indices = *indicesRecvBuff_[peerRank];
-        MpiBuffer<FieldVector> &values = *valuesRecvBuff_[peerRank];
+        const MpiBuffer<Index>& indices = *indicesRecvBuff_[peerRank];
+        MpiBuffer<FieldVector>& values = *valuesRecvBuff_[peerRank];
 
         // receive the values from the peer
         values.receive(peerRank);
 
         // add up the values of rows on the shared boundary
-        for (int j = 0; j < indices.size(); ++j) {
-            int domRowIdx = indices[j];
-            (*this)[domRowIdx] += values[j];
+        for (unsigned j = 0; j < indices.size(); ++j) {
+            Index domRowIdx = indices[j];
+            (*this)[static_cast<unsigned>(domRowIdx)] += values[j];
         }
     }
 
-    std::map<ProcessRank, std::shared_ptr<MpiBuffer<int> > > numIndicesSendBuff_;
+    std::map<ProcessRank, std::shared_ptr<MpiBuffer<unsigned> > > numIndicesSendBuff_;
     std::map<ProcessRank, std::shared_ptr<MpiBuffer<Index> > > indicesSendBuff_;
     std::map<ProcessRank, std::shared_ptr<MpiBuffer<Index> > > indicesRecvBuff_;
     std::map<ProcessRank, std::shared_ptr<MpiBuffer<FieldVector> > > valuesSendBuff_;

--- a/ewoms/linear/overlappingoperator.hh
+++ b/ewoms/linear/overlappingoperator.hh
@@ -49,33 +49,33 @@ public:
     // redefine the category, that is the only difference
     enum { category = Dune::SolverCategory::overlapping };
 
-    OverlappingOperator(const OverlappingMatrix &A) : A_(A)
+    OverlappingOperator(const OverlappingMatrix& A) : A_(A)
     {}
 
     //! apply operator to x:  \f$ y = A(x) \f$
-    virtual void apply(const DomainVector &x, RangeVector &y) const
+    virtual void apply(const DomainVector& x, RangeVector& y) const
     {
         A_.mv(x, y);
         y.sync();
     }
 
     //! apply operator to x, scale and add:  \f$ y = y + \alpha A(x) \f$
-    virtual void applyscaleadd(field_type alpha, const DomainVector &x,
-                               RangeVector &y) const
+    virtual void applyscaleadd(field_type alpha, const DomainVector& x,
+                               RangeVector& y) const
     {
         A_.usmv(alpha, x, y);
         y.sync();
     }
 
     //! returns the matrix
-    virtual const OverlappingMatrix &getmat() const
+    virtual const OverlappingMatrix& getmat() const
     { return A_; }
 
-    const Overlap &overlap() const
+    const Overlap& overlap() const
     { return A_.overlap(); }
 
 private:
-    const OverlappingMatrix &A_;
+    const OverlappingMatrix& A_;
 };
 
 } // namespace Linear

--- a/ewoms/linear/overlappingpreconditioner.hh
+++ b/ewoms/linear/overlappingpreconditioner.hh
@@ -51,11 +51,11 @@ public:
 
     enum { category = Dune::SolverCategory::overlapping };
 
-    OverlappingPreconditioner(SeqPreCond &seqPreCond, const Overlap &overlap)
+    OverlappingPreconditioner(SeqPreCond& seqPreCond, const Overlap& overlap)
         : seqPreCond_(seqPreCond), overlap_(&overlap)
     {}
 
-    void pre(domain_type &x, range_type &y)
+    void pre(domain_type& x, range_type& y)
     {
 #if HAVE_MPI
         short success;
@@ -96,7 +96,7 @@ public:
         y.sync();
     }
 
-    void apply(domain_type &x, const range_type &d)
+    void apply(domain_type& x, const range_type& d)
     {
 #if HAVE_MPI
         if (overlap_->peerSet().size() > 0) {
@@ -139,7 +139,7 @@ public:
             seqPreCond_.apply(x, d);
     }
 
-    void post(domain_type &x)
+    void post(domain_type& x)
     {
 #if HAVE_MPI
         short success;
@@ -178,7 +178,7 @@ public:
     }
 
 private:
-    SeqPreCond &seqPreCond_;
+    SeqPreCond& seqPreCond_;
     const Overlap *overlap_;
 };
 

--- a/ewoms/linear/overlappingscalarproduct.hh
+++ b/ewoms/linear/overlappingscalarproduct.hh
@@ -48,16 +48,16 @@ public:
 
     enum { category = Dune::SolverCategory::overlapping };
 
-    OverlappingScalarProduct(const Overlap &overlap) : overlap_(overlap)
+    OverlappingScalarProduct(const Overlap& overlap) : overlap_(overlap)
     {}
 
-    field_type dot(const OverlappingBlockVector &x,
-                   const OverlappingBlockVector &y)
+    field_type dot(const OverlappingBlockVector& x,
+                   const OverlappingBlockVector& y)
     {
         double sum = 0;
-        int numLocal = overlap_.numLocal();
-        for (int localIdx = 0; localIdx < numLocal; ++localIdx) {
-            if (overlap_.iAmMasterOf(localIdx))
+        size_t numLocal = overlap_.numLocal();
+        for (unsigned localIdx = 0; localIdx < numLocal; ++localIdx) {
+            if (overlap_.iAmMasterOf(static_cast<int>(localIdx)))
                 sum += x[localIdx] * y[localIdx];
         }
 
@@ -77,11 +77,11 @@ public:
         return sumGlobal;
     }
 
-    double norm(const OverlappingBlockVector &x)
+    double norm(const OverlappingBlockVector& x)
     { return std::sqrt(dot(x, x)); }
 
 private:
-    const Overlap &overlap_;
+    const Overlap& overlap_;
 };
 
 } // namespace Linear

--- a/ewoms/linear/overlaptypes.hh
+++ b/ewoms/linear/overlaptypes.hh
@@ -92,7 +92,7 @@ struct IndexDistanceNpeers
 {
     Index index;
     BorderDistance borderDistance;
-    int numPeers;
+    unsigned numPeers;
 };
 
 /*!
@@ -125,12 +125,12 @@ typedef std::list<BorderIndex> BorderList;
 class SeedList : public std::list<IndexRankDist>
 {
 public:
-    void update(const BorderList &borderList)
+    void update(const BorderList& borderList)
     {
         this->clear();
 
         auto it = borderList.begin();
-        const auto &endIt = borderList.end();
+        const auto& endIt = borderList.end();
         for (; it != endIt; ++it) {
             IndexRankDist ird;
             ird.index = it->localIdx;
@@ -148,12 +148,12 @@ public:
 class PeerSet : public std::set<ProcessRank>
 {
 public:
-    void update(const BorderList &borderList)
+    void update(const BorderList& borderList)
     {
         this->clear();
 
         auto it = borderList.begin();
-        const auto &endIt = borderList.end();
+        const auto& endIt = borderList.end();
         for (; it != endIt; ++it)
             this->insert(it->peerRank);
     }

--- a/ewoms/linear/residreductioncriterion.hh
+++ b/ewoms/linear/residreductioncriterion.hh
@@ -29,6 +29,8 @@
 
 #include "convergencecriterion.hh"
 
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/istl/scalarproducts.hh>
 
 namespace Ewoms {
@@ -51,11 +53,11 @@ class ResidReductionCriterion : public ConvergenceCriterion<Vector>
     typedef typename Vector::field_type Scalar;
 
 public:
-    ResidReductionCriterion(Dune::ScalarProduct<Vector> &scalarProduct)
+    ResidReductionCriterion(Dune::ScalarProduct<Vector>& scalarProduct)
         : scalarProduct_(scalarProduct)
     {}
 
-    ResidReductionCriterion(Dune::ScalarProduct<Vector> &scalarProduct,
+    ResidReductionCriterion(Dune::ScalarProduct<Vector>& scalarProduct,
                             Scalar reduction)
         : scalarProduct_(scalarProduct), defectReduction_(reduction)
     {}
@@ -76,9 +78,9 @@ public:
   }
 
     /*!
-     * \copydoc ConvergenceCriterion::setInitial(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::setInitial(const Vector& , const Vector& )
      */
-    void setInitial(const Vector &curSol, const Vector &curResid)
+    void setInitial(const Vector& OPM_UNUSED curSol, const Vector& curResid)
     {
         // make sure that we don't allow an initial error of 0 to avoid
         // divisions by zero
@@ -87,9 +89,9 @@ public:
     }
 
     /*!
-     * \copydoc ConvergenceCriterion::update(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::update(const Vector& , const Vector& )
      */
-    void update(const Vector &curSol, const Vector &curResid)
+    void update(const Vector& OPM_UNUSED curSol, const Vector& curResid)
     { curDefect_ = scalarProduct_.norm(curResid); }
 
     /*!
@@ -107,7 +109,7 @@ public:
     /*!
      * \copydoc ConvergenceCriterion::printInitial()
      */
-    void printInitial(std::ostream &os=std::cout) const
+    void printInitial(std::ostream& os=std::cout) const
     {
         os << std::setw(20) << " Iter ";
         os << std::setw(20) << " Defect ";
@@ -123,7 +125,7 @@ public:
     /*!
      * \copydoc ConvergenceCriterion::print()
      */
-    void print(Scalar iter, std::ostream &os=std::cout) const
+    void print(Scalar iter, std::ostream& os=std::cout) const
     {
         os << std::setw(20) << iter << " ";
         os << std::setw(20) << curDefect_ << " ";
@@ -132,7 +134,7 @@ public:
     }
 
 private:
-    Dune::ScalarProduct<Vector> &scalarProduct_;
+    Dune::ScalarProduct<Vector>& scalarProduct_;
 
     Scalar initialDefect_;
     Scalar curDefect_;

--- a/ewoms/linear/solverpreconditioner.hh
+++ b/ewoms/linear/solverpreconditioner.hh
@@ -28,6 +28,9 @@
 #define EWOMS_SOLVER_PRECONDITIONER_HH
 
 #include <ewoms/linear/solvers.hh>
+
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/istl/preconditioners.hh>
 
 namespace Ewoms {
@@ -53,7 +56,7 @@ public:
 
     enum { category = Dune::SolverCategory::overlapping };
 
-    SolverPreconditioner(const Matrix &matrix, int order, Scalar relaxationFactor)
+    SolverPreconditioner(const Matrix& matrix, int OPM_UNUSED order, Scalar OPM_UNUSED relaxationFactor)
     {
         innerOperator_ = new InnerOperator(matrix);
         innerScalarProduct_ = new InnerScalarProduct;
@@ -78,10 +81,10 @@ public:
         delete innerPreCond_;
     }
 
-    void pre(domain_type &x, range_type &y)
+    void pre(domain_type& OPM_UNUSED x, range_type& OPM_UNUSED y)
     {}
 
-    void apply(domain_type &x, const range_type &d)
+    void apply(domain_type& x, const range_type& d)
     {
         domain_type x0(x);
         range_type dd(d);
@@ -103,7 +106,7 @@ public:
         }
     }
 
-    void post(domain_type &x)
+    void post(domain_type& OPM_UNUSED x)
     {}
 
 private:

--- a/ewoms/linear/solvers.hh
+++ b/ewoms/linear/solvers.hh
@@ -110,14 +110,14 @@ public:
      * \brief Return the criterion to be used to check for convergence of the
      * linear solver.
      */
-    virtual const Ewoms::ConvergenceCriterion<X> &convergenceCriterion() const
+    virtual const Ewoms::ConvergenceCriterion<X>& convergenceCriterion() const
     { return *convergenceCriterion_; }
 
     /*!
      * \brief Return the criterion to be used to check for convergence of the
      * linear solver.
      */
-    virtual Ewoms::ConvergenceCriterion<X> &convergenceCriterion()
+    virtual Ewoms::ConvergenceCriterion<X>& convergenceCriterion()
     { return *convergenceCriterion_; }
 
     /*!
@@ -325,9 +325,9 @@ public:
 
 private:
     Dune::SeqScalarProduct<X> ssp;
-    Dune::LinearOperator<X, X> &_op;
-    Dune::Preconditioner<X, X> &_prec;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::LinearOperator<X, X>& _op;
+    Dune::Preconditioner<X, X>& _prec;
+    Dune::ScalarProduct<X>& _sp;
     std::shared_ptr<ConvergenceCriterion> convergenceCriterion_;
     int _maxit;
     int _verbose;
@@ -458,9 +458,9 @@ public:
 
 private:
     Dune::SeqScalarProduct<X> ssp;
-    Dune::LinearOperator<X, X> &_op;
-    Dune::Preconditioner<X, X> &_prec;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::LinearOperator<X, X>& _op;
+    Dune::Preconditioner<X, X>& _prec;
+    Dune::ScalarProduct<X>& _sp;
     std::shared_ptr<ConvergenceCriterion> convergenceCriterion_;
     int _maxit;
     int _verbose;
@@ -603,9 +603,9 @@ public:
 
 private:
     Dune::SeqScalarProduct<X> ssp;
-    Dune::LinearOperator<X, X> &_op;
-    Dune::Preconditioner<X, X> &_prec;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::LinearOperator<X, X>& _op;
+    Dune::Preconditioner<X, X>& _prec;
+    Dune::ScalarProduct<X>& _sp;
     std::shared_ptr<ConvergenceCriterion> convergenceCriterion_;
     int _maxit;
     int _verbose;
@@ -838,9 +838,9 @@ public:
 
 private:
     Dune::SeqScalarProduct<X> ssp;
-    Dune::LinearOperator<X, X> &_op;
-    Dune::Preconditioner<X, X> &_prec;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::LinearOperator<X, X>& _op;
+    Dune::Preconditioner<X, X>& _prec;
+    Dune::ScalarProduct<X>& _sp;
     std::shared_ptr<ConvergenceCriterion> convergenceCriterion_;
     int _maxit;
     int _verbose;
@@ -1382,10 +1382,10 @@ private :
         dx = temp;
     }
 
-    Dune::LinearOperator<X, X> &_A;
-    Dune::Preconditioner<X, X> &_W;
+    Dune::LinearOperator<X, X>& _A;
+    Dune::Preconditioner<X, X>& _W;
     Dune::SeqScalarProduct<X> ssp;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::ScalarProduct<X>& _sp;
     int _restart;
     int _maxit;
     int _verbose;
@@ -1584,9 +1584,9 @@ public:
 
 private:
     Dune::SeqScalarProduct<X> ssp;
-    Dune::LinearOperator<X, X> &_op;
-    Dune::Preconditioner<X, X> &_prec;
-    Dune::ScalarProduct<X> &_sp;
+    Dune::LinearOperator<X, X>& _op;
+    Dune::Preconditioner<X, X>& _prec;
+    Dune::ScalarProduct<X>& _sp;
     int _maxit;
     int _verbose;
     int _restart;

--- a/ewoms/linear/weightedresidreductioncriterion.hh
+++ b/ewoms/linear/weightedresidreductioncriterion.hh
@@ -59,12 +59,12 @@ class WeightedResidualReductionCriterion : public ConvergenceCriterion<Vector>
     typedef typename Vector::block_type BlockType;
 
 public:
-    WeightedResidualReductionCriterion(const CollectiveCommunication &comm)
+    WeightedResidualReductionCriterion(const CollectiveCommunication& comm)
         : comm_(comm)
     {}
 
-    WeightedResidualReductionCriterion(const CollectiveCommunication &comm,
-                                       const Vector &residWeights,
+    WeightedResidualReductionCriterion(const CollectiveCommunication& comm,
+                                       const Vector& residWeights,
                                        Scalar fixPointTolerance,
                                        Scalar residualReductionTolerance,
                                        Scalar absResidualTolerance = 0.0)
@@ -94,7 +94,7 @@ public:
      * \param residWeightVec A Dune::BlockVector<Dune::FieldVector<Scalar, n> >
      *                  with the relative weights of the linear equations
      */
-    void setResidualWeight(const Vector &residWeightVec)
+    void setResidualWeight(const Vector& residWeightVec)
     { residWeightVec_ = residWeightVec; }
 
     /*!
@@ -103,7 +103,7 @@ public:
      * \param outerIdx The index of the outer vector (i.e. Dune::BlockVector)
      * \param innerIdx The index of the inner vector (i.e. Dune::FieldVector)
      */
-    Scalar residualWeight(int outerIdx, int innerIdx) const
+    Scalar residualWeight(size_t outerIdx, unsigned innerIdx) const
     {
         return (residWeightVec_.size() == 0)
                    ? 1.0
@@ -163,9 +163,9 @@ public:
     { return fixPointError_; }
 
     /*!
-     * \copydoc ConvergenceCriterion::setInitial(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::setInitial(const Vector& , const Vector& )
      */
-    void setInitial(const Vector &curSol, const Vector &curResid)
+    void setInitial(const Vector& curSol, const Vector& curResid)
     {
         lastResidualError_ = 1e100;
 
@@ -181,9 +181,9 @@ public:
     }
 
     /*!
-     * \copydoc ConvergenceCriterion::update(const Vector &, const Vector &)
+     * \copydoc ConvergenceCriterion::update(const Vector& , const Vector& )
      */
-    void update(const Vector &curSol, const Vector &curResid)
+    void update(const Vector& curSol, const Vector& curResid)
     {
         lastResidualError_ = residualError_;
         updateErrors_(curSol, curResid);
@@ -213,7 +213,7 @@ public:
     /*!
      * \copydoc ConvergenceCriterion::printInitial()
      */
-    void printInitial(std::ostream &os = std::cout) const
+    void printInitial(std::ostream& os = std::cout) const
     {
         os << std::setw(20) << " Iter ";
         os << std::setw(20) << " Delta ";
@@ -233,7 +233,7 @@ public:
     /*!
      * \copydoc ConvergenceCriterion::print()
      */
-    void print(Scalar iter, std::ostream &os = std::cout) const
+    void print(Scalar iter, std::ostream& os = std::cout) const
     {
         os << std::setw(20) << iter << " ";
         os << std::setw(20) << fixPointAccuracy() << " ";
@@ -245,12 +245,12 @@ public:
 
 private:
     // update the weighted absolute residual
-    void updateErrors_(const Vector &curSol, const Vector &curResid)
+    void updateErrors_(const Vector& curSol, const Vector& curResid)
     {
         residualError_ = 0.0;
         fixPointError_ = 0.0;
         for (size_t i = 0; i < curResid.size(); ++i) {
-            for (size_t j = 0; j < BlockType::dimension; ++j) {
+            for (unsigned j = 0; j < BlockType::dimension; ++j) {
                 residualError_ =
                     std::max<Scalar>(residualError_,
                                      residualWeight(i, j)*std::abs(curResid[i][j]));
@@ -266,7 +266,7 @@ private:
         fixPointError_ = comm_.max(fixPointError_);
     }
 
-    const CollectiveCommunication &comm_;
+    const CollectiveCommunication& comm_;
 
     // the weights of the components of the residual
     Vector residWeightVec_;

--- a/ewoms/models/blackoil/blackoilboundaryratevector.hh
+++ b/ewoms/models/blackoil/blackoilboundaryratevector.hh
@@ -69,34 +69,34 @@ public:
     {}
 
     /*!
-     * \copydoc ImmiscibleBoundaryRateVector::ImmiscibleBoundaryRateVector(const ImmiscibleBoundaryRateVector &)
+     * \copydoc ImmiscibleBoundaryRateVector::ImmiscibleBoundaryRateVector(const ImmiscibleBoundaryRateVector& )
      */
-    BlackOilBoundaryRateVector(const BlackOilBoundaryRateVector &value)
-        : ParentType(value)
-    {}
-
+    BlackOilBoundaryRateVector(const BlackOilBoundaryRateVector& value) = default;
+    BlackOilBoundaryRateVector& operator=(const BlackOilBoundaryRateVector& value) = default;
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::setFreeFlow
      */
     template <class Context, class FluidState>
-    void setFreeFlow(const Context &context, int bfIdx, int timeIdx,
-                     const FluidState &fluidState)
+    void setFreeFlow(const Context& context,
+                     unsigned bfIdx,
+                     unsigned timeIdx,
+                     const FluidState& fluidState)
     {
         typename FluidSystem::ParameterCache paramCache;
         paramCache.updateAll(fluidState);
 
         ExtensiveQuantities extQuants;
         extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
-        const auto &insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Scalar meanMBoundary = 0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                 meanMBoundary += fluidState.moleFraction(phaseIdx, compIdx)
                                  * FluidSystem::molarMass(compIdx);
 
@@ -106,7 +106,7 @@ public:
             else
                 density = insideIntQuants.fluidState().density(phaseIdx);
 
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 Scalar molarity;
                 if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
                     molarity =
@@ -123,7 +123,7 @@ public:
         }
 
 #ifndef NDEBUG
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             Valgrind::CheckDefined((*this)[i]);
         }
         Valgrind::CheckDefined(*this);
@@ -134,15 +134,17 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setInFlow
      */
     template <class Context, class FluidState>
-    void setInFlow(const Context &context, int bfIdx, int timeIdx,
-                   const FluidState &fluidState)
+    void setInFlow(const Context& context,
+                   unsigned bfIdx,
+                   unsigned timeIdx,
+                   const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the direction opposite to the outer
         // unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Scalar &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Scalar& val = this->operator[](eqIdx);
             val = std::min<Scalar>(0.0, val);
         }
     }
@@ -151,15 +153,17 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setOutFlow
      */
     template <class Context, class FluidState>
-    void setOutFlow(const Context &context, int bfIdx, int timeIdx,
-                    const FluidState &fluidState)
+    void setOutFlow(const Context& context,
+                    unsigned bfIdx,
+                    unsigned timeIdx,
+                    const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the same direction as the outer
         // unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Scalar &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Scalar& val = this->operator[](eqIdx);
             val = std::max<Scalar>(0.0, val);
         }
     }

--- a/ewoms/models/blackoil/blackoilfluidstate.hh
+++ b/ewoms/models/blackoil/blackoilfluidstate.hh
@@ -30,6 +30,11 @@
 
 #include "blackoilproperties.hh"
 
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 namespace Ewoms {
 /*!
  * \ingroup BlackOilModel
@@ -88,24 +93,24 @@ public:
      *        state.
      */
     template <class FluidState>
-    void assign(const FluidState& fs)
+    void assign(const FluidState& OPM_UNUSED fs)
     {
         assert(false); // not yet implemented
     }
 
-    void setPvtRegionIndex(unsigned short newPvtRegionIdx)
-    { pvtRegionIdx_ = newPvtRegionIdx; }
+    void setPvtRegionIndex(unsigned newPvtRegionIdx)
+    { pvtRegionIdx_ = static_cast<unsigned short>(newPvtRegionIdx); }
 
-    void setPressure(int phaseIdx, const Evaluation& p)
+    void setPressure(unsigned phaseIdx, const Evaluation& p)
     { pressure_[phaseIdx] = p; }
 
-    void setSaturation(int phaseIdx, const Evaluation& S)
+    void setSaturation(unsigned phaseIdx, const Evaluation& S)
     { saturation_[phaseIdx] = S; }
 
-    void setInvB(int phaseIdx, const Evaluation& b)
+    void setInvB(unsigned phaseIdx, const Evaluation& b)
     { invB_[phaseIdx] = b; }
 
-    void setDensity(int phaseIdx, const Evaluation& rho)
+    void setDensity(unsigned phaseIdx, const Evaluation& rho)
     { density_[phaseIdx] = rho; }
 
     void setRs(const Evaluation& newRs)
@@ -114,16 +119,13 @@ public:
     void setRv(const Evaluation& newRv)
     { Rv_ = newRv; }
 
-    void setInvB(unsigned phaseIdx, const Evaluation& newb)
-    { invB_[phaseIdx] = newb; }
-
     const Evaluation& pressure(unsigned phaseIdx) const
     { return pressure_[phaseIdx]; }
 
     const Evaluation& saturation(unsigned phaseIdx) const
     { return saturation_[phaseIdx]; }
 
-    const Evaluation& temperature(unsigned phaseIdx) const
+    const Evaluation& temperature(unsigned OPM_UNUSED phaseIdx) const
     { return temperature_; }
 
     const Evaluation& invB(unsigned phaseIdx) const
@@ -136,9 +138,9 @@ public:
     { return Rv_; }
 
     unsigned short pvtRegionIndex() const
-    { return pvtRegionIdx_; };
+    { return pvtRegionIdx_; }
 
-    bool phaseIsPresent(int phaseIdx) const
+    bool phaseIsPresent(unsigned phaseIdx) const
     { return saturation_[phaseIdx] > 0.0; }
 
     //////
@@ -166,13 +168,13 @@ public:
     Evaluation viscosity(unsigned phaseIdx) const
     { return FluidSystem::viscosity(*this, phaseIdx, pvtRegionIdx_); }
 
-    Evaluation enthalpy(unsigned phaseIdx) const
+    Evaluation enthalpy(unsigned OPM_UNUSED phaseIdx) const
     {
         OPM_THROW(Opm::NotImplemented,
                   "The black-oil model does not support energy conservation yet.");
     }
 
-    Evaluation internalEnergy(unsigned phaseIdx) const
+    Evaluation internalEnergy(unsigned OPM_UNUSED phaseIdx) const
     {
         OPM_THROW(Opm::NotImplemented,
                   "The black-oil model does not support energy conservation yet.");
@@ -258,7 +260,7 @@ public:
     Evaluation averageMolarMass(unsigned phaseIdx) const
     {
         Evaluation result(0.0);
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
             result += FluidSystem::molarMass(compIdx, pvtRegionIdx_)*moleFraction(phaseIdx, compIdx);
         return result;
     }

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -69,20 +69,20 @@ public:
      * \copydoc FvBaseLocalResidual::computeStorage
      */
     template <class LhsEval>
-    void computeStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                        const ElementContext &elemCtx,
-                        int dofIdx,
-                        int timeIdx) const
+    void computeStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                        const ElementContext& elemCtx,
+                        unsigned dofIdx,
+                        unsigned timeIdx) const
     {
         // retrieve the intensive quantities for the SCV at the specified point in time
-        const IntensiveQuantities &intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
-        const auto &fs = intQuants.fluidState();
+        const IntensiveQuantities& intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
+        const auto& fs = intQuants.fluidState();
 
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             storage[conti0EqIdx + compIdx] = 0.0;
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            int compIdx = FluidSystem::solventComponentIndex(phaseIdx);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            unsigned compIdx = FluidSystem::solventComponentIndex(phaseIdx);
             LhsEval surfaceVolume =
                 Toolbox::template decay<LhsEval>(fs.saturation(phaseIdx))
                 * Toolbox::template decay<LhsEval>(fs.invB(phaseIdx))
@@ -118,20 +118,20 @@ public:
     /*!
      * \copydoc FvBaseLocalResidual::computeFlux
      */
-    void computeFlux(RateVector &flux,
-                     const ElementContext &elemCtx,
-                     int scvfIdx,
-                     int timeIdx) const
+    void computeFlux(RateVector& flux,
+                     const ElementContext& elemCtx,
+                     unsigned scvfIdx,
+                     unsigned timeIdx) const
     {
         assert(timeIdx == 0);
 
-        for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++ compIdx)
             flux[conti0EqIdx + compIdx] = 0.0;
 
-        const ExtensiveQuantities &extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        const ExtensiveQuantities& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
         unsigned interiorIdx = extQuants.interiorIndex();
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-            unsigned upIdx = extQuants.upstreamIndex(phaseIdx);
+            unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
             const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
             if (upIdx == interiorIdx)
                 evalPhaseFluxes_<Evaluation>(flux, phaseIdx, extQuants, up);
@@ -143,10 +143,10 @@ public:
     /*!
      * \copydoc FvBaseLocalResidual::computeSource
      */
-    void computeSource(RateVector &source,
-                       const ElementContext &elemCtx,
-                       int dofIdx,
-                       int timeIdx) const
+    void computeSource(RateVector& source,
+                       const ElementContext& elemCtx,
+                       unsigned dofIdx,
+                       unsigned timeIdx) const
     {
         // retrieve the source term intrinsic to the problem
         elemCtx.problem().source(source, elemCtx, dofIdx, timeIdx);
@@ -155,12 +155,12 @@ public:
 protected:
     template <class UpEval>
     void evalPhaseFluxes_(RateVector& flux,
-                          int phaseIdx,
+                          unsigned phaseIdx,
                           const ExtensiveQuantities& extQuants,
                           const IntensiveQuantities& up) const
     {
-        int compIdx = FluidSystem::solventComponentIndex(phaseIdx);
-        int pvtRegionIdx = up.pvtRegionIndex();
+        unsigned compIdx = FluidSystem::solventComponentIndex(phaseIdx);
+        unsigned pvtRegionIdx = up.pvtRegionIndex();
         const auto& fs = up.fluidState();
 
         Evaluation surfaceVolumeFlux =

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -32,6 +32,8 @@
 
 #include <ewoms/common/signum.hh>
 
+#include <opm/material/common/Unused.hpp>
+
 namespace Ewoms {
 
 /*!
@@ -51,10 +53,10 @@ class BlackOilNewtonMethod : public GET_PROP_TYPE(TypeTag, DiscNewtonMethod)
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Linearizer) Linearizer;
 
-    static const int numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    static const unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
 
 public:
-    BlackOilNewtonMethod(Simulator &simulator) : ParentType(simulator)
+    BlackOilNewtonMethod(Simulator& simulator) : ParentType(simulator)
     { }
 
     /*!
@@ -69,16 +71,12 @@ public:
      * \brief Returns the number of degrees of freedom for which the
      *        interpretation has changed for the most recent iteration.
      */
-    int numPriVarsSwitched() const
+    unsigned numPriVarsSwitched() const
     { return numPriVarsSwitched_; }
 
-    // HACK which is necessary because GCC 4.4 does not support
-    // being a friend of typedefs
-/*
 protected:
-    friend class NewtonMethod<TypeTag>;
-    friend class ParentType;
-*/
+    friend NewtonMethod<TypeTag>;
+    friend ParentType;
 
     /*!
      * \copydoc FvBaseNewtonMethod::beginIteration_
@@ -92,8 +90,8 @@ protected:
     /*!
      * \copydoc FvBaseNewtonMethod::endIteration_
      */
-    void endIteration_(SolutionVector &uCurrentIter,
-                       const SolutionVector &uLastIter)
+    void endIteration_(SolutionVector& uCurrentIter,
+                       const SolutionVector& uLastIter)
     {
 #if HAVE_MPI
         // in the MPI enabled case we need to add up the number of DOF
@@ -116,13 +114,13 @@ protected:
     /*!
      * \copydoc FvBaseNewtonMethod::updatePrimaryVariables_
      */
-    void updatePrimaryVariables_(int globalDofIdx,
+    void updatePrimaryVariables_(unsigned globalDofIdx,
                                  PrimaryVariables& nextValue,
                                  const PrimaryVariables& currentValue,
                                  const EqVector& update,
-                                 const EqVector& currentResidual)
+                                 const EqVector& OPM_UNUSED currentResidual)
     {
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             // calculate the update of the current primary variable. For the
             // black-oil model we limit the pressure and saturation updates, but do
             // we not clamp anything after the specified number of iterations was

--- a/ewoms/models/blackoil/blackoilproblem.hh
+++ b/ewoms/models/blackoil/blackoilproblem.hh
@@ -32,6 +32,8 @@
 
 #include <ewoms/models/common/multiphasebaseproblem.hh>
 
+#include <opm/material/common/Unused.hpp>
+
 namespace Ewoms {
 
 /*!
@@ -53,7 +55,7 @@ public:
      *
      * \param simulator The manager object of the simulation
      */
-    BlackOilProblem(Simulator &simulator)
+    BlackOilProblem(Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -61,30 +63,36 @@ public:
      * \brief Returns the index of the relevant region for thermodynmic properties
      */
     template <class Context>
-    int pvtRegionIndex(const Context &context, int spaceIdx, int timeIdx) const
+    unsigned pvtRegionIndex(const Context& OPM_UNUSED context,
+                            unsigned OPM_UNUSED spaceIdx,
+                            unsigned OPM_UNUSED timeIdx) const
     { return 0; }
 
     /*!
      * \brief Returns the compressibility of the porous medium of a cell
      */
     template <class Context>
-    Scalar rockCompressibility(const Context &context, int spaceIdx, int timeIdx) const
+    Scalar rockCompressibility(const Context& OPM_UNUSED context,
+                               unsigned OPM_UNUSED spaceIdx,
+                               unsigned OPM_UNUSED timeIdx) const
     { return 0.0; }
 
     /*!
      * \brief Returns the reference pressure for rock the compressibility of a cell
      */
     template <class Context>
-    Scalar rockReferencePressure(const Context &context, int spaceIdx, int timeIdx) const
+    Scalar rockReferencePressure(const Context& OPM_UNUSED context,
+                                 unsigned OPM_UNUSED spaceIdx,
+                                 unsigned OPM_UNUSED timeIdx) const
     { return 1e5; }
 
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation *>(this); }
 
     //! \copydoc asImp_()
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 };
 

--- a/ewoms/models/blackoil/blackoilratevector.hh
+++ b/ewoms/models/blackoil/blackoilratevector.hh
@@ -79,27 +79,27 @@ public:
 
     /*!
      * \copydoc ImmiscibleRateVector::ImmiscibleRateVector(const
-     * ImmiscibleRateVector &)
+     * ImmiscibleRateVector& )
      */
-    BlackOilRateVector(const BlackOilRateVector &value) : ParentType(value)
+    BlackOilRateVector(const BlackOilRateVector& value) : ParentType(value)
     {}
 
     /*!
      * \copydoc ImmiscibleRateVector::setMassRate
      */
-    void setMassRate(const ParentType &value)
+    void setMassRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     {
         // first, assign molar rates
         ParentType::operator=(value);
 
         // then, convert them to mass rates
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] *= FluidSystem::molarMass(compIdx);
     }
 
@@ -107,11 +107,11 @@ public:
      * \copydoc ImmiscibleRateVector::setVolumetricRate
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState,
-                           int phaseIdx,
+    void setVolumetricRate(const FluidState& fluidState,
+                           unsigned phaseIdx,
                            const RhsEval& volume)
     {
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] =
                 fluidState.density(phaseIdx)
                 * fluidState.massFraction(phaseIdx, compIdx)

--- a/ewoms/models/common/energymodule.hh
+++ b/ewoms/models/common/energymodule.hh
@@ -32,6 +32,11 @@
 #include <ewoms/disc/common/fvbaseproperties.hh>
 #include <ewoms/models/common/quantitycallbacks.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <dune/common/fvector.hh>
 
 #include <string>
@@ -85,7 +90,7 @@ public:
      *        string if the specified primary variable index does not belong to
      *        the energy module.
      */
-    static std::string primaryVarName(int pvIdx)
+    static std::string primaryVarName(unsigned OPM_UNUSED pvIdx)
     { return ""; }
 
     /*!
@@ -93,32 +98,32 @@ public:
      *        string if the specified equation index does not belong to
      *        the energy module.
      */
-    static std::string eqName(int eqIdx)
+    static std::string eqName(unsigned OPM_UNUSED eqIdx)
     { return ""; }
 
     /*!
      * \brief Returns the relative weight of a primary variable for
      *        calculating relative errors.
      */
-    static Scalar primaryVarWeight(const Model &model,
-                                   int globalDofIdx,
-                                   int pvIdx)
+    static Scalar primaryVarWeight(const Model& OPM_UNUSED model,
+                                   unsigned OPM_UNUSED globalDofIdx,
+                                   unsigned OPM_UNUSED pvIdx)
     { return -1; }
 
     /*!
      * \brief Returns the relative weight of a equation of the residual.
      */
-    static Scalar eqWeight(const Model &model,
-                           int globalDofIdx,
-                           int eqIdx)
+    static Scalar eqWeight(const Model& OPM_UNUSED model,
+                           unsigned OPM_UNUSED globalDofIdx,
+                           unsigned OPM_UNUSED eqIdx)
     { return -1; }
 
     /*!
      * \brief Given a fluid state, set the temperature in the primary variables
      */
     template <class FluidState>
-    static void setPriVarTemperatures(PrimaryVariables &priVars,
-                                      const FluidState &fs)
+    static void setPriVarTemperatures(PrimaryVariables& OPM_UNUSED priVars,
+                                      const FluidState& OPM_UNUSED fs)
     {}
 
     /*!
@@ -126,30 +131,30 @@ public:
      *        from a volumetric rate.
      */
     template <class FluidState>
-    static void setEnthalpyRate(RateVector &rateVec,
-                                const FluidState &fluidState,
-                                int phaseIdx,
-                                const Evaluation& volume)
+    static void setEnthalpyRate(RateVector& OPM_UNUSED rateVec,
+                                const FluidState& OPM_UNUSED fluidState,
+                                unsigned OPM_UNUSED phaseIdx,
+                                const Evaluation& OPM_UNUSED volume)
     {}
 
     /*!
      * \brief Add the rate of the enthalpy flux to a rate vector.
      */
-    static void setEnthalpyRate(RateVector &rateVec,
-                                const Evaluation& rate)
+    static void setEnthalpyRate(RateVector& OPM_UNUSED rateVec,
+                                const Evaluation& OPM_UNUSED rate)
     {}
 
     /*!
      * \brief Add the rate of the enthalpy flux to a rate vector.
      */
-    static void addToEnthalpyRate(RateVector &rateVec,
-                                  const Evaluation& rate)
+    static void addToEnthalpyRate(RateVector& OPM_UNUSED rateVec,
+                                  const Evaluation& OPM_UNUSED rate)
     {}
 
     /*!
      * \brief Add the rate of the conductive heat flux to a rate vector.
      */
-    static Scalar heatConductionRate(const ExtensiveQuantities &extQuants)
+    static Scalar heatConductionRate(const ExtensiveQuantities& OPM_UNUSED extQuants)
     { return 0.0; }
 
     /*!
@@ -157,9 +162,9 @@ public:
      * vector
      */
     template <class LhsEval>
-    static void addPhaseStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                const IntensiveQuantities &intQuants,
-                                int phaseIdx)
+    static void addPhaseStorage(Dune::FieldVector<LhsEval, numEq>& OPM_UNUSED storage,
+                                const IntensiveQuantities& OPM_UNUSED intQuants,
+                                unsigned OPM_UNUSED phaseIdx)
     {}
 
     /*!
@@ -167,10 +172,10 @@ public:
      * vector
      */
     template <class LhsEval, class Scv>
-    static void addFracturePhaseStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                        const IntensiveQuantities& intQuants,
-                                        const Scv& scv,
-                                        int phaseIdx)
+    static void addFracturePhaseStorage(Dune::FieldVector<LhsEval, numEq>& OPM_UNUSED storage,
+                                        const IntensiveQuantities& OPM_UNUSED intQuants,
+                                        const Scv& OPM_UNUSED scv,
+                                        unsigned OPM_UNUSED phaseIdx)
     {}
 
     /*!
@@ -178,8 +183,8 @@ public:
      *        equation vector
      */
     template <class LhsEval>
-    static void addSolidHeatStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                    const IntensiveQuantities& intQuants)
+    static void addSolidHeatStorage(Dune::FieldVector<LhsEval, numEq>& OPM_UNUSED storage,
+                                    const IntensiveQuantities& OPM_UNUSED intQuants)
     {}
 
     /*!
@@ -189,10 +194,10 @@ public:
      * This method is called by compute flux (base class)
      */
     template <class Context>
-    static void addAdvectiveFlux(RateVector &flux,
-                                 const Context &context,
-                                 int spaceIdx,
-                                 int timeIdx)
+    static void addAdvectiveFlux(RateVector& OPM_UNUSED flux,
+                                 const Context& OPM_UNUSED context,
+                                 unsigned OPM_UNUSED spaceIdx,
+                                 unsigned OPM_UNUSED timeIdx)
     {}
 
     /*!
@@ -201,10 +206,10 @@ public:
      *        volume and adds the result in the flux vector.
      */
     template <class Context>
-    static void handleFractureFlux(RateVector &flux,
-                                   const Context &context,
-                                   int spaceIdx,
-                                   int timeIdx)
+    static void handleFractureFlux(RateVector& OPM_UNUSED flux,
+                                   const Context& OPM_UNUSED context,
+                                   unsigned OPM_UNUSED spaceIdx,
+                                   unsigned OPM_UNUSED timeIdx)
     {}
 
     /*!
@@ -214,10 +219,10 @@ public:
      * This method is called by compute flux (base class)
      */
     template <class Context>
-    static void addDiffusiveFlux(RateVector &flux,
-                                 const Context &context,
-                                 int spaceIdx,
-                                 int timeIdx)
+    static void addDiffusiveFlux(RateVector& OPM_UNUSED flux,
+                                 const Context& OPM_UNUSED context,
+                                 unsigned OPM_UNUSED spaceIdx,
+                                 unsigned OPM_UNUSED timeIdx)
     {}
 };
 
@@ -258,7 +263,7 @@ public:
      *        string if the specified primary variable index does not belong to
      *        the energy module.
      */
-    static std::string primaryVarName(int pvIdx)
+    static std::string primaryVarName(unsigned pvIdx)
     {
         if (pvIdx == temperatureIdx)
             return "temperature";
@@ -270,7 +275,7 @@ public:
      *        string if the specified equation index does not belong to
      *        the energy module.
      */
-    static std::string eqName(int eqIdx)
+    static std::string eqName(unsigned eqIdx)
     {
         if (eqIdx == energyEqIdx)
             return "energy";
@@ -281,7 +286,7 @@ public:
      * \brief Returns the relative weight of a primary variable for
      *        calculating relative errors.
      */
-    static Scalar primaryVarWeight(const Model &model, int globalDofIdx, int pvIdx)
+    static Scalar primaryVarWeight(const Model& model, unsigned globalDofIdx, unsigned pvIdx)
     {
         if (pvIdx != temperatureIdx)
             return -1;
@@ -293,9 +298,9 @@ public:
     /*!
      * \brief Returns the relative weight of a equation.
      */
-    static Scalar eqWeight(const Model &model,
-                           int globalDofIdx,
-                           int eqIdx)
+    static Scalar eqWeight(const Model& OPM_UNUSED model,
+                           unsigned OPM_UNUSED globalDofIdx,
+                           unsigned eqIdx)
     {
         if (eqIdx != energyEqIdx)
             return -1;
@@ -307,20 +312,20 @@ public:
     /*!
      * \brief Add the rate of the enthalpy flux to a rate vector.
      */
-    static void setEnthalpyRate(RateVector &rateVec, const Evaluation& rate)
+    static void setEnthalpyRate(RateVector& rateVec, const Evaluation& rate)
     { rateVec[energyEqIdx] = rate; }
 
     /*!
      * \brief Add the rate of the enthalpy flux to a rate vector.
      */
-    static void addToEnthalpyRate(RateVector &rateVec, const Evaluation& rate)
+    static void addToEnthalpyRate(RateVector& rateVec, const Evaluation& rate)
     { rateVec[energyEqIdx] += rate; }
 
     /*!
      * \brief Returns the rate of the conductive heat flux for a given flux
      *        integration point.
      */
-    static Evaluation heatConductionRate(const ExtensiveQuantities &extQuants)
+    static Evaluation heatConductionRate(const ExtensiveQuantities& extQuants)
     { return -extQuants.temperatureGradNormal() * extQuants.heatConductivity(); }
 
     /*!
@@ -328,8 +333,9 @@ public:
      *        from a volumetric rate.
      */
     template <class FluidState>
-    static void setEnthalpyRate(RateVector &rateVec,
-                                const FluidState &fluidState, int phaseIdx,
+    static void setEnthalpyRate(RateVector& rateVec,
+                                const FluidState& fluidState,
+                                unsigned phaseIdx,
                                 Scalar volume)
     {
         rateVec[energyEqIdx] =
@@ -342,12 +348,12 @@ public:
      * \brief Given a fluid state, set the temperature in the primary variables
      */
     template <class FluidState>
-    static void setPriVarTemperatures(PrimaryVariables &priVars,
-                                      const FluidState &fs)
+    static void setPriVarTemperatures(PrimaryVariables& priVars,
+                                      const FluidState& fs)
     {
         priVars[temperatureIdx] = Toolbox::value(fs.temperature(/*phaseIdx=*/0));
 #ifndef NDEBUG
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             assert(std::abs(Toolbox::value(fs.temperature(/*phaseIdx=*/0))
                             - Toolbox::value(fs.temperature(phaseIdx))) < 1e-30);
         }
@@ -359,10 +365,11 @@ public:
      * vector
      */
     template <class LhsEval>
-    static void addPhaseStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                const IntensiveQuantities &intQuants, int phaseIdx)
+    static void addPhaseStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                                const IntensiveQuantities& intQuants,
+                                unsigned phaseIdx)
     {
-        const auto &fs = intQuants.fluidState();
+        const auto& fs = intQuants.fluidState();
         storage[energyEqIdx] +=
             Toolbox::template decay<LhsEval>(fs.density(phaseIdx))
             * Toolbox::template decay<LhsEval>(fs.internalEnergy(phaseIdx))
@@ -375,11 +382,12 @@ public:
      * vector
      */
     template <class Scv, class LhsEval>
-    static void addFracturePhaseStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                        const IntensiveQuantities &intQuants,
-                                        const Scv &scv, int phaseIdx)
+    static void addFracturePhaseStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                                        const IntensiveQuantities& intQuants,
+                                        const Scv& scv,
+                                        unsigned phaseIdx)
     {
-        const auto &fs = intQuants.fractureFluidState();
+        const auto& fs = intQuants.fractureFluidState();
         storage[energyEqIdx] +=
             Toolbox::template decay<LhsEval>(fs.density(phaseIdx))
             * Toolbox::template decay<LhsEval>(fs.internalEnergy(phaseIdx))
@@ -393,8 +401,8 @@ public:
      * vector
      */
     template <class LhsEval>
-    static void addSolidHeatStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                                    const IntensiveQuantities &intQuants)
+    static void addSolidHeatStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                                    const IntensiveQuantities& intQuants)
     {
         storage[energyEqIdx] +=
             Toolbox::template decay<LhsEval>(intQuants.heatCapacitySolid())
@@ -408,18 +416,21 @@ public:
      * This method is called by compute flux (base class)
      */
     template <class Context>
-    static void addAdvectiveFlux(RateVector &flux, const Context &context, int spaceIdx, int timeIdx)
+    static void addAdvectiveFlux(RateVector& flux,
+                                 const Context& context,
+                                 unsigned spaceIdx,
+                                 unsigned timeIdx)
     {
-        const auto &extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
+        const auto& extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
 
         // advective heat flux in all phases
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!context.model().phaseIsConsidered(phaseIdx))
                 continue;
 
             // intensive quantities of the upstream and the downstream DOFs
-            const IntensiveQuantities &up =
-                context.intensiveQuantities(extQuants.upstreamIndex(phaseIdx), timeIdx);
+            unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
+            const IntensiveQuantities& up = context.intensiveQuantities(upIdx, timeIdx);
 
             flux[energyEqIdx] +=
                 extQuants.volumeFlux(phaseIdx)
@@ -434,11 +445,13 @@ public:
      *        vector.
      */
     template <class Context>
-    static void handleFractureFlux(RateVector &flux, const Context &context,
-                                   int spaceIdx, int timeIdx)
+    static void handleFractureFlux(RateVector& flux,
+                                   const Context& context,
+                                   unsigned spaceIdx,
+                                   unsigned timeIdx)
     {
-        const auto &scvf = context.stencil(timeIdx).interiorFace(spaceIdx);
-        const auto &extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
+        const auto& scvf = context.stencil(timeIdx).interiorFace(spaceIdx);
+        const auto& extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
 
         // reduce the heat flux in the matrix by the half the width
         // occupied by the fracture
@@ -446,13 +459,13 @@ public:
             1 - extQuants.fractureWidth()/(2*scvf.area());
 
         // advective heat flux in all phases
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!context.model().phaseIsConsidered(phaseIdx))
                 continue;
 
             // intensive quantities of the upstream and the downstream DOFs
-            const IntensiveQuantities &up =
-                context.intensiveQuantities(extQuants.upstreamIndex(phaseIdx), timeIdx);
+            unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
+            const IntensiveQuantities& up = context.intensiveQuantities(upIdx, timeIdx);
 
             flux[energyEqIdx] +=
                 extQuants.fractureVolumeFlux(phaseIdx)
@@ -468,10 +481,12 @@ public:
      * This method is called by compute flux (base class)
      */
     template <class Context>
-    static void addDiffusiveFlux(RateVector &flux, const Context &context,
-                                 int spaceIdx, int timeIdx)
+    static void addDiffusiveFlux(RateVector& flux,
+                                 const Context& context,
+                                 unsigned spaceIdx,
+                                 unsigned timeIdx)
     {
-        const auto &extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
+        const auto& extQuants = context.extensiveQuantities(spaceIdx, timeIdx);
 
         // diffusive heat flux
         flux[energyEqIdx] +=
@@ -486,13 +501,13 @@ public:
  *
  * \brief Provides the indices required for the energy equation.
  */
-template <int PVOffset, bool enableEnergy>
+template <unsigned PVOffset, bool enableEnergy>
 struct EnergyIndices;
 
 /*!
  * \copydoc Ewoms::EnergyIndices
  */
-template <int PVOffset>
+template <unsigned PVOffset>
 struct EnergyIndices<PVOffset, /*enableEnergy=*/false>
 {
 protected:
@@ -502,7 +517,7 @@ protected:
 /*!
  * \copydoc Ewoms::EnergyIndices
  */
-template <int PVOffset>
+template <unsigned PVOffset>
 struct EnergyIndices<PVOffset, /*enableEnergy=*/true>
 {
     //! The index of the primary variable representing temperature
@@ -565,9 +580,10 @@ protected:
      * \brief Update the temperatures of the fluids of a fluid state.
      */
     template <class FluidState, class Context>
-    static void updateTemperatures_(FluidState &fluidState,
-                                    const Context &context, int spaceIdx,
-                                    int timeIdx)
+    static void updateTemperatures_(FluidState& fluidState,
+                                    const Context& context,
+                                    unsigned spaceIdx,
+                                    unsigned timeIdx)
     {
         Scalar T = context.problem().temperature(context, spaceIdx, timeIdx);
         fluidState.setTemperature(Toolbox::createConstant(T));
@@ -578,11 +594,11 @@ protected:
      *        energy fluxes.
      */
     template <class FluidState>
-    void update_(FluidState &fs,
-                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache,
-                 const ElementContext &elemCtx,
-                 int dofIdx,
-                 int timeIdx)
+    void update_(FluidState& OPM_UNUSED fs,
+                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& OPM_UNUSED paramCache,
+                 const ElementContext& OPM_UNUSED elemCtx,
+                 unsigned OPM_UNUSED dofIdx,
+                 unsigned OPM_UNUSED timeIdx)
     { }
 };
 
@@ -610,9 +626,10 @@ protected:
      * \brief Update the temperatures of the fluids of a fluid state.
      */
     template <class FluidState, class Context>
-    static void updateTemperatures_(FluidState &fluidState,
-                                    const Context &context, int spaceIdx,
-                                    int timeIdx)
+    static void updateTemperatures_(FluidState& fluidState,
+                                    const Context& context,
+                                    unsigned spaceIdx,
+                                    unsigned timeIdx)
     {
         const auto& priVars = context.primaryVars(spaceIdx, timeIdx);
         Evaluation val;
@@ -629,14 +646,14 @@ protected:
      *        energy fluxes.
      */
     template <class FluidState>
-    void update_(FluidState &fs,
-                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache,
-                 const ElementContext &elemCtx,
-                 int dofIdx,
-                 int timeIdx)
+    void update_(FluidState& fs,
+                 typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache,
+                 const ElementContext& elemCtx,
+                 unsigned dofIdx,
+                 unsigned timeIdx)
     {
         // set the specific enthalpies of the fluids
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!elemCtx.model().phaseIsConsidered(phaseIdx))
                 continue;
 
@@ -645,8 +662,8 @@ protected:
         }
 
         // compute and set the heat capacity of the solid phase
-        const auto &problem = elemCtx.problem();
-        const auto &heatCondParams = problem.heatConductionParams(elemCtx, dofIdx, timeIdx);
+        const auto& problem = elemCtx.problem();
+        const auto& heatCondParams = problem.heatConductionParams(elemCtx, dofIdx, timeIdx);
 
         heatCapacitySolid_ = problem.heatCapacitySolid(elemCtx, dofIdx, timeIdx);
         heatConductivity_ =
@@ -701,12 +718,16 @@ protected:
      * \brief Update the quantities required to calculate
      *        energy fluxes.
      */
-    void update_(const ElementContext &elemCtx, int faceIdx, int timeIdx)
+    void update_(const ElementContext& OPM_UNUSED elemCtx,
+                 unsigned OPM_UNUSED faceIdx,
+                 unsigned OPM_UNUSED timeIdx)
     {}
 
     template <class Context, class FluidState>
-    void updateBoundary_(const Context &context, int bfIdx, int timeIdx,
-                         const FluidState &fs)
+    void updateBoundary_(const Context& OPM_UNUSED context,
+                         unsigned OPM_UNUSED bfIdx,
+                         unsigned OPM_UNUSED timeIdx,
+                         const FluidState& OPM_UNUSED fs)
     {}
 
 public:
@@ -750,7 +771,7 @@ protected:
      * \brief Update the quantities required to calculate
      *        energy fluxes.
      */
-    void update_(const ElementContext &elemCtx, int faceIdx, int timeIdx)
+    void update_(const ElementContext& elemCtx, unsigned faceIdx, unsigned timeIdx)
     {
         const auto& gradCalc = elemCtx.gradientCalculator();
         Ewoms::TemperatureCallback<TypeTag> temperatureCallback(elemCtx);
@@ -762,15 +783,15 @@ protected:
                                    temperatureCallback);
 
         // scalar product of temperature gradient and scvf normal
-        const auto &face = elemCtx.stencil(/*timeIdx=*/0).interiorFace(faceIdx);
+        const auto& face = elemCtx.stencil(/*timeIdx=*/0).interiorFace(faceIdx);
 
         temperatureGradNormal_ = 0;
-        for (int dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
+        for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
             temperatureGradNormal_ += (face.normal()[dimIdx]*temperatureGrad[dimIdx]);
 
-        const auto &extQuants = elemCtx.extensiveQuantities(faceIdx, timeIdx);
-        const auto &intQuantsInside = elemCtx.intensiveQuantities(extQuants.interiorIndex(), timeIdx);
-        const auto &intQuantsOutside = elemCtx.intensiveQuantities(extQuants.exteriorIndex(), timeIdx);
+        const auto& extQuants = elemCtx.extensiveQuantities(faceIdx, timeIdx);
+        const auto& intQuantsInside = elemCtx.intensiveQuantities(extQuants.interiorIndex(), timeIdx);
+        const auto& intQuantsOutside = elemCtx.intensiveQuantities(extQuants.exteriorIndex(), timeIdx);
 
         // arithmetic mean
         heatConductivity_ =
@@ -779,24 +800,24 @@ protected:
     }
 
     template <class Context, class FluidState>
-    void updateBoundary_(const Context &context, int bfIdx, int timeIdx, const FluidState &fs)
+    void updateBoundary_(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fs)
     {
-        const auto &stencil = context.stencil(timeIdx);
-        const auto &face = stencil.boundaryFace(bfIdx);
+        const auto& stencil = context.stencil(timeIdx);
+        const auto& face = stencil.boundaryFace(bfIdx);
 
-        const auto &elemCtx = context.elementContext();
-        int insideScvIdx = face.interiorIndex();
-        const auto &insideScv = elemCtx.stencil(timeIdx).subControlVolume(insideScvIdx);
+        const auto& elemCtx = context.elementContext();
+        unsigned insideScvIdx = face.interiorIndex();
+        const auto& insideScv = elemCtx.stencil(timeIdx).subControlVolume(insideScvIdx);
 
-        const auto &intQuantsInside = elemCtx.intensiveQuantities(insideScvIdx, timeIdx);
-        const auto &fsInside = intQuantsInside.fluidState();
+        const auto& intQuantsInside = elemCtx.intensiveQuantities(insideScvIdx, timeIdx);
+        const auto& fsInside = intQuantsInside.fluidState();
 
         // distance between the center of the SCV and center of the boundary face
         DimVector distVec = face.integrationPos();
         distVec -= insideScv.geometry().center();
 
         Scalar tmp = 0;
-        for (int dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
+        for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
             tmp += distVec[dimIdx] * face.normal()[dimIdx];
         Scalar dist = tmp;
 

--- a/ewoms/models/common/multiphasebaseextensivequantities.hh
+++ b/ewoms/models/common/multiphasebaseextensivequantities.hh
@@ -34,6 +34,9 @@
 #include <ewoms/disc/common/fvbaseextensivequantities.hh>
 #include <ewoms/common/parametersystem.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/common/fvector.hh>
 
 namespace Ewoms {
@@ -77,7 +80,7 @@ public:
      *                which the extensive quantities should be calculated.
      * \param timeIdx The index used by the time discretization.
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
 
@@ -86,7 +89,7 @@ public:
 
         // Check whether the pressure potential is in the same direction as the face
         // normal or in the opposite one
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!elemCtx.model().phaseIsConsidered(phaseIdx)) {
                 Valgrind::SetUndefined(upstreamScvIdx_[phaseIdx]);
                 Valgrind::SetUndefined(downstreamScvIdx_[phaseIdx]);
@@ -112,11 +115,11 @@ public:
      * \param paramCache The FluidSystem's parameter cache.
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context,
-                        int bfIdx,
-                        int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
 
@@ -137,7 +140,7 @@ public:
      * \param phaseIdx The index of the fluid phase for which the upstream
      *                 direction is requested.
      */
-    short upstreamIndex(int phaseIdx) const
+    short upstreamIndex(unsigned phaseIdx) const
     { return upstreamScvIdx_[phaseIdx]; }
 
     /*!
@@ -147,7 +150,7 @@ public:
      * \param phaseIdx The index of the fluid phase for which the downstream
      *                 direction is requested.
      */
-    short downstreamIndex(int phaseIdx) const
+    short downstreamIndex(unsigned phaseIdx) const
     { return downstreamScvIdx_[phaseIdx]; }
 
     /*!
@@ -156,7 +159,7 @@ public:
      *
      * \param phaseIdx The index of the fluid phase
      */
-    Scalar upstreamWeight(int phaseIdx) const
+    Scalar upstreamWeight(unsigned OPM_UNUSED phaseIdx) const
     { return 1.0; }
 
     /*!
@@ -165,7 +168,7 @@ public:
      *
      * \param phaseIdx The index of the fluid phase
      */
-    Scalar downstreamWeight(int phaseIdx) const
+    Scalar downstreamWeight(unsigned phaseIdx) const
     { return 1.0 - upstreamWeight(phaseIdx); }
 
 private:

--- a/ewoms/models/common/multiphasebasemodel.hh
+++ b/ewoms/models/common/multiphasebasemodel.hh
@@ -29,6 +29,7 @@
 #define EWOMS_MULTI_PHASE_BASE_MODEL_HH
 
 #include <opm/material/densead/Math.hpp>
+
 #include "multiphasebaseproperties.hh"
 #include "multiphasebaseproblem.hh"
 #include "multiphasebaseextensivequantities.hh"
@@ -39,8 +40,7 @@
 #include <opm/material/fluidmatrixinteractions/NullMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 #include <opm/material/heatconduction/DummyHeatConductionLaw.hpp>
-
-#include <dune/common/unused.hh>
+#include <opm/material/common/Unused.hpp>
 
 namespace Ewoms {
 template <class TypeTag>
@@ -137,7 +137,7 @@ class MultiPhaseBaseModel : public GET_PROP_TYPE(TypeTag, Discretization)
     enum { numComponents = FluidSystem::numComponents };
 
 public:
-    MultiPhaseBaseModel(Simulator &simulator)
+    MultiPhaseBaseModel(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -164,7 +164,7 @@ public:
         // large grids the tolerance needs to be reduced because the total mass lost
         // would be too large.)
         Scalar minDofVolume = 1e100;
-        for (size_t globalDofIdx = 0; globalDofIdx < this->numGridDof(); ++ globalDofIdx)
+        for (unsigned globalDofIdx = 0; globalDofIdx < this->numGridDof(); ++ globalDofIdx)
             if (this->isLocalDof(globalDofIdx))
                 minDofVolume = std::min(minDofVolume, this->dofTotalVolume(globalDofIdx));
         minDofVolume = this->gridView().comm().min(minDofVolume);
@@ -179,7 +179,7 @@ public:
      *
      * \param phaseIdx The index of the fluid phase in question
      */
-    bool phaseIsConsidered(unsigned phaseIdx) const
+    bool phaseIsConsidered(unsigned OPM_UNUSED phaseIdx) const
     { return true; }
 
     /*!
@@ -189,7 +189,7 @@ public:
      * \copydetails Doxygen::storageParam
      * \copydetails Doxygen::phaseIdxParam
      */
-    void globalPhaseStorage(EqVector &storage, unsigned phaseIdx)
+    void globalPhaseStorage(EqVector& storage, unsigned phaseIdx)
     {
         assert(0 <= phaseIdx && phaseIdx < numPhases);
 
@@ -203,7 +203,7 @@ public:
         {
             // Attention: the variables below are thread specific and thus cannot be
             // moved in front of the #pragma!
-            int threadId = ThreadManager::threadId();
+            unsigned threadId = ThreadManager::threadId();
             ElementContext elemCtx(this->simulator_);
             ElementIterator elemIt = threadedElemIt.beginParallel();
             EqVector tmp;
@@ -216,11 +216,11 @@ public:
                 elemCtx.updateStencil(elem);
                 elemCtx.updateIntensiveQuantities(/*timeIdx=*/0);
 
-                const auto &stencil = elemCtx.stencil(/*timeIdx=*/0);
+                const auto& stencil = elemCtx.stencil(/*timeIdx=*/0);
 
                 for (unsigned dofIdx = 0; dofIdx < elemCtx.numDof(/*timeIdx=*/0); ++dofIdx) {
-                    const auto &scv = stencil.subControlVolume(dofIdx);
-                    const auto &intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
+                    const auto& scv = stencil.subControlVolume(dofIdx);
+                    const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
 
                     tmp = 0;
                     this->localResidual(threadId).addPhaseStorage(tmp,
@@ -250,7 +250,7 @@ public:
     }
 
 private:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 };
 } // namespace Ewoms

--- a/ewoms/models/common/multiphasebaseproblem.hh
+++ b/ewoms/models/common/multiphasebaseproblem.hh
@@ -35,6 +35,9 @@
 
 #include <opm/material/fluidmatrixinteractions/NullMaterial.hpp>
 #include <opm/material/common/Means.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -77,9 +80,9 @@ class MultiPhaseBaseProblem
 
 public:
     /*!
-     * \copydoc Problem::FvBaseProblem(Simulator &)
+     * \copydoc Problem::FvBaseProblem(Simulator& )
      */
-    MultiPhaseBaseProblem(Simulator &simulator)
+    MultiPhaseBaseProblem(Simulator& simulator)
         : ParentType(simulator)
     { init_(); }
 
@@ -104,19 +107,20 @@ public:
      * problem (if a finite-volume discretization is used).
      */
     template <class Context>
-    void intersectionIntrinsicPermeability(DimMatrix &result,
-                                           const Context &context,
-                                           int intersectionIdx, int timeIdx) const
+    void intersectionIntrinsicPermeability(DimMatrix& result,
+                                           const Context& context,
+                                           unsigned intersectionIdx,
+                                           unsigned timeIdx) const
     {
-        const auto &scvf = context.stencil(timeIdx).interiorFace(intersectionIdx);
+        const auto& scvf = context.stencil(timeIdx).interiorFace(intersectionIdx);
 
-        const DimMatrix &K1 = asImp_().intrinsicPermeability(context, scvf.interiorIndex(), timeIdx);
-        const DimMatrix &K2 = asImp_().intrinsicPermeability(context, scvf.exteriorIndex(), timeIdx);
+        const DimMatrix& K1 = asImp_().intrinsicPermeability(context, scvf.interiorIndex(), timeIdx);
+        const DimMatrix& K2 = asImp_().intrinsicPermeability(context, scvf.exteriorIndex(), timeIdx);
 
         // entry-wise harmonic mean. this is almost certainly wrong if
         // you have off-main diagonal entries in your permeabilities!
-        for (int i = 0; i < dimWorld; ++i)
-            for (int j = 0; j < dimWorld; ++j)
+        for (unsigned i = 0; i < dimWorld; ++i)
+            for (unsigned j = 0; j < dimWorld; ++j)
                 result[i][j] = Opm::harmonicMean(K1[i][j], K2[i][j]);
     }
 
@@ -134,8 +138,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context,
-                                           int spaceIdx, int timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& OPM_UNUSED context,
+                                           unsigned OPM_UNUSED spaceIdx,
+                                           unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: Problem::intrinsicPermeability()");
@@ -151,8 +156,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar porosity(const Context &context,
-                    int spaceIdx, int timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: Problem::porosity()");
@@ -168,11 +174,12 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar heatCapacitySolid(const Context &context,
-                             int spaceIdx, int timeIdx) const
+    Scalar heatCapacitySolid(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
-                   "Not implemented: Problem::heatCapacitySolid()");
+                  "Not implemented: Problem::heatCapacitySolid()");
     }
 
     /*!
@@ -186,7 +193,9 @@ public:
      */
     template <class Context>
     const HeatConductionLawParams&
-    heatConductionParams(const Context &context, int spaceIdx, int timeIdx) const
+    heatConductionParams(const Context& OPM_UNUSED context,
+                         unsigned OPM_UNUSED spaceIdx,
+                         unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: Problem::heatConductionParams()");
@@ -201,10 +210,12 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar tortuosity(const Context &context, int spaceIdx, int timeIdx) const
+    Scalar tortuosity(const Context& OPM_UNUSED context,
+                      unsigned OPM_UNUSED spaceIdx,
+                      unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
-                   "Not implemented: Problem::tortuosity()");
+                  "Not implemented: Problem::tortuosity()");
     }
 
     /*!
@@ -216,8 +227,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar dispersivity(const Context &context,
-                        int spaceIdx, int timeIdx) const
+    Scalar dispersivity(const Context& OPM_UNUSED context,
+                        unsigned OPM_UNUSED spaceIdx,
+                        unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                   "Not implemented: Problem::dispersivity()");
@@ -238,7 +250,9 @@ public:
      */
     template <class Context>
     const MaterialLawParams &
-    materialLawParams(const Context &context, int spaceIdx, int timeIdx) const
+    materialLawParams(const Context& OPM_UNUSED context,
+                      unsigned OPM_UNUSED spaceIdx,
+                      unsigned OPM_UNUSED timeIdx) const
     {
         static MaterialLawParams dummy;
         return dummy;
@@ -253,8 +267,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar temperature(const Context &context,
-                       int spaceIdx, int timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return asImp_().temperature(); }
 
     /*!
@@ -278,8 +293,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    const DimVector &gravity(const Context &context,
-                             int spaceIdx, int timeIdx) const
+    const DimVector& gravity(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     { return asImp_().gravity(); }
 
     /*!
@@ -291,7 +307,7 @@ public:
      * property is true, \f$\boldsymbol{g} = ( 0,\dots,\ -9.81)^T \f$ holds,
      * else \f$\boldsymbol{g} = ( 0,\dots, 0)^T \f$.
      */
-    const DimVector &gravity() const
+    const DimVector& gravity() const
     { return gravity_; }
 
     /*!
@@ -299,11 +315,11 @@ public:
      *
      * \return The number of elements marked for refinement or coarsening.
      */
-    int markForGridAdaptation()
+    unsigned markForGridAdaptation()
     {
         typedef Opm::MathToolbox<Evaluation> Toolbox;
 
-        int numMarked = 0;
+        unsigned numMarked = 0;
         ElementContext elemCtx( this->simulator() );
         auto gridView = this->simulator().gridManager().gridView();
         auto& grid = this->simulator().gridManager().grid();
@@ -315,11 +331,11 @@ public:
             elemCtx.updateAll( element );
 
             // HACK: this should better be part of an AdaptionCriterion class
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 Scalar minSat = 1e100 ;
                 Scalar maxSat = -1e100;
-                const int nDofs = elemCtx.numDof(/*timeIdx=*/0);
-                for (int dofIdx = 0; dofIdx < nDofs; ++dofIdx)
+                size_t nDofs = elemCtx.numDof(/*timeIdx=*/0);
+                for (unsigned dofIdx = 0; dofIdx < nDofs; ++dofIdx)
                 {
                     const auto& intQuant = elemCtx.intensiveQuantities( dofIdx, /*timeIdx=*/0 );
                     minSat = std::min(minSat,
@@ -367,7 +383,7 @@ protected:
     DimMatrix toDimMatrix_(Scalar val) const
     {
         DimMatrix ret(0.0);
-        for (int i = 0; i < DimMatrix::rows; ++i)
+        for (unsigned i = 0; i < DimMatrix::rows; ++i)
             ret[i][i] = val;
         return ret;
     }
@@ -376,10 +392,10 @@ protected:
 
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation *>(this); }
     //! \copydoc asImp_()
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 
     void init_()

--- a/ewoms/models/common/quantitycallbacks.hh
+++ b/ewoms/models/common/quantitycallbacks.hh
@@ -33,6 +33,7 @@
 #include <ewoms/disc/common/fvbaseproperties.hh>
 
 #include <opm/material/common/MathToolbox.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <type_traits>
 
@@ -64,7 +65,7 @@ public:
      * In this context, we assume that thermal equilibrium applies,
      * i.e. that the temperature of all phases is equal.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     { return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().temperature(/*phaseIdx=*/0); }
 
 private:
@@ -91,23 +92,23 @@ public:
         : elemCtx_(elemCtx)
     { Valgrind::SetUndefined(phaseIdx_); }
 
-    PressureCallback(const ElementContext& elemCtx, short phaseIdx)
+    PressureCallback(const ElementContext& elemCtx, unsigned phaseIdx)
         : elemCtx_(elemCtx)
-        , phaseIdx_(phaseIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which the pressure
      *        should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Return the pressure of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().pressure(phaseIdx_);
@@ -115,7 +116,7 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short phaseIdx_;
+    unsigned short phaseIdx_;
 };
 
 /*!
@@ -144,24 +145,24 @@ public:
 
     BoundaryPressureCallback(const ElementContext& elemCtx,
                              const FluidState& boundaryFs,
-                             short phaseIdx)
+                             unsigned phaseIdx)
         : elemCtx_(elemCtx)
         , boundaryFs_(boundaryFs)
-        , phaseIdx_(phaseIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which the pressure
      *        should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Return the pressure of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().pressure(phaseIdx_);
@@ -176,7 +177,7 @@ public:
 private:
     const ElementContext& elemCtx_;
     const FluidState& boundaryFs_;
-    short phaseIdx_;
+    unsigned short phaseIdx_;
 };
 
 /*!
@@ -199,23 +200,23 @@ public:
         : elemCtx_(elemCtx)
     { Valgrind::SetUndefined(phaseIdx_); }
 
-    DensityCallback(const ElementContext& elemCtx, short phaseIdx)
+    DensityCallback(const ElementContext& elemCtx, unsigned phaseIdx)
         : elemCtx_(elemCtx)
-        , phaseIdx_(phaseIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which the density
      *        should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Return the density of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().density(phaseIdx_);
@@ -223,7 +224,7 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short phaseIdx_;
+    unsigned short phaseIdx_;
 };
 
 /*!
@@ -246,23 +247,23 @@ public:
         : elemCtx_(elemCtx)
     { Valgrind::SetUndefined(phaseIdx_); }
 
-    MolarDensityCallback(const ElementContext& elemCtx, short phaseIdx)
+    MolarDensityCallback(const ElementContext& elemCtx, unsigned phaseIdx)
         : elemCtx_(elemCtx)
-        , phaseIdx_(phaseIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which the molar
      *        density should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Return the molar density of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().molarDensity(phaseIdx_);
@@ -270,7 +271,7 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short phaseIdx_;
+    unsigned short phaseIdx_;
 };
 
 /*!
@@ -293,23 +294,23 @@ public:
         : elemCtx_(elemCtx)
     { Valgrind::SetUndefined(phaseIdx_); }
 
-    ViscosityCallback(const ElementContext& elemCtx, short phaseIdx)
+    ViscosityCallback(const ElementContext& elemCtx, unsigned phaseIdx)
         : elemCtx_(elemCtx)
-        , phaseIdx_(phaseIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which the viscosity
      *        should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Return the viscosity of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState().viscosity(phaseIdx_);
@@ -317,7 +318,7 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short phaseIdx_;
+    unsigned short phaseIdx_;
 };
 
 /*!
@@ -343,7 +344,7 @@ public:
      * \brief Return the velocity of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     { return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).velocityCenter(); }
 
 private:
@@ -368,7 +369,7 @@ public:
         : elemCtx_(elemCtx)
     { Valgrind::SetUndefined(dimIdx_); }
 
-    VelocityComponentCallback(const ElementContext& elemCtx, short dimIdx)
+    VelocityComponentCallback(const ElementContext& elemCtx, unsigned dimIdx)
         : elemCtx_(elemCtx)
         , dimIdx_(dimIdx)
     {}
@@ -377,14 +378,14 @@ public:
      * \brief Set the index of the component of the velocity
      *        which should be returned.
      */
-    void setDimIndex(short dimIdx)
+    void setDimIndex(unsigned dimIdx)
     { dimIdx_ = dimIdx; }
 
     /*!
      * \brief Return the velocity of a phase given the index of a
      *        degree of freedom within an element context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(dimIdx_);
         return elemCtx_.intensiveQuantities(dofIdx, /*timeIdx=*/0).velocityCenter()[dimIdx_];
@@ -392,7 +393,7 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short dimIdx_;
+    unsigned dimIdx_;
 };
 
 /*!
@@ -418,32 +419,32 @@ public:
         Valgrind::SetUndefined(compIdx_);
     }
 
-    MoleFractionCallback(const ElementContext& elemCtx, short phaseIdx, short compIdx)
+    MoleFractionCallback(const ElementContext& elemCtx, unsigned phaseIdx, unsigned compIdx)
         : elemCtx_(elemCtx)
-        , phaseIdx_(phaseIdx)
-        , compIdx_(compIdx)
+        , phaseIdx_(static_cast<unsigned short>(phaseIdx))
+        , compIdx_(static_cast<unsigned short>(compIdx))
     {}
 
     /*!
      * \brief Set the index of the fluid phase for which a mole
      *        fraction should be returned.
      */
-    void setPhaseIndex(short phaseIdx)
-    { phaseIdx_ = phaseIdx; }
+    void setPhaseIndex(unsigned phaseIdx)
+    { phaseIdx_ = static_cast<unsigned short>(phaseIdx); }
 
     /*!
      * \brief Set the index of the component for which the mole
      *        fraction should be returned.
      */
-    void setComponentIndex(short compIdx)
-    { compIdx_ = compIdx; }
+    void setComponentIndex(unsigned compIdx)
+    { compIdx_ = static_cast<unsigned short>(compIdx); }
 
     /*!
      * \brief Return the mole fraction of a component in a phase given
      *        the index of a degree of freedom within an element
      *        context.
      */
-    ResultType operator()(int dofIdx) const
+    ResultType operator()(unsigned dofIdx) const
     {
         Valgrind::CheckDefined(phaseIdx_);
         Valgrind::CheckDefined(compIdx_);
@@ -452,8 +453,8 @@ public:
 
 private:
     const ElementContext& elemCtx_;
-    short phaseIdx_;
-    short compIdx_;
+    unsigned short phaseIdx_;
+    unsigned short compIdx_;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/discretefracture/discretefractureextensivequantities.hh
+++ b/ewoms/models/discretefracture/discretefractureextensivequantities.hh
@@ -61,19 +61,19 @@ public:
     /*!
      * \copydoc MultiPhaseBaseExtensiveQuantities::update()
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
 
-        const auto &extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
-        const auto &stencil = elemCtx.stencil(timeIdx);
-        const auto &scvf = stencil.interiorFace(scvfIdx);
-        int insideScvIdx = scvf.interiorIndex();
-        int outsideScvIdx = scvf.exteriorIndex();
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        const auto& stencil = elemCtx.stencil(timeIdx);
+        const auto& scvf = stencil.interiorFace(scvfIdx);
+        unsigned insideScvIdx = scvf.interiorIndex();
+        unsigned outsideScvIdx = scvf.exteriorIndex();
 
-        int globalI = elemCtx.globalSpaceIndex(insideScvIdx, timeIdx);
-        int globalJ = elemCtx.globalSpaceIndex(outsideScvIdx, timeIdx);
-        const auto &fractureMapper = elemCtx.problem().fractureMapper();
+        unsigned globalI = elemCtx.globalSpaceIndex(insideScvIdx, timeIdx);
+        unsigned globalJ = elemCtx.globalSpaceIndex(outsideScvIdx, timeIdx);
+        const auto& fractureMapper = elemCtx.problem().fractureMapper();
         if (!fractureMapper.isFractureEdge(globalI, globalJ))
             // do nothing if no fracture goes though the current edge
             return;
@@ -86,16 +86,16 @@ public:
         distDirection -= elemCtx.pos(insideScvIdx, timeIdx);
         distDirection /= distDirection.two_norm();
 
-        const auto &problem = elemCtx.problem();
+        const auto& problem = elemCtx.problem();
         fractureWidth_ = problem.fractureWidth(elemCtx, insideScvIdx,
                                                outsideScvIdx, timeIdx);
         assert(fractureWidth_ < scvf.area());
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            const auto &pGrad = extQuants.potentialGrad(phaseIdx);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            const auto& pGrad = extQuants.potentialGrad(phaseIdx);
 
-            int upstreamIdx = extQuants.upstreamIndex(phaseIdx);
-            const auto &up = elemCtx.intensiveQuantities(upstreamIdx, timeIdx);
+            unsigned upstreamIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
+            const auto& up = elemCtx.intensiveQuantities(upstreamIdx, timeIdx);
 
             // multiply with the fracture mobility of the upstream vertex
             fractureIntrinsicPermeability_.mv(pGrad,
@@ -106,7 +106,7 @@ public:
             // a fracture is always shared by two sub-control-volume
             // faces.
             fractureVolumeFlux_[phaseIdx] = 0;
-            for (int dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
+            for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
                 fractureVolumeFlux_[phaseIdx] +=
                     (fractureFilterVelocity_[phaseIdx][dimIdx] * distDirection[dimIdx])
                     * (fractureWidth_ / 2.0) / scvf.area();
@@ -114,16 +114,16 @@ public:
     }
 
 public:
-    const DimMatrix &fractureIntrinsicPermeability() const
+    const DimMatrix& fractureIntrinsicPermeability() const
     { return fractureIntrinsicPermeability_; }
 
-    Scalar fractureVolumeFlux(int phaseIdx) const
+    Scalar fractureVolumeFlux(unsigned phaseIdx) const
     { return fractureVolumeFlux_[phaseIdx]; }
 
     Scalar fractureWidth() const
     { return fractureWidth_; }
 
-    const DimVector &fractureFilterVelocity(int phaseIdx) const
+    const DimVector& fractureFilterVelocity(unsigned phaseIdx) const
     { return fractureFilterVelocity_[phaseIdx]; }
 
 private:

--- a/ewoms/models/discretefracture/discretefractureintensivequantities.hh
+++ b/ewoms/models/discretefracture/discretefractureintensivequantities.hh
@@ -32,6 +32,8 @@
 
 #include <ewoms/models/immiscible/immiscibleintensivequantities.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+
 namespace Ewoms {
 
 /*!
@@ -80,12 +82,12 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext &elemCtx, unsigned vertexIdx, unsigned timeIdx)
+    void update(const ElementContext& elemCtx, unsigned vertexIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, vertexIdx, timeIdx);
 
-        const auto &problem = elemCtx.problem();
-        const auto &fractureMapper = problem.fractureMapper();
+        const auto& problem = elemCtx.problem();
+        const auto& fractureMapper = problem.fractureMapper();
         unsigned globalVertexIdx = elemCtx.globalSpaceIndex(vertexIdx, timeIdx);
 
         Valgrind::SetUndefined(fractureFluidState_);
@@ -118,7 +120,7 @@ public:
         // volume. note, that we don't take overlaps of fractures into
         // account for this.
         fractureVolume_ = 0;
-        const auto &vertexPos = elemCtx.pos(vertexIdx, timeIdx);
+        const auto& vertexPos = elemCtx.pos(vertexIdx, timeIdx);
         for (unsigned vertex2Idx = 0; vertex2Idx < elemCtx.numDof(/*timeIdx=*/0); ++ vertex2Idx) {
             unsigned globalVertex2Idx = elemCtx.globalSpaceIndex(vertex2Idx, timeIdx);
 
@@ -154,7 +156,7 @@ public:
 
         // ask the problem for the material law parameters of the
         // fracture.
-        const auto &fractureMatParams =
+        const auto& fractureMatParams =
             problem.fractureMaterialLawParams(elemCtx, vertexIdx, timeIdx);
 
         // calculate the fracture saturations which would be required
@@ -214,7 +216,7 @@ public:
      * \brief Returns the average intrinsic permeability within the
      *        fracture.
      */
-    const DimMatrix &fractureIntrinsicPermeability() const
+    const DimMatrix& fractureIntrinsicPermeability() const
     { return fractureIntrinsicPermeability_; }
 
     /*!
@@ -228,7 +230,7 @@ public:
      * \brief Returns a fluid state object which represents the
      *        thermodynamic state of the fluids within the fracture.
      */
-    const FluidState &fractureFluidState() const
+    const FluidState& fractureFluidState() const
     { return fractureFluidState_; }
 
 protected:

--- a/ewoms/models/discretefracture/discretefracturemodel.hh
+++ b/ewoms/models/discretefracture/discretefracturemodel.hh
@@ -40,6 +40,9 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include <ewoms/io/vtkdiscretefracturemodule.hh>
 
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
 #include <string>
 
 namespace Ewoms {
@@ -113,7 +116,7 @@ class DiscreteFractureModel : public ImmiscibleModel<TypeTag>
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
 
 public:
-    DiscreteFractureModel(Simulator &simulator)
+    DiscreteFractureModel(Simulator& simulator)
         : ParentType(simulator)
     {
         if (EWOMS_GET_PARAM(TypeTag, bool, EnableIntensiveQuantityCache)) {

--- a/ewoms/models/discretefracture/discretefractureprimaryvariables.hh
+++ b/ewoms/models/discretefracture/discretefractureprimaryvariables.hh
@@ -71,9 +71,8 @@ public:
      *
      * \param value The primary variables that will be duplicated.
      */
-    DiscreteFracturePrimaryVariables(const DiscreteFracturePrimaryVariables &value)
-        : ParentType(value)
-    {}
+    DiscreteFracturePrimaryVariables(const DiscreteFracturePrimaryVariables& value) = default;
+    DiscreteFracturePrimaryVariables& operator=(const DiscreteFracturePrimaryVariables& value) = default;
 
     /*!
      * \brief Directly retrieve the primary variables from an
@@ -88,8 +87,8 @@ public:
      *                  which apply for the fracture.
      */
     template <class FluidState>
-    void assignNaiveFromFracture(const FluidState &fractureFluidState,
-                                 const MaterialLawParams &matParams)
+    void assignNaiveFromFracture(const FluidState& fractureFluidState,
+                                 const MaterialLawParams& matParams)
     {
         FluidState matrixFluidState;
         fractureToMatrixFluidState_(matrixFluidState, fractureFluidState,
@@ -100,9 +99,9 @@ public:
 
 private:
     template <class FluidState>
-    void fractureToMatrixFluidState_(FluidState &matrixFluidState,
-                                     const FluidState &fractureFluidState,
-                                     const MaterialLawParams &matParams) const
+    void fractureToMatrixFluidState_(FluidState& matrixFluidState,
+                                     const FluidState& fractureFluidState,
+                                     const MaterialLawParams& matParams) const
     {
         // start with the same fluid state as in the fracture
         matrixFluidState.assign(fractureFluidState);
@@ -115,7 +114,7 @@ private:
         Scalar saturations[numPhases];
         MaterialLaw::saturations(saturations, matParams, matrixFluidState);
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             matrixFluidState.setSaturation(phaseIdx, saturations[phaseIdx]);
     }
 };

--- a/ewoms/models/discretefracture/discretefractureproblem.hh
+++ b/ewoms/models/discretefracture/discretefractureproblem.hh
@@ -33,6 +33,9 @@
 #include <ewoms/models/common/multiphasebaseproblem.hh>
 
 #include <opm/material/common/Means.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -65,9 +68,9 @@ class DiscreteFractureProblem
 
 public:
     /*!
-     * \copydoc Problem::FvBaseProblem(Simulator &)
+     * \copydoc Problem::FvBaseProblem(Simulator& )
      */
-    DiscreteFractureProblem(Simulator &simulator)
+    DiscreteFractureProblem(Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -81,20 +84,21 @@ public:
      * problem (if a finite-volume discretization is used).
      */
     template <class Context>
-    void fractureFaceIntrinsicPermeability(DimMatrix &result,
-                                           const Context &context,
-                                           int localFaceIdx, int timeIdx) const
+    void fractureFaceIntrinsicPermeability(DimMatrix& result,
+                                           const Context& context,
+                                           unsigned localFaceIdx,
+                                           unsigned timeIdx) const
     {
-        const auto &scvf = context.stencil(timeIdx).interiorFace(localFaceIdx);
-        int interiorElemIdx = scvf.interiorIndex();
-        int exteriorElemIdx = scvf.exteriorIndex();
-        const DimMatrix &K1 = asImp_().fractureIntrinsicPermeability(context, interiorElemIdx, timeIdx);
-        const DimMatrix &K2 = asImp_().fractureIntrinsicPermeability(context, exteriorElemIdx, timeIdx);
+        const auto& scvf = context.stencil(timeIdx).interiorFace(localFaceIdx);
+        unsigned interiorElemIdx = scvf.interiorIndex();
+        unsigned exteriorElemIdx = scvf.exteriorIndex();
+        const DimMatrix& K1 = asImp_().fractureIntrinsicPermeability(context, interiorElemIdx, timeIdx);
+        const DimMatrix& K2 = asImp_().fractureIntrinsicPermeability(context, exteriorElemIdx, timeIdx);
 
         // entry-wise harmonic mean. this is almost certainly wrong if
         // you have off-main diagonal entries in your permeabilities!
-        for (int i = 0; i < dimWorld; ++i)
-            for (int j = 0; j < dimWorld; ++j)
+        for (unsigned i = 0; i < dimWorld; ++i)
+            for (unsigned j = 0; j < dimWorld; ++j)
                 result[i][j] = Opm::harmonicMean(K1[i][j], K2[i][j]);
     }
     /*!
@@ -106,8 +110,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    const DimMatrix &fractureIntrinsicPermeability(const Context &context,
-                                                   int spaceIdx, int timeIdx) const
+    const DimMatrix& fractureIntrinsicPermeability(const Context& OPM_UNUSED context,
+                                                   unsigned OPM_UNUSED spaceIdx,
+                                                   unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: Problem::fractureIntrinsicPermeability()");
@@ -122,8 +127,9 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar fracturePorosity(const Context &context,
-                            int spaceIdx, int timeIdx) const
+    Scalar fracturePorosity(const Context& OPM_UNUSED context,
+                            unsigned OPM_UNUSED spaceIdx,
+                            unsigned OPM_UNUSED timeIdx) const
     {
         OPM_THROW(std::logic_error,
                    "Not implemented: Problem::fracturePorosity()");
@@ -131,10 +137,10 @@ public:
 
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation *>(this); }
     //! \copydoc asImp_()
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 };
 

--- a/ewoms/models/discretefracture/fracturemapper.hh
+++ b/ewoms/models/discretefracture/fracturemapper.hh
@@ -43,19 +43,19 @@ class FractureMapper
 {
     struct FractureEdge
     {
-        FractureEdge(int edgeVertex1Idx, int edgeVertex2Idx)
+        FractureEdge(unsigned edgeVertex1Idx, unsigned edgeVertex2Idx)
             : i_(std::min(edgeVertex1Idx, edgeVertex2Idx)),
               j_(std::max(edgeVertex1Idx, edgeVertex2Idx))
         {}
 
-        bool operator<(const FractureEdge &e) const
+        bool operator<(const FractureEdge& e) const
         { return i_ < e.i_ || (i_ == e.i_ && j_ < e.j_); }
 
-        bool operator==(const FractureEdge &e) const
+        bool operator==(const FractureEdge& e) const
         { return i_ == e.i_ && j_ == e.j_; }
 
-        int i_;
-        int j_;
+        unsigned i_;
+        unsigned j_;
     };
 
 public:
@@ -71,7 +71,7 @@ public:
      * \param vertexIdx1 The index of the edge's first vertex.
      * \param vertexIdx2 The index of the edge's second vertex.
      */
-    void addFractureEdge(int vertexIdx1, int vertexIdx2)
+    void addFractureEdge(unsigned vertexIdx1, unsigned vertexIdx2)
     {
         fractureEdges_.insert(FractureEdge(vertexIdx1, vertexIdx2));
         fractureVertices_.insert(vertexIdx1);

--- a/ewoms/models/flash/flashboundaryratevector.hh
+++ b/ewoms/models/flash/flashboundaryratevector.hh
@@ -74,33 +74,34 @@ public:
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::ImmiscibleBoundaryRateVector(const
-     * ImmiscibleBoundaryRateVector &)
+     * ImmiscibleBoundaryRateVector& )
      */
-    FlashBoundaryRateVector(const FlashBoundaryRateVector &value)
-        : ParentType(value)
-    {}
+    FlashBoundaryRateVector(const FlashBoundaryRateVector& value) = default;
+    FlashBoundaryRateVector& operator=(const FlashBoundaryRateVector& value) = default;
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::setFreeFlow
      */
     template <class Context, class FluidState>
-    void setFreeFlow(const Context &context, int bfIdx, int timeIdx,
-                     const FluidState &fluidState)
+    void setFreeFlow(const Context& context,
+                     unsigned bfIdx,
+                     unsigned timeIdx,
+                     const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
         paramCache.updateAll(fluidState);
 
         ExtensiveQuantities extQuants;
         extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
-        const auto &insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Evaluation meanMBoundary = 0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                 meanMBoundary +=
                     fluidState.moleFraction(phaseIdx, compIdx)*FluidSystem::molarMass(compIdx);
 
@@ -110,7 +111,7 @@ public:
             else
                 density = insideIntQuants.fluidState().density(phaseIdx);
 
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 Evaluation molarity;
                 if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
                     molarity = fluidState.moleFraction(phaseIdx, compIdx)*density/meanMBoundary;
@@ -138,7 +139,7 @@ public:
         EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
 
 #ifndef NDEBUG
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             Valgrind::CheckDefined((*this)[i]);
         }
 #endif
@@ -148,14 +149,16 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setInFlow
      */
     template <class Context, class FluidState>
-    void setInFlow(const Context &context, int bfIdx, int timeIdx,
-                   const FluidState &fluidState)
+    void setInFlow(const Context& context,
+                   unsigned bfIdx,
+                   unsigned timeIdx,
+                   const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the direction opposite to the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Evaluation &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::min(0.0, val);
         }
     }
@@ -164,14 +167,16 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setOutFlow
      */
     template <class Context, class FluidState>
-    void setOutFlow(const Context &context, int bfIdx, int timeIdx,
-                    const FluidState &fluidState)
+    void setOutFlow(const Context& context,
+                    unsigned bfIdx,
+                    unsigned timeIdx,
+                    const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the same direction as the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Evaluation &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::max(0.0, val);
         }
     }

--- a/ewoms/models/flash/flashextensivequantities.hh
+++ b/ewoms/models/flash/flashextensivequantities.hh
@@ -69,7 +69,7 @@ public:
     /*!
      * \copydoc MultiPhaseBaseExtensiveQuantities::update
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
         DiffusionExtensiveQuantities::update_(elemCtx, scvfIdx, timeIdx);
@@ -80,9 +80,11 @@ public:
      * \copydoc MultiPhaseBaseExtensiveQuantities::updateBoundary
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context, int bfIdx, int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);

--- a/ewoms/models/flash/flashmodel.hh
+++ b/ewoms/models/flash/flashmodel.hh
@@ -191,7 +191,7 @@ class FlashModel
     typedef Ewoms::EnergyModule<TypeTag, enableEnergy> EnergyModule;
 
 public:
-    FlashModel(Simulator &simulator)
+    FlashModel(Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -225,9 +225,9 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarName
      */
-    std::string primaryVarName(int pvIdx) const
+    std::string primaryVarName(unsigned pvIdx) const
     {
-        const std::string &tmp = EnergyModule::primaryVarName(pvIdx);
+        const std::string& tmp = EnergyModule::primaryVarName(pvIdx);
         if (tmp != "")
             return tmp;
 
@@ -245,16 +245,16 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::eqName
      */
-    std::string eqName(int eqIdx) const
+    std::string eqName(unsigned eqIdx) const
     {
-        const std::string &tmp = EnergyModule::eqName(eqIdx);
+        const std::string& tmp = EnergyModule::eqName(eqIdx);
         if (tmp != "")
             return tmp;
 
         std::ostringstream oss;
         if (Indices::conti0EqIdx <= eqIdx && eqIdx < Indices::conti0EqIdx
                                                      + numComponents) {
-            int compIdx = eqIdx - Indices::conti0EqIdx;
+            unsigned compIdx = eqIdx - Indices::conti0EqIdx;
             oss << "continuity^" << FluidSystem::componentName(compIdx);
         }
         else
@@ -266,13 +266,13 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarWeight
      */
-    Scalar primaryVarWeight(int globalDofIdx, int pvIdx) const
+    Scalar primaryVarWeight(unsigned globalDofIdx, unsigned pvIdx) const
     {
         Scalar tmp = EnergyModule::primaryVarWeight(*this, globalDofIdx, pvIdx);
         if (tmp > 0)
             return tmp;
 
-        int compIdx = pvIdx - Indices::cTot0Idx;
+        unsigned compIdx = pvIdx - Indices::cTot0Idx;
 
         // make all kg equal. also, divide the weight of all total
         // compositions by 100 to make the relative errors more
@@ -285,13 +285,13 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::eqWeight
      */
-    Scalar eqWeight(int globalDofIdx, int eqIdx) const
+    Scalar eqWeight(unsigned globalDofIdx, unsigned eqIdx) const
     {
         Scalar tmp = EnergyModule::eqWeight(*this, globalDofIdx, eqIdx);
         if (tmp > 0)
             return tmp;
 
-        int compIdx = eqIdx - Indices::conti0EqIdx;
+        unsigned compIdx = eqIdx - Indices::conti0EqIdx;
 
         // make all kg equal
         return FluidSystem::molarMass(compIdx);

--- a/ewoms/models/flash/flashprimaryvariables.hh
+++ b/ewoms/models/flash/flashprimaryvariables.hh
@@ -36,6 +36,8 @@
 
 #include <opm/material/constraintsolvers/NcpFlash.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -87,19 +89,18 @@ public:
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
-     * ImmisciblePrimaryVariables &)
+     * ImmisciblePrimaryVariables& )
      */
-    FlashPrimaryVariables(const FlashPrimaryVariables &value)
-        : ParentType(value)
-    { Valgrind::SetDefined(*this); }
+    FlashPrimaryVariables(const FlashPrimaryVariables& value) = default;
+    FlashPrimaryVariables& operator=(const FlashPrimaryVariables& value) = default;
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative
      */
     template <class FluidState>
-    void assignMassConservative(const FluidState &fluidState,
-                                const MaterialLawParams &matParams,
-                                bool isInEquilibrium = false)
+    void assignMassConservative(const FluidState& fluidState,
+                                const MaterialLawParams& OPM_UNUSED matParams,
+                                bool OPM_UNUSED isInEquilibrium = false)
     {
         // there is no difference between naive and mass conservative
         // assignment in the flash model. (we only need the total
@@ -111,7 +112,7 @@ public:
      * \copydoc ImmisciblePrimaryVariables::assignNaive
      */
     template <class FluidState>
-    void assignNaive(const FluidState &fluidState)
+    void assignNaive(const FluidState& fluidState)
     {
         // reset everything
         (*this) = 0.0;
@@ -121,8 +122,8 @@ public:
         EnergyModule::setPriVarTemperatures(*this, fluidState);
 
         // determine the phase presence.
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 this->operator[](cTot0Idx + compIdx) +=
                     fluidState.molarity(phaseIdx, compIdx) * fluidState.saturation(phaseIdx);
             }
@@ -134,9 +135,9 @@ public:
      *
      * \param os The \c std::ostream which should be used for the output.
      */
-    void print(std::ostream &os = std::cout) const
+    void print(std::ostream& os = std::cout) const
     {
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             os << "(c_tot," << FluidSystem::componentName(compIdx) << " = "
                << this->operator[](cTot0Idx + compIdx);
         }

--- a/ewoms/models/flash/flashratevector.hh
+++ b/ewoms/models/flash/flashratevector.hh
@@ -72,7 +72,7 @@ public:
 
     /*!
      * \copydoc ImmiscibleRateVector::ImmiscibleRateVector(const
-     * ImmiscibleRateVector &)
+     * ImmiscibleRateVector& )
      */
     FlashRateVector(const FlashRateVector& value) : ParentType(value)
     {}
@@ -84,7 +84,7 @@ public:
     {
         // convert to molar rates
         ParentType molarRate(value);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             molarRate[conti0EqIdx + compIdx] /= FluidSystem::molarMass(compIdx);
 
         setMolarRate(molarRate);
@@ -93,7 +93,7 @@ public:
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
@@ -106,9 +106,9 @@ public:
      * \copydoc ImmiscibleRateVector::setVolumetricRate
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState, int phaseIdx, const RhsEval& volume)
+    void setVolumetricRate(const FluidState& fluidState, unsigned phaseIdx, const RhsEval& volume)
     {
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] =
                 fluidState.density(phaseIdx, compIdx)
                 * fluidState.moleFraction(phaseIdx, compIdx)

--- a/ewoms/models/immiscible/immiscibleboundaryratevector.hh
+++ b/ewoms/models/immiscible/immiscibleboundaryratevector.hh
@@ -79,9 +79,9 @@ public:
      *
      * \param value The boundary rate vector to be duplicated.
      */
-    ImmiscibleBoundaryRateVector(const ImmiscibleBoundaryRateVector &value)
-        : ParentType(value)
-    {}
+    ImmiscibleBoundaryRateVector(const ImmiscibleBoundaryRateVector& value) = default;
+
+    ImmiscibleBoundaryRateVector& operator=(const ImmiscibleBoundaryRateVector& value) = default;
 
     /*!
      * \brief Specify a free-flow boundary
@@ -95,20 +95,20 @@ public:
      *                   boundary segment.
      */
     template <class Context, class FluidState>
-    void setFreeFlow(const Context &context, int bfIdx, int timeIdx, const FluidState &fluidState)
+    void setFreeFlow(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
         paramCache.updateAll(fluidState);
 
         ExtensiveQuantities extQuants;
         extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
-        const auto &insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Evaluation density;
             if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
                 density = FluidSystem::density(fluidState, paramCache, phaseIdx);
@@ -140,7 +140,7 @@ public:
         EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
 
 #ifndef NDEBUG
-        for (int i = 0; i < numEq; ++i)
+        for (unsigned i = 0; i < numEq; ++i)
             Valgrind::CheckDefined((*this)[i]);
         Valgrind::CheckDefined(*this);
 #endif
@@ -156,13 +156,15 @@ public:
      * \copydetails setFreeFlow
      */
     template <class Context, class FluidState>
-    void setInFlow(const Context &context, int bfIdx, int timeIdx,
-                   const FluidState &fluidState)
+    void setInFlow(const Context& context,
+                   unsigned bfIdx,
+                   unsigned timeIdx,
+                   const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the direction opposite to the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::min(0.0, val);
         }
@@ -178,14 +180,16 @@ public:
      * \copydetails setFreeFlow
      */
     template <class Context, class FluidState>
-    void setOutFlow(const Context &context, int bfIdx, int timeIdx,
-                    const FluidState &fluidState)
+    void setOutFlow(const Context& context,
+                    unsigned bfIdx,
+                    unsigned timeIdx,
+                    const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the same direction as the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Evaluation &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::max(0.0, val);
         }
     }

--- a/ewoms/models/immiscible/immiscibleextensivequantities.hh
+++ b/ewoms/models/immiscible/immiscibleextensivequantities.hh
@@ -72,7 +72,7 @@ public:
     /*!
      * \copydoc MultiPhaseBaseExtensiveQuantities::update()
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
         EnergyExtensiveQuantities::update_(elemCtx, scvfIdx, timeIdx);
@@ -82,9 +82,11 @@ public:
      * \copydoc MultiPhaseBaseExtensiveQuantities::updateBoundary()
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context, int bfIdx, int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
         EnergyExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);

--- a/ewoms/models/immiscible/immisciblemodel.hh
+++ b/ewoms/models/immiscible/immisciblemodel.hh
@@ -47,8 +47,6 @@
 #include <opm/material/fluidsystems/SinglePhaseFluidSystem.hpp>
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 
-#include <dune/common/unused.hh>
-
 #include <sstream>
 #include <string>
 
@@ -214,7 +212,7 @@ class ImmiscibleModel
     typedef Ewoms::EnergyModule<TypeTag, enableEnergy> EnergyModule;
 
 public:
-    ImmiscibleModel(Simulator &simulator)
+    ImmiscibleModel(Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -238,7 +236,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarName
      */
-    std::string primaryVarName(int pvIdx) const
+    std::string primaryVarName(unsigned pvIdx) const
     {
         std::string s;
         if (!(s = EnergyModule::primaryVarName(pvIdx)).empty())
@@ -251,7 +249,7 @@ public:
         }
         else if (Indices::saturation0Idx <= pvIdx
                  && pvIdx < Indices::saturation0Idx + numPhases - 1) {
-            int phaseIdx = pvIdx - Indices::saturation0Idx;
+            unsigned phaseIdx = pvIdx - Indices::saturation0Idx;
             oss << "saturation_" << FluidSystem::phaseName(phaseIdx);
         }
         else
@@ -263,7 +261,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::eqName
      */
-    std::string eqName(int eqIdx) const
+    std::string eqName(unsigned eqIdx) const
     {
         std::string s;
         if (!(s = EnergyModule::eqName(eqIdx)).empty())
@@ -289,8 +287,8 @@ public:
         // find the a reference pressure. The first degree of freedom
         // might correspond to non-interior entities which would lead
         // to an undefined value, so we have to iterate...
-        int nDof = this->numTotalDof();
-        for (int dofIdx = 0; dofIdx < nDof; ++ dofIdx) {
+        size_t nDof = this->numTotalDof();
+        for (unsigned dofIdx = 0; dofIdx < nDof; ++ dofIdx) {
             if (this->isLocalDof(dofIdx)) {
                 referencePressure_ =
                     this->solution(/*timeIdx=*/0)[dofIdx][/*pvIdx=*/Indices::pressure0Idx];
@@ -302,7 +300,7 @@ public:
     /*!
      * \copydetails FvBaseDiscretization::primaryVarWeight
      */
-    Scalar primaryVarWeight(int globalDofIdx, int pvIdx) const
+    Scalar primaryVarWeight(unsigned globalDofIdx, unsigned pvIdx) const
     {
         assert(referencePressure_ > 0);
 
@@ -319,7 +317,7 @@ public:
     /*!
      * \copydetails FvBaseDiscretization::eqWeight
      */
-    Scalar eqWeight(int globalDofIdx, int eqIdx) const
+    Scalar eqWeight(unsigned globalDofIdx, unsigned eqIdx) const
     {
         Scalar tmp = EnergyModule::eqWeight(asImp_(), globalDofIdx, eqIdx);
         if (tmp > 0)
@@ -327,7 +325,7 @@ public:
             return tmp;
 
 #ifndef NDEBUG
-        int compIdx = eqIdx - Indices::conti0EqIdx;
+        unsigned compIdx = eqIdx - Indices::conti0EqIdx;
         assert(0 <= compIdx && compIdx <= numPhases);
 #endif
 
@@ -344,7 +342,7 @@ public:
     }
 
 private:
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 
     mutable Scalar referencePressure_;

--- a/ewoms/models/immiscible/immiscibleratevector.hh
+++ b/ewoms/models/immiscible/immiscibleratevector.hh
@@ -96,7 +96,7 @@ public:
      *
      * \param value The mass rate in \f$[kg/(m^2\,s)]\f$ (unit for areal fluxes)
      */
-    void setMassRate(const ParentType &value)
+    void setMassRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
@@ -108,10 +108,10 @@ public:
      *
      * \param value The new molar rate in \f$[mol/(m^2\,s)]\f$
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     {
         // convert to mass rates
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             ParentType::operator[](conti0EqIdx + compIdx) =
                 value[conti0EqIdx + compIdx]*FluidSystem::molarMass(compIdx);
     }
@@ -143,9 +143,9 @@ public:
      *               \f$[m^3/(m^2\,s)]\f$ (unit for areal fluxes)
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState, int phaseIdx, const RhsEval& volume)
+    void setVolumetricRate(const FluidState& fluidState, unsigned phaseIdx, const RhsEval& volume)
     {
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] =
                 fluidState.density(phaseIdx, compIdx)
                 * fluidState.massFraction(phaseIdx, compIdx)

--- a/ewoms/models/ncp/ncpextensivequantities.hh
+++ b/ewoms/models/ncp/ncpextensivequantities.hh
@@ -64,7 +64,7 @@ public:
     /*!
      * \copydoc MultiPhaseBaseExtensiveQuantities::update
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
         DiffusionExtensiveQuantities::update_(elemCtx, scvfIdx, timeIdx);
@@ -75,9 +75,11 @@ public:
      * \copydoc MultiPhaseBaseExtensiveQuantities::updateBoundary
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context, int bfIdx, int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);

--- a/ewoms/models/ncp/ncpmodel.hh
+++ b/ewoms/models/ncp/ncpmodel.hh
@@ -47,11 +47,11 @@
 #include <ewoms/io/vtkenergymodule.hh>
 #include <ewoms/io/vtkdiffusionmodule.hh>
 
+#include <opm/material/common/Valgrind.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
 
 #include <dune/common/fvector.hh>
-#include <dune/common/unused.hh>
 
 #include <sstream>
 #include <string>
@@ -224,7 +224,7 @@ class NcpModel
     typedef Ewoms::DiffusionModule<TypeTag, enableDiffusion> DiffusionModule;
 
 public:
-    NcpModel(Simulator &simulator)
+    NcpModel(Simulator& simulator)
         : ParentType(simulator)
     {}
 
@@ -317,7 +317,7 @@ public:
         // find the a reference pressure. The first degree of freedom
         // might correspond to non-interior entities which would lead
         // to an undefined value, so we have to iterate...
-        for (size_t dofIdx = 0; dofIdx < this->numGridDof(); ++ dofIdx) {
+        for (unsigned dofIdx = 0; dofIdx < this->numGridDof(); ++ dofIdx) {
             if (this->isLocalDof(dofIdx)) {
                 referencePressure_ =
                     this->solution(/*timeIdx=*/0)[dofIdx][/*pvIdx=*/Indices::pressure0Idx];
@@ -329,7 +329,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::updatePVWeights
      */
-    void updatePVWeights(const ElementContext &elemCtx) const
+    void updatePVWeights(const ElementContext& elemCtx) const
     {
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numDof(/*timeIdx=*/0); ++dofIdx) {
             unsigned globalIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
@@ -337,7 +337,7 @@ public:
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 minActivityCoeff_[globalIdx][compIdx] = 1e100;
                 for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-                    const auto &fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
+                    const auto& fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
 
                     minActivityCoeff_[globalIdx][compIdx] =
                         std::min(minActivityCoeff_[globalIdx][compIdx],

--- a/ewoms/models/ncp/ncpprimaryvariables.hh
+++ b/ewoms/models/ncp/ncpprimaryvariables.hh
@@ -88,24 +88,24 @@ public:
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
-     * ImmisciblePrimaryVariables &)
+     * ImmisciblePrimaryVariables& )
      */
-    NcpPrimaryVariables(const NcpPrimaryVariables &value) : ParentType(value)
-    {}
+    NcpPrimaryVariables(const NcpPrimaryVariables& value) = default;
+    NcpPrimaryVariables& operator=(const NcpPrimaryVariables& value) = default;
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative
      */
     template <class FluidState>
-    void assignMassConservative(const FluidState &fluidState,
-                                const MaterialLawParams &matParams,
+    void assignMassConservative(const FluidState& fluidState,
+                                const MaterialLawParams& matParams,
                                 bool isInEquilibrium = false)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
 #ifndef NDEBUG
         // make sure the temperature is the same in all fluid phases
-        for (int phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 1; phaseIdx < numPhases; ++phaseIdx) {
             assert(fluidState.temperature(0) == fluidState.temperature(phaseIdx));
         }
 #endif // NDEBUG
@@ -128,15 +128,15 @@ public:
 
         // calculate the phase densities
         paramCache.updateAll(fsFlash);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Scalar rho = FluidSystem::density(fsFlash, paramCache, phaseIdx);
             fsFlash.setDensity(phaseIdx, rho);
         }
 
         // calculate the "global molarities"
         ComponentVector globalMolarities(0.0);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 globalMolarities[compIdx] +=
                     FsToolbox::value(fsFlash.saturation(phaseIdx))
                     * FsToolbox::value(fsFlash.molarity(phaseIdx, compIdx));
@@ -154,7 +154,7 @@ public:
      * \copydoc ImmisciblePrimaryVariables::assignNaive
      */
     template <class FluidState>
-    void assignNaive(const FluidState &fluidState, unsigned refPhaseIdx = 0)
+    void assignNaive(const FluidState& fluidState, unsigned refPhaseIdx = 0)
     {
         typedef Opm::MathToolbox<typename FluidState::Scalar> FsToolbox;
 
@@ -163,7 +163,7 @@ public:
         EnergyModule::setPriVarTemperatures(*this, fluidState);
 
         // assign fugacities.
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             Scalar fug = FsToolbox::value(fluidState.fugacity(refPhaseIdx, compIdx));
             (*this)[fugacity0Idx + compIdx] = fug;
         }
@@ -172,7 +172,7 @@ public:
         (*this)[pressure0Idx] = FsToolbox::value(fluidState.pressure(/*phaseIdx=*/0));
 
         // assign first M - 1 saturations
-        for (int phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases - 1; ++phaseIdx)
             (*this)[saturation0Idx + phaseIdx] = FsToolbox::value(fluidState.saturation(phaseIdx));
     }
 };

--- a/ewoms/models/ncp/ncpratevector.hh
+++ b/ewoms/models/ncp/ncpratevector.hh
@@ -77,20 +77,20 @@ public:
 
     /*!
      * \copydoc ImmiscibleRateVector::ImmiscibleRateVector(const
-     * ImmiscibleRateVector &)
+     * ImmiscibleRateVector& )
      */
-    NcpRateVector(const NcpRateVector &value)
+    NcpRateVector(const NcpRateVector& value)
         : ParentType(value)
     {}
 
     /*!
      * \copydoc ImmiscibleRateVector::setMassRate
      */
-    void setMassRate(const ParentType &value)
+    void setMassRate(const ParentType& value)
     {
         // convert to molar rates
         ParentType molarRate(value);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             molarRate[conti0EqIdx + compIdx] /= FluidSystem::molarMass(compIdx);
 
         // set the molar rate
@@ -100,7 +100,7 @@ public:
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
@@ -114,10 +114,10 @@ public:
      * \copydoc ImmiscibleRateVector::setVolumetricRate
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState, int phaseIdx, const RhsEval& volume)
+    void setVolumetricRate(const FluidState& fluidState, unsigned phaseIdx, const RhsEval& volume)
     {
         *this = 0.0;
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] = fluidState.molarity(phaseIdx, compIdx) * volume;
 
         EnergyModule::setEnthalpyRate(*this, fluidState, phaseIdx, volume);

--- a/ewoms/models/pvs/pvsboundaryratevector.hh
+++ b/ewoms/models/pvs/pvsboundaryratevector.hh
@@ -76,32 +76,31 @@ public:
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::ImmiscibleBoundaryRateVector(const
-     * ImmiscibleBoundaryRateVector &)
+     * ImmiscibleBoundaryRateVector& )
      */
-    PvsBoundaryRateVector(const PvsBoundaryRateVector &value)
-        : ParentType(value)
-    {}
+    PvsBoundaryRateVector(const PvsBoundaryRateVector& value) = default;
+    PvsBoundaryRateVector& operator=(const PvsBoundaryRateVector& value) = default;
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::setFreeFlow
      */
     template <class Context, class FluidState>
-    void setFreeFlow(const Context &context, int bfIdx, int timeIdx, const FluidState &fluidState)
+    void setFreeFlow(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
         paramCache.updateAll(fluidState);
 
         ExtensiveQuantities extQuants;
         extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
-        const auto &insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             Evaluation meanMBoundary = 0;
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
                 meanMBoundary +=
                     fluidState.moleFraction(phaseIdx, compIdx)*FluidSystem::molarMass(compIdx);
 
@@ -111,7 +110,7 @@ public:
             else
                 density = insideIntQuants.fluidState().density(phaseIdx);
 
-            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 Evaluation molarity;
                 if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
                     molarity = fluidState.moleFraction(phaseIdx, compIdx)*density/meanMBoundary;
@@ -139,7 +138,7 @@ public:
         EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
 
 #ifndef NDEBUG
-        for (int i = 0; i < numEq; ++i)
+        for (unsigned i = 0; i < numEq; ++i)
             Valgrind::CheckDefined((*this)[i]);
 #endif
     }
@@ -148,14 +147,16 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setInFlow
      */
     template <class Context, class FluidState>
-    void setInFlow(const Context &context, int bfIdx, int timeIdx,
-                   const FluidState &fluidState)
+    void setInFlow(const Context& context,
+                   unsigned bfIdx,
+                   unsigned timeIdx,
+                   const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the direction opposite to the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Evaluation &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::min(0.0, val);
         }
     }
@@ -164,14 +165,16 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setOutFlow
      */
     template <class Context, class FluidState>
-    void setOutFlow(const Context &context, int bfIdx, int timeIdx,
-                    const FluidState &fluidState)
+    void setOutFlow(const Context& context,
+                    unsigned bfIdx,
+                    unsigned timeIdx,
+                    const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the same direction as the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            Evaluation &val = this->operator[](eqIdx);
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+            Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::max(0.0, val);
         }
     }

--- a/ewoms/models/pvs/pvsextensivequantities.hh
+++ b/ewoms/models/pvs/pvsextensivequantities.hh
@@ -67,7 +67,7 @@ public:
     /*!
      * \copydoc ParentType::update
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, scvfIdx, timeIdx);
         DiffusionExtensiveQuantities::update_(elemCtx, scvfIdx, timeIdx);
@@ -78,9 +78,11 @@ public:
      * \copydoc ParentType::updateBoundary
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context, int bfIdx, int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);

--- a/ewoms/models/pvs/pvsintensivequantities.hh
+++ b/ewoms/models/pvs/pvsintensivequantities.hh
@@ -36,6 +36,7 @@
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
 #include <opm/material/constraintsolvers/MiscibleMultiPhaseComposition.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -106,19 +107,19 @@ public:
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::update
      */
-    void update(const ElementContext &elemCtx, int dofIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);
 
-        const auto &priVars = elemCtx.primaryVars(dofIdx, timeIdx);
-        const auto &problem = elemCtx.problem();
+        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        const auto& problem = elemCtx.problem();
 
         /////////////
         // set the saturations
         /////////////
         Evaluation sumSat = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             fluidState_.setSaturation(phaseIdx, priVars.explicitSaturationValue(phaseIdx, timeIdx));
             Valgrind::CheckDefined(fluidState_.saturation(phaseIdx));
             sumSat += fluidState_.saturation(phaseIdx);
@@ -132,14 +133,14 @@ public:
         /////////////
 
         // calculate capillary pressure
-        const MaterialLawParams &materialParams =
+        const MaterialLawParams& materialParams =
             problem.materialLawParams(elemCtx, dofIdx, timeIdx);
         EvalPhaseVector pC;
         MaterialLaw::capillaryPressures(pC, materialParams, fluidState_);
 
         // set the absolute phase pressures in the fluid state
         const Evaluation& p0 = priVars.makeEvaluation(pressure0Idx, timeIdx);
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             fluidState_.setPressure(phaseIdx, p0 + (pC[phaseIdx] - pC[0]));
 
         /////////////
@@ -147,9 +148,9 @@ public:
         /////////////
 
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;
-        int lowestPresentPhaseIdx = priVars.lowestPresentPhaseIdx();
-        int numNonPresentPhases = 0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        unsigned lowestPresentPhaseIdx = priVars.lowestPresentPhaseIdx();
+        unsigned numNonPresentPhases = 0;
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!priVars.phaseIsPresent(phaseIdx))
                 ++numNonPresentPhases;
         }
@@ -159,7 +160,7 @@ public:
             // only one phase is present, i.e. the primary variables
             // contain the complete composition of the phase
             Evaluation sumx = 0.0;
-            for (int compIdx = 1; compIdx < numComponents; ++compIdx) {
+            for (unsigned compIdx = 1; compIdx < numComponents; ++compIdx) {
                 const Evaluation& x = priVars.makeEvaluation(switch0Idx + compIdx - 1, timeIdx);
                 fluidState_.setMoleFraction(lowestPresentPhaseIdx, compIdx, x);
                 sumx += x;
@@ -178,14 +179,14 @@ public:
         }
         else {
             // create the auxiliary constraints
-            int numAuxConstraints = numComponents + numNonPresentPhases - numPhases;
+            unsigned numAuxConstraints = numComponents + numNonPresentPhases - numPhases;
             Opm::MMPCAuxConstraint<Evaluation> auxConstraints[numComponents];
 
-            int auxIdx = 0;
-            int switchIdx = 0;
+            unsigned auxIdx = 0;
+            unsigned switchIdx = 0;
             for (; switchIdx < numPhases - 1; ++switchIdx) {
-                int compIdx = switchIdx + 1;
-                int switchPhaseIdx = switchIdx;
+                unsigned compIdx = switchIdx + 1;
+                unsigned switchPhaseIdx = switchIdx;
                 if (switchIdx >= lowestPresentPhaseIdx)
                     switchPhaseIdx += 1;
 
@@ -197,7 +198,7 @@ public:
             }
 
             for (; auxIdx < numAuxConstraints; ++auxIdx, ++switchIdx) {
-                int compIdx = numPhases - numNonPresentPhases + auxIdx;
+                unsigned compIdx = numPhases - numNonPresentPhases + auxIdx;
                 auxConstraints[auxIdx].set(lowestPresentPhaseIdx, compIdx,
                                            priVars.makeEvaluation(switch0Idx + switchIdx, timeIdx));
             }
@@ -217,7 +218,7 @@ public:
         // make valgrind happy and set the enthalpies to NaN
         if (!enableEnergy) {
             Scalar myNan = std::numeric_limits<Scalar>::quiet_NaN();
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
                 fluidState_.setEnthalpy(phaseIdx, myNan);
         }
 #endif
@@ -232,7 +233,7 @@ public:
         Valgrind::CheckDefined(relativePermeability_);
 
         // mobilities
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             mobility_[phaseIdx] =
                 relativePermeability_[phaseIdx] / fluidState().viscosity(phaseIdx);
 
@@ -258,25 +259,25 @@ public:
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::fluidState
      */
-    const FluidState &fluidState() const
+    const FluidState& fluidState() const
     { return fluidState_; }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::intrinsicPermeability
      */
-    const DimMatrix &intrinsicPermeability() const
+    const DimMatrix& intrinsicPermeability() const
     { return intrinsicPerm_; }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::relativePermeability
      */
-    const Evaluation& relativePermeability(int phaseIdx) const
+    const Evaluation& relativePermeability(unsigned phaseIdx) const
     { return relativePermeability_[phaseIdx]; }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::mobility
      */
-    const Evaluation& mobility(int phaseIdx) const
+    const Evaluation& mobility(unsigned phaseIdx) const
     { return mobility_[phaseIdx]; }
 
     /*!

--- a/ewoms/models/pvs/pvslocalresidual.hh
+++ b/ewoms/models/pvs/pvslocalresidual.hh
@@ -33,6 +33,8 @@
 #include <ewoms/models/common/diffusionmodule.hh>
 #include <ewoms/models/common/energymodule.hh>
 
+#include <opm/material/common/Valgrind.hpp>
+
 namespace Ewoms {
 
 /*!
@@ -69,18 +71,18 @@ public:
      * \copydoc ImmiscibleLocalResidual::addPhaseStorage
      */
     template <class LhsEval>
-    void addPhaseStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                         const ElementContext &elemCtx,
-                         int dofIdx,
-                         int timeIdx,
-                         int phaseIdx) const
+    void addPhaseStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                         const ElementContext& elemCtx,
+                         unsigned dofIdx,
+                         unsigned timeIdx,
+                         unsigned phaseIdx) const
     {
-        const IntensiveQuantities &intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
-        const auto &fs = intQuants.fluidState();
+        const IntensiveQuantities& intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
+        const auto& fs = intQuants.fluidState();
 
         // compute storage term of all components within all phases
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-            int eqIdx = conti0EqIdx + compIdx;
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+            unsigned eqIdx = conti0EqIdx + compIdx;
             storage[eqIdx] +=
                 Toolbox::template decay<LhsEval>(fs.molarity(phaseIdx, compIdx))
                 * Toolbox::template decay<LhsEval>(fs.saturation(phaseIdx))
@@ -96,11 +98,11 @@ public:
     template <class LhsEval>
     void computeStorage(Dune::FieldVector<LhsEval, numEq>& storage,
                         const ElementContext& elemCtx,
-                        int dofIdx,
-                        int timeIdx) const
+                        unsigned dofIdx,
+                        unsigned timeIdx) const
     {
         storage = 0.0;
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             addPhaseStorage(storage, elemCtx, dofIdx, timeIdx, phaseIdx);
 
         EnergyModule::addSolidHeatStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
@@ -109,7 +111,10 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::computeFlux
      */
-    void computeFlux(RateVector &flux, const ElementContext &elemCtx, int scvfIdx, int timeIdx) const
+    void computeFlux(RateVector& flux,
+                     const ElementContext& elemCtx,
+                     unsigned scvfIdx,
+                     unsigned timeIdx) const
     {
         flux = 0.0;
         addAdvectiveFlux(flux, elemCtx, scvfIdx, timeIdx);
@@ -122,17 +127,19 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::addAdvectiveFlux
      */
-    void addAdvectiveFlux(RateVector &flux, const ElementContext &elemCtx,
-                          int scvfIdx, int timeIdx) const
+    void addAdvectiveFlux(RateVector& flux,
+                          const ElementContext& elemCtx,
+                          unsigned scvfIdx,
+                          unsigned timeIdx) const
     {
-        const auto &extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
 
-        int interiorIdx = extQuants.interiorIndex();
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        unsigned interiorIdx = extQuants.interiorIndex();
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             // data attached to upstream and the downstream DOFs
             // of the current phase
-            int upIdx = extQuants.upstreamIndex(phaseIdx);
-            const IntensiveQuantities &up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+            unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
+            const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
 
             // this is a bit hacky because it is specific to the element-centered
             // finite volume scheme. (N.B. that if finite differences are used to
@@ -142,7 +149,7 @@ public:
                     up.fluidState().molarDensity(phaseIdx)
                     * extQuants.volumeFlux(phaseIdx);
 
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     flux[conti0EqIdx + compIdx] +=
                         tmp*up.fluidState().moleFraction(phaseIdx, compIdx);
                 }
@@ -152,7 +159,7 @@ public:
                     Toolbox::value(up.fluidState().molarDensity(phaseIdx))
                     * extQuants.volumeFlux(phaseIdx);
 
-                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                     flux[conti0EqIdx + compIdx] +=
                         tmp*Toolbox::value(up.fluidState().moleFraction(phaseIdx, compIdx));
                 }
@@ -165,8 +172,10 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::addDiffusiveFlux
      */
-    void addDiffusiveFlux(RateVector &flux, const ElementContext &elemCtx,
-                          int scvfIdx, int timeIdx) const
+    void addDiffusiveFlux(RateVector& flux,
+                          const ElementContext& elemCtx,
+                          unsigned scvfIdx,
+                          unsigned timeIdx) const
     {
         DiffusionModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
         EnergyModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
@@ -175,10 +184,10 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::computeSource
      */
-    void computeSource(RateVector &source,
-                       const ElementContext &elemCtx,
-                       int dofIdx,
-                       int timeIdx) const
+    void computeSource(RateVector& source,
+                       const ElementContext& elemCtx,
+                       unsigned dofIdx,
+                       unsigned timeIdx) const
     {
         Valgrind::SetUndefined(source);
         elemCtx.problem().source(source, elemCtx, dofIdx, timeIdx);

--- a/ewoms/models/pvs/pvsnewtonmethod.hh
+++ b/ewoms/models/pvs/pvsnewtonmethod.hh
@@ -46,22 +46,18 @@ class PvsNewtonMethod : public GET_PROP_TYPE(TypeTag, DiscNewtonMethod)
     typedef typename GET_PROP_TYPE(TypeTag, SolutionVector) SolutionVector;
 
 public:
-    PvsNewtonMethod(Simulator &simulator) : ParentType(simulator)
+    PvsNewtonMethod(Simulator& simulator) : ParentType(simulator)
     {}
 
-    // HACK which is necessary because GCC 4.4 does not support
-    // being a friend of typedefs
-/*
 protected:
-    friend class NewtonMethod<TypeTag>;
-    friend class ParentType;
-*/
+    friend NewtonMethod<TypeTag>;
+    friend ParentType;
 
     /*!
      * \copydoc NewtonMethod::endIteration_
      */
-    void endIteration_(SolutionVector &uCurrentIter,
-                       const SolutionVector &uLastIter)
+    void endIteration_(SolutionVector& uCurrentIter,
+                       const SolutionVector& uLastIter)
     {
         ParentType::endIteration_(uCurrentIter, uLastIter);
         this->problem().model().switchPrimaryVars_();

--- a/ewoms/models/pvs/pvsratevector.hh
+++ b/ewoms/models/pvs/pvsratevector.hh
@@ -78,16 +78,16 @@ public:
     /*!
      * \copydoc ImmiscibleRateVector::ImmiscibleRateVector(const ImmiscibleRateVector&)
      */
-    PvsRateVector(const PvsRateVector &value) : ParentType(value)
+    PvsRateVector(const PvsRateVector& value) : ParentType(value)
     {}
 
     /*!
      * \copydoc ImmiscibleRateVector::setMassRate
      */
-    void setMassRate(const ParentType &value)
+    void setMassRate(const ParentType& value)
     {
         // convert to molar rates
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             (*this)[compIdx] = value[compIdx];
             (*this)[compIdx] /= FluidSystem::molarMass(compIdx);
         }
@@ -96,7 +96,7 @@ public:
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
@@ -110,9 +110,9 @@ public:
      * \copydoc ImmiscibleRateVector::setVolumetricRate
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState, int phaseIdx, const RhsEval& volume)
+    void setVolumetricRate(const FluidState& fluidState, unsigned phaseIdx, const RhsEval& volume)
     {
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx)
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
             (*this)[conti0EqIdx + compIdx] =
                 fluidState.density(phaseIdx, compIdx)
                 * fluidState.moleFraction(phaseIdx, compIdx)

--- a/ewoms/models/richards/richardsboundaryratevector.hh
+++ b/ewoms/models/richards/richardsboundaryratevector.hh
@@ -70,31 +70,30 @@ public:
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::ImmiscibleBoundaryRateVector(const
-     * ImmiscibleBoundaryRateVector &)
+     * ImmiscibleBoundaryRateVector& )
      */
-    RichardsBoundaryRateVector(const RichardsBoundaryRateVector &value)
-        : ParentType(value)
-    {}
+    RichardsBoundaryRateVector(const RichardsBoundaryRateVector& value) = default;
+    RichardsBoundaryRateVector& operator=(const RichardsBoundaryRateVector& value) = default;
 
     /*!
      * \copydoc ImmiscibleBoundaryRateVector::setFreeFlow
      */
     template <class Context, class FluidState>
-    void setFreeFlow(const Context &context, int bfIdx, int timeIdx, const FluidState &fluidState)
+    void setFreeFlow(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fluidState)
     {
         typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
         paramCache.updateAll(fluidState);
 
         ExtensiveQuantities extQuants;
         extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
-        const auto &insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
 
-        int phaseIdx = liquidPhaseIdx;
+        unsigned phaseIdx = liquidPhaseIdx;
         Evaluation density;
         if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
             density = FluidSystem::density(fluidState, paramCache, phaseIdx);
@@ -106,7 +105,7 @@ public:
         (*this)[contiEqIdx] += extQuants.volumeFlux(phaseIdx) * density;
 
 #ifndef NDEBUG
-        for (int i = 0; i < numEq; ++i) {
+        for (unsigned i = 0; i < numEq; ++i) {
             Valgrind::CheckDefined((*this)[i]);
         }
         Valgrind::CheckDefined(*this);
@@ -117,13 +116,15 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setInFlow
      */
     template <class Context, class FluidState>
-    void setInFlow(const Context &context, int bfIdx, int timeIdx,
-                   const FluidState &fluidState)
+    void setInFlow(const Context& context,
+                   unsigned bfIdx,
+                   unsigned timeIdx,
+                   const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the direction opposite to the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::min(0.0, val);
         }
@@ -133,13 +134,15 @@ public:
      * \copydoc ImmiscibleBoundaryRateVector::setOutFlow
      */
     template <class Context, class FluidState>
-    void setOutFlow(const Context &context, int bfIdx, int timeIdx,
-                    const FluidState &fluidState)
+    void setOutFlow(const Context& context,
+                    unsigned bfIdx,
+                    unsigned timeIdx,
+                    const FluidState& fluidState)
     {
         this->setFreeFlow(context, bfIdx, timeIdx, fluidState);
 
         // we only allow fluxes in the same direction as the outer unit normal
-        for (int eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             Evaluation& val = this->operator[](eqIdx);
             val = Toolbox::max(0.0, val);
         }

--- a/ewoms/models/richards/richardsintensivequantities.hh
+++ b/ewoms/models/richards/richardsintensivequantities.hh
@@ -86,7 +86,7 @@ public:
     /*!
      * \copydoc IntensiveQuantities::update
      */
-    void update(const ElementContext &elemCtx, int dofIdx, int timeIdx)
+    void update(const ElementContext& elemCtx, unsigned dofIdx, unsigned timeIdx)
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
 
@@ -95,10 +95,10 @@ public:
 
         // material law parameters
         typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
-        const auto &problem = elemCtx.problem();
-        const typename MaterialLaw::Params &materialParams =
+        const auto& problem = elemCtx.problem();
+        const typename MaterialLaw::Params& materialParams =
             problem.materialLawParams(elemCtx, dofIdx, timeIdx);
-        const auto &priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
 
         /////////
         // calculate the pressures
@@ -146,7 +146,7 @@ public:
         MaterialLaw::relativePermeabilities(relativePermeability_, materialParams, fluidState_);
 
         // mobilities
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             mobility_[phaseIdx] = relativePermeability_[phaseIdx]/fluidState_.viscosity(phaseIdx);
 
         // porosity
@@ -162,7 +162,7 @@ public:
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::fluidState
      */
-    const FluidState &fluidState() const
+    const FluidState& fluidState() const
     { return fluidState_; }
 
     /*!
@@ -174,19 +174,19 @@ public:
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::intrinsicPermeability
      */
-    const DimMatrix &intrinsicPermeability() const
+    const DimMatrix& intrinsicPermeability() const
     { return intrinsicPerm_; }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::relativePermeability
      */
-    const Evaluation& relativePermeability(int phaseIdx) const
+    const Evaluation& relativePermeability(unsigned phaseIdx) const
     { return relativePermeability_[phaseIdx]; }
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::mobility
      */
-    const Evaluation& mobility(int phaseIdx) const
+    const Evaluation& mobility(unsigned phaseIdx) const
     { return mobility_[phaseIdx]; }
 
 private:

--- a/ewoms/models/richards/richardslocalresidual.hh
+++ b/ewoms/models/richards/richardslocalresidual.hh
@@ -58,12 +58,12 @@ public:
      * \copydoc ImmiscibleLocalResidual::computeStorage
      */
     template <class LhsEval>
-    void computeStorage(Dune::FieldVector<LhsEval, numEq> &storage,
-                        const ElementContext &elemCtx,
-                        int dofIdx,
-                        int timeIdx) const
+    void computeStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                        const ElementContext& elemCtx,
+                        unsigned dofIdx,
+                        unsigned timeIdx) const
     {
-        const IntensiveQuantities &intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
+        const IntensiveQuantities& intQuants = elemCtx.intensiveQuantities(dofIdx, timeIdx);
 
         // partial time derivative of the wetting phase mass
         storage[contiEqIdx] =
@@ -75,15 +75,17 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::computeFlux
      */
-    void computeFlux(RateVector &flux, const ElementContext &elemCtx,
-                     int scvfIdx, int timeIdx) const
+    void computeFlux(RateVector& flux,
+                     const ElementContext& elemCtx,
+                     unsigned scvfIdx,
+                     unsigned timeIdx) const
     {
-        const auto &extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
 
-        int interiorIdx = extQuants.interiorIndex();
-        int upIdx = extQuants.upstreamIndex(liquidPhaseIdx);
+        unsigned interiorIdx = extQuants.interiorIndex();
+        unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(liquidPhaseIdx));
 
-        const IntensiveQuantities &up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+        const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
 
         // compute advective mass flux of the liquid phase. This is slightly hacky
         // because it is specific to the element-centered finite volume method.
@@ -97,10 +99,10 @@ public:
     /*!
      * \copydoc ImmiscibleLocalResidual::computeSource
      */
-    void computeSource(RateVector &source,
-                       const ElementContext &elemCtx,
-                       int dofIdx,
-                       int timeIdx) const
+    void computeSource(RateVector& source,
+                       const ElementContext& elemCtx,
+                       unsigned dofIdx,
+                       unsigned timeIdx) const
     { elemCtx.problem().source(source, elemCtx, dofIdx, timeIdx); }
 };
 

--- a/ewoms/models/richards/richardsmodel.hh
+++ b/ewoms/models/richards/richardsmodel.hh
@@ -46,8 +46,7 @@
 #include <opm/material/fluidsystems/LiquidPhase.hpp>
 #include <opm/material/fluidsystems/GasPhase.hpp>
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
-
-#include <dune/common/unused.hh>
+#include <opm/material/common/Unused.hpp>
 
 #include <sstream>
 #include <string>
@@ -241,14 +240,14 @@ class RichardsModel
     typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
     typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
 
-     static const int numPhases = FluidSystem::numPhases;
-     static const int numComponents = FluidSystem::numComponents;
+     static const unsigned numPhases = FluidSystem::numPhases;
+     static const unsigned numComponents = FluidSystem::numComponents;
 
-    static const int liquidPhaseIdx = GET_PROP_VALUE(TypeTag, LiquidPhaseIndex);
-    static const int gasPhaseIdx = GET_PROP_VALUE(TypeTag, GasPhaseIndex);
+    static const unsigned liquidPhaseIdx = GET_PROP_VALUE(TypeTag, LiquidPhaseIndex);
+    static const unsigned gasPhaseIdx = GET_PROP_VALUE(TypeTag, GasPhaseIndex);
 
-    static const int liquidCompIdx = GET_PROP_VALUE(TypeTag, LiquidComponentIndex);
-    static const int gasCompIdx = GET_PROP_VALUE(TypeTag, GasComponentIndex);
+    static const unsigned liquidCompIdx = GET_PROP_VALUE(TypeTag, LiquidComponentIndex);
+    static const unsigned gasCompIdx = GET_PROP_VALUE(TypeTag, GasComponentIndex);
 
 
     // some consistency checks
@@ -262,7 +261,7 @@ class RichardsModel
                   "The liquid and the gas components must be different");
 
 public:
-    RichardsModel(Simulator &simulator)
+    RichardsModel(Simulator& simulator)
         : ParentType(simulator)
     {
         // the liquid phase must be liquid, the gas phase must be
@@ -288,7 +287,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarName
      */
-    std::string primaryVarName(int pvIdx) const
+    std::string primaryVarName(unsigned pvIdx) const
     {
         std::ostringstream oss;
         if (pvIdx == Indices::pressureWIdx)
@@ -302,7 +301,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::eqName
      */
-    std::string eqName(int eqIdx) const
+    std::string eqName(unsigned eqIdx) const
     {
         std::ostringstream oss;
         if (eqIdx == Indices::contiEqIdx)
@@ -316,7 +315,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::primaryVarWeight
      */
-    Scalar primaryVarWeight(int globalDofIdx, int pvIdx) const
+    Scalar primaryVarWeight(unsigned OPM_UNUSED globalDofIdx, unsigned pvIdx) const
     {
         if (Indices::pressureWIdx == pvIdx) {
             return 10 / referencePressure_;
@@ -328,9 +327,9 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::eqWeight
      */
-    Scalar eqWeight(int globalDofIdx, int eqIdx) const
+    Scalar eqWeight(unsigned OPM_UNUSED globalDofIdx, unsigned OPM_OPTIM_UNUSED eqIdx) const
     {
-        int DUNE_UNUSED compIdx = eqIdx - Indices::contiEqIdx;
+        unsigned OPM_OPTIM_UNUSED compIdx = eqIdx - Indices::contiEqIdx;
         assert(0 <= compIdx && compIdx <= FluidSystem::numPhases);
 
         // make all kg equal
@@ -347,7 +346,7 @@ public:
         // find the a reference pressure. The first degree of freedom
         // might correspond to non-interior entities which would lead
         // to an undefined value, so we have to iterate...
-        for (size_t dofIdx = 0; dofIdx < this->numGridDof(); ++ dofIdx) {
+        for (unsigned dofIdx = 0; dofIdx < this->numGridDof(); ++ dofIdx) {
             if (this->isLocalDof(dofIdx)) {
                 referencePressure_ =
                     this->solution(/*timeIdx=*/0)[dofIdx][/*pvIdx=*/Indices::pressureWIdx];
@@ -359,7 +358,7 @@ public:
     /*!
      * \copydoc FvBaseDiscretization::phaseIsConsidered
      */
-    bool phaseIsConsidered(int phaseIdx) const
+    bool phaseIsConsidered(unsigned phaseIdx) const
     { return phaseIdx == liquidPhaseIdx; }
 
     void registerOutputModules_()

--- a/ewoms/models/richards/richardsnewtonmethod.hh
+++ b/ewoms/models/richards/richardsnewtonmethod.hh
@@ -31,6 +31,7 @@
 #include "richardsproperties.hh"
 
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -64,24 +65,21 @@ class RichardsNewtonMethod : public GET_PROP_TYPE(TypeTag, DiscNewtonMethod)
     typedef Dune::FieldVector<Scalar, numPhases> PhaseVector;
 
 public:
-    RichardsNewtonMethod(Simulator &simulator) : ParentType(simulator)
+    RichardsNewtonMethod(Simulator& simulator) : ParentType(simulator)
     {}
 
-    // HACK necessary for GCC 4.4
-/*
 protected:
-    friend class NewtonMethod<TypeTag>;
+    friend NewtonMethod<TypeTag>;
     friend ParentType;
-*/
 
     /*!
      * \copydoc FvBaseNewtonMethod::updatePrimaryVariables_
      */
-    void updatePrimaryVariables_(int globalDofIdx,
+    void updatePrimaryVariables_(unsigned globalDofIdx,
                                  PrimaryVariables& nextValue,
                                  const PrimaryVariables& currentValue,
                                  const EqVector& update,
-                                 const EqVector& currentResidual)
+                                 const EqVector& OPM_UNUSED currentResidual)
     {
         // normal Newton-Raphson update
         nextValue = currentValue;
@@ -94,7 +92,7 @@ protected:
         const auto& problem = this->simulator_.problem();
 
         // calculate the old wetting phase saturation
-        const MaterialLawParams &matParams =
+        const MaterialLawParams& matParams =
             problem.materialLawParams(globalDofIdx, /*timeIdx=*/0);
 
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;

--- a/ewoms/models/richards/richardsprimaryvariables.hh
+++ b/ewoms/models/richards/richardsprimaryvariables.hh
@@ -34,6 +34,8 @@
 
 #include <opm/material/constraintsolvers/ImmiscibleFlash.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -85,11 +87,10 @@ public:
 
     /*!
      * \copydoc ImmisciblePrimaryVariables::ImmisciblePrimaryVariables(const
-     * ImmisciblePrimaryVariables &)
+     * ImmisciblePrimaryVariables& )
      */
-    RichardsPrimaryVariables(const RichardsPrimaryVariables &value)
-        : ParentType(value)
-    {}
+    RichardsPrimaryVariables(const RichardsPrimaryVariables& value) = default;
+    RichardsPrimaryVariables& operator=(const RichardsPrimaryVariables& value) = default;
 
     /*!
      * \brief Set the primary variables with the wetting phase
@@ -101,7 +102,7 @@ public:
      * \param matParams The capillary pressure law parameters
      */
     void assignImmiscibleFromWetting(Scalar T, Scalar pw, Scalar Sw,
-                                     const MaterialLawParams &matParams)
+                                     const MaterialLawParams& matParams)
     {
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
 
@@ -129,7 +130,7 @@ public:
      * \param matParams The capillary pressure law parameters
      */
     void assignImmiscibleFromNonWetting(Scalar T, Scalar pn, Scalar Sn,
-                                        const MaterialLawParams &matParams)
+                                        const MaterialLawParams& matParams)
     {
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
 
@@ -151,13 +152,13 @@ public:
      * \copydoc ImmisciblePrimaryVariables::assignMassConservative
      */
     template <class FluidState>
-    void assignMassConservative(const FluidState &fluidState,
-                                const MaterialLawParams &matParams,
-                                bool isInEquilibrium = false)
+    void assignMassConservative(const FluidState& fluidState,
+                                const MaterialLawParams& matParams,
+                                bool OPM_UNUSED isInEquilibrium = false)
     {
         ComponentVector globalMolarities(0.0);
-        for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
-            for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 globalMolarities[compIdx] +=
                     fluidState.molarity(phaseIdx, compIdx) * fluidState.saturation(phaseIdx);
             }
@@ -177,7 +178,7 @@ public:
      * \copydoc ImmisciblePrimaryVariables::assignNaive
      */
     template <class FluidState>
-    void assignNaive(const FluidState &fluidState)
+    void assignNaive(const FluidState& fluidState)
     {
         // assign the phase temperatures. this is out-sourced to
         // the energy module

--- a/ewoms/models/richards/richardsratevector.hh
+++ b/ewoms/models/richards/richardsratevector.hh
@@ -75,22 +75,22 @@ public:
 
     /*!
      * \copydoc ImmiscibleRateVector::ImmiscibleRateVector(const
-     * ImmiscibleRateVector &)
+     * ImmiscibleRateVector& )
      */
-    RichardsRateVector(const RichardsRateVector &value)
+    RichardsRateVector(const RichardsRateVector& value)
         : ParentType(value)
     {}
 
     /*!
      * \copydoc ImmiscibleRateVector::setMassRate
      */
-    void setMassRate(const ParentType &value)
+    void setMassRate(const ParentType& value)
     { ParentType::operator=(value); }
 
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType &value)
+    void setMolarRate(const ParentType& value)
     {
         // convert to mass rates
         ParentType::operator[](contiEqIdx) =
@@ -108,7 +108,7 @@ public:
      * \copydoc ImmiscibleRateVector::setVolumetricRate
      */
     template <class FluidState, class RhsEval>
-    void setVolumetricRate(const FluidState &fluidState, int phaseIdx, const RhsEval& volume)
+    void setVolumetricRate(const FluidState& fluidState, unsigned phaseIdx, const RhsEval& volume)
     {
        (*this)[contiEqIdx] =
             fluidState.density(phaseIdx)

--- a/ewoms/models/stokes/stokesextensivequantities.hh
+++ b/ewoms/models/stokes/stokesextensivequantities.hh
@@ -34,6 +34,7 @@
 #include <ewoms/models/common/quantitycallbacks.hh>
 
 #include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -82,10 +83,10 @@ public:
      * \param isBoundaryFace Specifies whether the sub-control-volume face is on the
      *                       domain boundary or not.
      */
-    void update(const ElementContext &elemCtx, int scvfIdx, int timeIdx, bool isBoundaryFace=false)
+    void update(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx, bool isBoundaryFace=false)
     {
-        const auto &stencil = elemCtx.stencil(timeIdx);
-        const auto &scvf =
+        const auto& stencil = elemCtx.stencil(timeIdx);
+        const auto& scvf =
             isBoundaryFace?
             stencil.boundaryFace(scvfIdx):
             stencil.interiorFace(scvfIdx);
@@ -113,7 +114,7 @@ public:
         viscosity_ = gradCalc.calculateValue(elemCtx, scvfIdx, viscosityCallback);
         velocity_ = gradCalc.calculateValue(elemCtx, scvfIdx, velocityCallback);
 
-        for (int dimIdx = 0; dimIdx < dimWorld; ++dimIdx) {
+        for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx) {
             velocityComponentCallback.setDimIndex(dimIdx);
             gradCalc.calculateGradient(velocityGrad_[dimIdx],
                                        elemCtx,
@@ -143,9 +144,11 @@ public:
      * \copydoc MultiPhaseBaseExtensiveQuantities::updateBoundary
      */
     template <class Context, class FluidState>
-    void updateBoundary(const Context &context, int bfIdx, int timeIdx,
-                        const FluidState &fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> &paramCache)
+    void updateBoundary(const Context& context,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState,
+                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
     {
         update(context, bfIdx, timeIdx, fluidState, paramCache,
                /*isOnBoundary=*/true);
@@ -183,20 +186,20 @@ public:
     /*!
      * \brief Return the pressure gradient at the integration point.
      */
-    const DimVector &pressureGrad() const
+    const DimVector& pressureGrad() const
     { return pressureGrad_; }
 
     /*!
      * \brief Return the velocity vector at the integration point.
      */
-    const DimVector &velocity() const
+    const DimVector& velocity() const
     { return velocity_; }
 
     /*!
      * \brief Return the velocity gradient at the integration
      *        point of a face.
      */
-    const DimVector &velocityGrad(int axisIdx) const
+    const DimVector& velocityGrad(unsigned axisIdx) const
     { return velocityGrad_[axisIdx]; }
 
     /*!
@@ -214,45 +217,45 @@ public:
     /*!
      * \brief Return the volume flux of mass
      */
-    Scalar volumeFlux(int phaseIdx) const
+    Scalar volumeFlux(unsigned OPM_UNUSED phaseIdx) const
     { return volumeFlux_; }
 
     /*!
      * \brief Return the weight of the upstream index
      */
-    Scalar upstreamWeight(int phaseIdx) const
+    Scalar upstreamWeight(unsigned OPM_UNUSED phaseIdx) const
     { return 1.0; }
 
     /*!
      * \brief Return the weight of the downstream index
      */
-    Scalar downstreamWeight(int phaseIdx) const
+    Scalar downstreamWeight(unsigned OPM_UNUSED phaseIdx) const
     { return 0.0; }
 
     /*!
      * \brief Return the local index of the upstream sub-control volume.
      */
-    int upstreamIndex(int phaseIdx) const
+    unsigned upstreamIndex(unsigned OPM_UNUSED phaseIdx) const
     { return upstreamIdx_; }
 
     /*!
      * \brief Return the local index of the downstream sub-control volume.
      */
-    int downstreamIndex(int phaseIdx) const
+    unsigned downstreamIndex(unsigned OPM_UNUSED phaseIdx) const
     { return downstreamIdx_; }
 
     /*!
      * \brief Return the local index of the sub-control volume which is located
      * in negative normal direction.
      */
-    int interiorIndex() const
+    unsigned interiorIndex() const
     { return insideIdx_; }
 
     /*!
      * \brief Return the local index of the sub-control volume which is located
      * in negative normal direction.
      */
-    int exteriorIndex() const
+    unsigned exteriorIndex() const
     { return outsideIdx_; }
 
     /*!
@@ -271,7 +274,7 @@ public:
     /*!
      * \brief Returns normal vector of the face of the extensive quantities.
      */
-    const DimVector &normal() const
+    const DimVector& normal() const
     { return normal_; }
 
 private:
@@ -291,12 +294,12 @@ private:
     DimVector velocityGrad_[dimWorld];
 
     // local index of the upstream dof
-    int upstreamIdx_;
+    unsigned upstreamIdx_;
     // local index of the downstream dof
-    int downstreamIdx_;
+    unsigned downstreamIdx_;
 
-    int insideIdx_;
-    int outsideIdx_;
+    unsigned insideIdx_;
+    unsigned outsideIdx_;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/stokes/stokesproblem.hh
+++ b/ewoms/models/stokes/stokesproblem.hh
@@ -29,7 +29,12 @@
 #define EWOMS_STOKES_PROBLEM_HH
 
 #include "stokesproperties.hh"
+
 #include <ewoms/disc/common/fvbaseproblem.hh>
+
+#include <opm/material/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -61,9 +66,9 @@ class StokesProblem : public Ewoms::FvBaseProblem<TypeTag>
 
 public:
     /*!
-     * \copydoc FvBaseProblem::FvBaseProblem(Simulator &, const GridView &)
+     * \copydoc FvBaseProblem::FvBaseProblem(Simulator& , const GridView& )
      */
-    StokesProblem(Simulator &simulator)
+    StokesProblem(Simulator& simulator)
         : ParentType(simulator)
         , gravity_(0)
     {
@@ -95,7 +100,9 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    Scalar temperature(const Context &context, int spaceIdx, int timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return asImp_().temperature(); }
 
     /*!
@@ -115,8 +122,9 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    Scalar heatCapacitySolid(const Context &context, int spaceIdx,
-                             int timeIdx) const
+    Scalar heatCapacitySolid(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     { return 0; }
 
     /*!
@@ -127,7 +135,9 @@ public:
      */
     template <class Context>
     const HeatConductionLawParams &
-    heatConductionParams(const Context &context, int spaceIdx, int timeIdx) const
+    heatConductionParams(const Context& OPM_UNUSED context,
+                         unsigned OPM_UNUSED spaceIdx,
+                         unsigned OPM_UNUSED timeIdx) const
     {
         static const HeatConductionLawParams dummy;
         return dummy;
@@ -143,8 +153,9 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    const DimVector &gravity(const Context &context, int spaceIdx,
-                             int timeIdx) const
+    const DimVector& gravity(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     { return asImp_().gravity(); }
 
     /*!
@@ -155,18 +166,18 @@ public:
      {g} = (
      *0,\dots, 0)^T \f$
      */
-    const DimVector &gravity() const
+    const DimVector& gravity() const
     { return gravity_; }
 
     // \}
 
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
-    Implementation &asImp_()
+    Implementation& asImp_()
     { return *static_cast<Implementation *>(this); }
 
     //! \copydoc asImp_()
-    const Implementation &asImp_() const
+    const Implementation& asImp_() const
     { return *static_cast<const Implementation *>(this); }
 
     DimVector gravity_;

--- a/ewoms/nonlinear/nullconvergencewriter.hh
+++ b/ewoms/nonlinear/nullconvergencewriter.hh
@@ -30,6 +30,8 @@
 
 #include <ewoms/common/propertysystem.hh>
 
+#include <opm/material/common/Unused.hpp>
+
 namespace Ewoms {
 namespace Properties {
 NEW_PROP_TAG(NewtonMethod);
@@ -54,7 +56,7 @@ class NullConvergenceWriter
     typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) GlobalEqVector;
 
 public:
-    NullConvergenceWriter(NewtonMethod &method)
+    NullConvergenceWriter(NewtonMethod& method OPM_UNUSED)
     {}
 
     /*!
@@ -80,8 +82,8 @@ public:
      * \param deltaU The negative difference between the solution
      *        vectors of the previous and the current iteration.
      */
-    void writeFields(const SolutionVector &uLastIter,
-                     const GlobalEqVector &deltaU)
+    void writeFields(const SolutionVector& uLastIter OPM_UNUSED,
+                     const GlobalEqVector& deltaU OPM_UNUSED)
     {}
 
     /*!

--- a/ewoms/parallel/gridcommhandles.hh
+++ b/ewoms/parallel/gridcommhandles.hh
@@ -29,6 +29,8 @@
 #ifndef EWOMS_GRID_COMM_HANDLES_HH
 #define EWOMS_GRID_COMM_HANDLES_HH
 
+#include <opm/material/common/Unused.hpp>
+
 #include <dune/grid/common/datahandleif.hh>
 #include <dune/common/version.hh>
 
@@ -45,18 +47,18 @@ class GridCommHandleSum
                                     FieldType>
 {
 public:
-    GridCommHandleSum(Container &container, const EntityMapper &mapper)
+    GridCommHandleSum(Container& container, const EntityMapper& mapper)
         : mapper_(mapper), container_(container)
     {}
 
-    bool contains(int dim, int codim) const
+    bool contains(int OPM_UNUSED dim, int codim) const
     {
         // return true if the codim is the same as the codim which we
         // are asked to communicate with.
         return codim == commCodim;
     }
 
-    bool fixedsize(int dim, int codim) const
+    bool fixedsize(int OPM_UNUSED dim, int OPM_UNUSED codim) const
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -64,30 +66,30 @@ public:
     }
 
     template <class EntityType>
-    size_t size(const EntityType &e) const
+    size_t size(const EntityType& OPM_UNUSED e) const
     {
         // communicate a field type per entity
         return 1;
     }
 
     template <class MessageBufferImp, class EntityType>
-    void gather(MessageBufferImp &buff, const EntityType &e) const
+    void gather(MessageBufferImp& buff, const EntityType& e) const
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
-    void scatter(MessageBufferImp &buff, const EntityType &e, size_t n)
+    void scatter(MessageBufferImp& buff, const EntityType& e, size_t OPM_UNUSED n)
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
 
         FieldType tmp;
@@ -96,8 +98,8 @@ public:
     }
 
 private:
-    const EntityMapper &mapper_;
-    Container &container_;
+    const EntityMapper& mapper_;
+    Container& container_;
 };
 
 /*!
@@ -105,26 +107,26 @@ private:
  *        set the values values of ghost and overlap DOFs from their
  *        respective master processes.
  */
-template <class FieldType, class Container, class EntityMapper, int commCodim>
+template <class FieldType, class Container, class EntityMapper, unsigned commCodim>
 class GridCommHandleGhostSync
     : public Dune::CommDataHandleIF<GridCommHandleGhostSync<FieldType, Container,
                                                             EntityMapper, commCodim>,
                                     FieldType>
 {
 public:
-    GridCommHandleGhostSync(Container &container, const EntityMapper &mapper)
+    GridCommHandleGhostSync(Container& container, const EntityMapper& mapper)
         : mapper_(mapper), container_(container)
     {
     }
 
-    bool contains(int dim, int codim) const
+    bool contains(unsigned OPM_UNUSED dim, unsigned codim) const
     {
         // return true if the codim is the same as the codim which we
         // are asked to communicate with.
         return codim == commCodim;
     }
 
-    bool fixedsize(int dim, int codim) const
+    bool fixedsize(unsigned OPM_UNUSED dim, unsigned OPM_UNUSED codim) const
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -132,62 +134,62 @@ public:
     }
 
     template <class EntityType>
-    size_t size(const EntityType &e) const
+    size_t size(const EntityType& OPM_UNUSED e) const
     {
         // communicate a field type per entity
         return 1;
     }
 
     template <class MessageBufferImp, class EntityType>
-    void gather(MessageBufferImp &buff, const EntityType &e) const
+    void gather(MessageBufferImp& buff, const EntityType& e) const
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
-    void scatter(MessageBufferImp &buff, const EntityType &e, size_t n)
+    void scatter(MessageBufferImp& buff, const EntityType& e, size_t OPM_UNUSED n)
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         buff.read(container_[dofIdx]);
     }
 
 private:
-    const EntityMapper &mapper_;
-    Container &container_;
+    const EntityMapper& mapper_;
+    Container& container_;
 };
 
 /*!
  * \brief Data handle for parallel communication which takes the
  *        maximum of all values that are attached to DOFs
  */
-template <class FieldType, class Container, class EntityMapper, int commCodim>
+template <class FieldType, class Container, class EntityMapper, unsigned commCodim>
 class GridCommHandleMax
     : public Dune::CommDataHandleIF<GridCommHandleMax<FieldType, Container,
                                                       EntityMapper, commCodim>,
                                     FieldType>
 {
 public:
-    GridCommHandleMax(Container &container, const EntityMapper &mapper)
+    GridCommHandleMax(Container& container, const EntityMapper& mapper)
         : mapper_(mapper), container_(container)
     {}
 
-    bool contains(int dim, int codim) const
+    bool contains(unsigned OPM_UNUSED dim, unsigned codim) const
     {
         // return true if the codim is the same as the codim which we
         // are asked to communicate with.
         return codim == commCodim;
     }
 
-    bool fixedsize(int dim, int codim) const
+    bool fixedsize(unsigned OPM_UNUSED dim, unsigned OPM_UNUSED codim) const
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -195,30 +197,30 @@ public:
     }
 
     template <class EntityType>
-    size_t size(const EntityType &e) const
+    size_t size(const EntityType& OPM_UNUSED e) const
     {
         // communicate a field type per entity
         return 1;
     }
 
     template <class MessageBufferImp, class EntityType>
-    void gather(MessageBufferImp &buff, const EntityType &e) const
+    void gather(MessageBufferImp& buff, const EntityType& e) const
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
-    void scatter(MessageBufferImp &buff, const EntityType &e, size_t n)
+    void scatter(MessageBufferImp& buff, const EntityType& e, size_t OPM_UNUSED n)
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         FieldType tmp;
         buff.read(tmp);
@@ -226,33 +228,33 @@ public:
     }
 
 private:
-    const EntityMapper &mapper_;
-    Container &container_;
+    const EntityMapper& mapper_;
+    Container& container_;
 };
 
 /*!
  * \brief Provides data handle for parallel communication which takes
  *        the minimum of all values that are attached to DOFs
  */
-template <class FieldType, class Container, class EntityMapper, int commCodim>
+template <class FieldType, class Container, class EntityMapper, unsigned commCodim>
 class GridCommHandleMin
     : public Dune::CommDataHandleIF<GridCommHandleMin<FieldType, Container,
                                                       EntityMapper, commCodim>,
                                     FieldType>
 {
 public:
-    GridCommHandleMin(Container &container, const EntityMapper &mapper)
+    GridCommHandleMin(Container& container, const EntityMapper& mapper)
         : mapper_(mapper), container_(container)
     {}
 
-    bool contains(int dim, int codim) const
+    bool contains(unsigned OPM_UNUSED dim, unsigned codim) const
     {
         // return true if the codim is the same as the codim which we
         // are asked to communicate with.
         return codim == commCodim;
     }
 
-    bool fixedsize(int dim, int codim) const
+    bool fixedsize(unsigned OPM_UNUSED dim, unsigned OPM_UNUSED codim) const
     {
         // for each DOF we communicate a single value which has a
         // fixed size
@@ -260,30 +262,30 @@ public:
     }
 
     template <class EntityType>
-    size_t size(const EntityType &e) const
+    size_t size(const EntityType& OPM_UNUSED e) const
     {
         // communicate a field type per entity
         return 1;
     }
 
     template <class MessageBufferImp, class EntityType>
-    void gather(MessageBufferImp &buff, const EntityType &e) const
+    void gather(MessageBufferImp& buff, const EntityType& e) const
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
-    void scatter(MessageBufferImp &buff, const EntityType &e, size_t n)
+    void scatter(MessageBufferImp& buff, const EntityType& e, size_t OPM_UNUSED n)
     {
 #if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-        int dofIdx = mapper_.index(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
 #else
-        int dofIdx = mapper_.map(e);
+        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
 #endif
         FieldType tmp;
         buff.read(tmp);
@@ -291,8 +293,8 @@ public:
     }
 
 private:
-    const EntityMapper &mapper_;
-    Container &container_;
+    const EntityMapper& mapper_;
+    Container& container_;
 };
 
 } // namespace Ewoms

--- a/ewoms/parallel/mpibuffer.hh
+++ b/ewoms/parallel/mpibuffer.hh
@@ -30,6 +30,7 @@
 #if HAVE_MPI
 #include <mpi.h>
 #endif
+
 #include <stddef.h>
 
 #include <type_traits>
@@ -53,7 +54,7 @@ public:
         updateMpiDataSize_();
     }
 
-    MpiBuffer(int size)
+    MpiBuffer(size_t size)
     {
         data_ = new DataType[size];
         dataSize_ = size;
@@ -61,6 +62,8 @@ public:
         setMpiDataType_();
         updateMpiDataSize_();
     }
+
+    MpiBuffer(const MpiBuffer&) = default;
 
     ~MpiBuffer()
     { delete[] data_; }
@@ -79,11 +82,16 @@ public:
     /*!
      * \brief Send the buffer asyncronously to a peer process.
      */
-    void send(int peerRank, bool setNoAccess = true)
+    void send(unsigned peerRank)
     {
 #if HAVE_MPI
-        MPI_Isend(data_, mpiDataSize_, mpiDataType_, peerRank, 0, // tag
-                  MPI_COMM_WORLD, &mpiRequest_);
+        MPI_Isend(data_,
+                  static_cast<int>(mpiDataSize_),
+                  mpiDataType_,
+                  static_cast<int>(peerRank),
+                  0, // tag
+                  MPI_COMM_WORLD,
+                  &mpiRequest_);
 #endif
     }
 
@@ -100,11 +108,16 @@ public:
     /*!
      * \brief Receive the buffer syncronously from a peer rank
      */
-    void receive(int peerRank)
+    void receive(unsigned peerRank)
     {
 #if HAVE_MPI
-        MPI_Recv(data_, mpiDataSize_, mpiDataType_, peerRank, 0, // tag
-                 MPI_COMM_WORLD, &mpiStatus_);
+        MPI_Recv(data_,
+                 static_cast<int>(mpiDataSize_),
+                 mpiDataType_,
+                 static_cast<int>(peerRank),
+                 0, // tag
+                 MPI_COMM_WORLD,
+                 &mpiStatus_);
         assert(!mpiStatus_.MPI_ERROR);
 #endif // HAVE_MPI
     }
@@ -115,14 +128,14 @@ public:
      *
      * This object is only well defined after the send() method.
      */
-    MPI_Request &request()
+    MPI_Request& request()
     { return mpiRequest_; }
     /*!
      * \brief Returns the current MPI_Request object.
      *
      * This object is only well defined after the send() method.
      */
-    const MPI_Request &request() const
+    const MPI_Request& request() const
     { return mpiRequest_; }
 
     /*!
@@ -130,14 +143,14 @@ public:
      *
      * This object is only well defined after the receive() and wait() methods.
      */
-    MPI_Status &status()
+    MPI_Status& status()
     { return mpiStatus_; }
     /*!
      * \brief Returns the current MPI_Status object.
      *
      * This object is only well defined after the receive() and wait() methods.
      */
-    const MPI_Status &status() const
+    const MPI_Status& status() const
     { return mpiStatus_; }
 #endif // HAVE_MPI
 
@@ -150,7 +163,7 @@ public:
     /*!
      * \brief Provide access to the buffer data.
      */
-    DataType &operator[](size_t i)
+    DataType& operator[](size_t i)
     {
         assert(0 <= i && i < dataSize_);
         return data_[i];
@@ -159,7 +172,7 @@ public:
     /*!
      * \brief Provide access to the buffer data.
      */
-    const DataType &operator[](size_t i) const
+    const DataType& operator[](size_t i) const
     {
         assert(0 <= i && i < dataSize_);
         return data_[i];

--- a/ewoms/parallel/threadedentityiterator.hh
+++ b/ewoms/parallel/threadedentityiterator.hh
@@ -49,7 +49,7 @@ public:
         , sequentialEnd_(gridView.template end<codim>())
     { }
 
-    ThreadedEntityIterator(const ThreadedEntityIterator &other) = default;
+    ThreadedEntityIterator(const ThreadedEntityIterator& other) = default;
 
     // begin iterating over the grid in parallel
     EntityIterator beginParallel()

--- a/ewoms/parallel/threadmanager.hh
+++ b/ewoms/parallel/threadmanager.hh
@@ -33,8 +33,10 @@
 
 #include <ewoms/parallel/locks.hh>
 #include <ewoms/common/parametersystem.hh>
-
 #include <ewoms/common/propertysystem.hh>
+
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
 
 #include <dune/common/version.hh>
 
@@ -116,16 +118,16 @@ public:
     /*!
      * \brief Return the maximum number of threads of the current process.
      */
-    static int maxThreads()
-    { return numThreads_; }
+    static unsigned maxThreads()
+    { return static_cast<unsigned>(numThreads_); }
 
     /*!
      * \brief Return the index of the current OpenMP thread
      */
-    static int threadId()
+    static unsigned threadId()
     {
 #ifdef _OPENMP
-        return omp_get_thread_num();
+        return static_cast<unsigned>(omp_get_thread_num());
 #else
         return 0;
 #endif

--- a/tests/problems/co2injectionflash.hh
+++ b/tests/problems/co2injectionflash.hh
@@ -50,11 +50,11 @@ public:
      * \brief Guess initial values for all quantities.
      */
     template <class FluidState, class ComponentVector>
-    static void guessInitial(FluidState &fluidState, const ComponentVector &globalMolarities)
+    static void guessInitial(FluidState& fluidState, const ComponentVector& globalMolarities)
     {
         ParentType::guessInitial(fluidState, globalMolarities);
 
-        for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             // pressure. use something close to the reservoir pressure as initial guess
             fluidState.setPressure(phaseIdx, 100e5);
         }

--- a/tests/problems/diffusionproblem.hh
+++ b/tests/problems/diffusionproblem.hh
@@ -30,7 +30,6 @@
 
 #include <ewoms/models/ncp/ncpproperties.hh>
 
-#include <dune/grid/yaspgrid.hh>
 #include <ewoms/io/cubegridmanager.hh>
 
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
@@ -38,7 +37,9 @@
 #include <opm/material/fluidsystems/H2ON2FluidSystem.hpp>
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
+#include <opm/material/common/Unused.hpp>
 
+#include <dune/grid/yaspgrid.hh>
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
@@ -174,7 +175,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    DiffusionProblem(Simulator &simulator)
+    DiffusionProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -237,30 +238,37 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
-                                           unsigned timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& OPM_UNUSED context,
+                                           unsigned OPM_UNUSED spaceIdx,
+                                           unsigned OPM_UNUSED timeIdx) const
     { return K_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return 0.35; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
-                                               unsigned spaceIdx, unsigned timeIdx) const
+    const MaterialLawParams&
+    materialLawParams(const Context& OPM_UNUSED context,
+                      unsigned OPM_UNUSED spaceIdx,
+                      unsigned OPM_UNUSED timeIdx) const
     { return materialParams_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; }
 
     //! \}
@@ -276,8 +284,10 @@ public:
      * This problem sets no-flow boundaries everywhere.
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
-                  unsigned spaceIdx, unsigned timeIdx) const
+    void boundary(BoundaryRateVector& values,
+                  const Context& OPM_UNUSED context,
+                  unsigned OPM_UNUSED spaceIdx,
+                  unsigned OPM_UNUSED timeIdx) const
     { values.setNoFlow(); }
 
     //! \}
@@ -291,10 +301,12 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values,
+                 const Context& context,
+                 unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
         if (onLeftSide_(pos))
             values.assignNaive(leftInitialFluidState_);
         else
@@ -308,14 +320,16 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool onLeftSide_(const GlobalPosition &pos) const
+    bool onLeftSide_(const GlobalPosition& pos) const
     { return pos[0] < (this->boundingBoxMin()[0] + this->boundingBoxMax()[0]) / 2; }
 
     void setupInitialFluidStates_()

--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -28,7 +28,6 @@
 #ifndef EWOMS_FRACTURE_PROBLEM_HH
 #define EWOMS_FRACTURE_PROBLEM_HH
 
-
 #if HAVE_DUNE_ALUGRID
 // avoid reordering of macro elements, otherwise this problem won't work
 #define DISABLE_ALUGRID_SFC_ORDERING 1
@@ -40,16 +39,17 @@
 
 #include <ewoms/models/discretefracture/discretefracturemodel.hh>
 #include <ewoms/io/dgfgridmanager.hh>
+
 #include <opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp>
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
-
 #include <opm/material/heatconduction/Somerton.hpp>
 #include <opm/material/fluidsystems/TwoPhaseImmiscibleFluidSystem.hpp>
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Dnapl.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/fmatrix.hh>
@@ -220,7 +220,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    FractureProblem(Simulator &simulator)
+    FractureProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -316,7 +316,9 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; }
 
     // \}
@@ -330,8 +332,9 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
-                                           unsigned timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& OPM_UNUSED context,
+                                           unsigned OPM_UNUSED spaceIdx,
+                                           unsigned OPM_UNUSED timeIdx) const
     { return matrixK_; }
 
     /*!
@@ -340,16 +343,18 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    const DimMatrix &fractureIntrinsicPermeability(const Context &context,
-                                                   unsigned spaceIdx,
-                                                   unsigned timeIdx) const
+    const DimMatrix& fractureIntrinsicPermeability(const Context& OPM_UNUSED context,
+                                                   unsigned OPM_UNUSED spaceIdx,
+                                                   unsigned OPM_UNUSED timeIdx) const
     { return fractureK_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return matrixPorosity_; }
 
     /*!
@@ -358,16 +363,18 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    Scalar fracturePorosity(const Context &context, unsigned spaceIdx,
-                            unsigned timeIdx) const
+    Scalar fracturePorosity(const Context& OPM_UNUSED context,
+                            unsigned OPM_UNUSED spaceIdx,
+                            unsigned OPM_UNUSED timeIdx) const
     { return fracturePorosity_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
-                                               unsigned spaceIdx, unsigned timeIdx) const
+    const MaterialLawParams& materialLawParams(const Context& OPM_UNUSED context,
+                                               unsigned OPM_UNUSED spaceIdx,
+                                               unsigned OPM_UNUSED timeIdx) const
     { return matrixMaterialParams_; }
 
     /*!
@@ -376,15 +383,15 @@ public:
      * \copydoc Doxygen::contextParams
      */
     template <class Context>
-    const MaterialLawParams &fractureMaterialLawParams(const Context &context,
-                                                       unsigned spaceIdx,
-                                                       unsigned timeIdx) const
+    const MaterialLawParams& fractureMaterialLawParams(const Context& OPM_UNUSED context,
+                                                       unsigned OPM_UNUSED spaceIdx,
+                                                       unsigned OPM_UNUSED timeIdx) const
     { return fractureMaterialParams_; }
 
     /*!
      * \brief Returns the object representating the fracture topology.
      */
-    const FractureMapper &fractureMapper() const
+    const FractureMapper& fractureMapper() const
     { return this->simulator().gridManager().fractureMapper(); }
 
     /*!
@@ -400,8 +407,10 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar fractureWidth(const Context &context, unsigned spaceIdx1, unsigned spaceIdx2,
-                         unsigned timeIdx) const
+    Scalar fractureWidth(const Context& OPM_UNUSED context,
+                         unsigned OPM_UNUSED spaceIdx1,
+                         unsigned OPM_UNUSED spaceIdx2,
+                         unsigned OPM_UNUSED timeIdx) const
     { return fractureWidth_; }
 
     /*!
@@ -409,7 +418,9 @@ public:
      */
     template <class Context>
     const HeatConductionLawParams &
-    heatConductionParams(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    heatConductionParams(const Context& OPM_UNUSED context,
+                         unsigned OPM_UNUSED spaceIdx,
+                         unsigned OPM_UNUSED timeIdx) const
     { return heatCondParams_; }
 
     /*!
@@ -418,8 +429,9 @@ public:
      * In this case, we assume the rock-matrix to be granite.
      */
     template <class Context>
-    Scalar heatCapacitySolid(const Context &context, unsigned spaceIdx,
-                             unsigned timeIdx) const
+    Scalar heatCapacitySolid(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     {
         return 790     // specific heat capacity of granite [J / (kg K)]
                * 2700; // density of granite [kg/m^3]
@@ -436,10 +448,10 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
+    void boundary(BoundaryRateVector& values, const Context& context,
                   unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onRightBoundary_(pos)) {
             // on the right boundary, we impose a free-flow
@@ -474,10 +486,10 @@ public:
      * \copydoc FvBaseProblem::constraints
      */
     template <class Context>
-    void constraints(Constraints &constraints, const Context &context,
+    void constraints(Constraints& constraints, const Context& context,
                      unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (!onLeftBoundary_(pos))
             // only impose constraints adjacent to the left boundary
@@ -520,8 +532,10 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
-                 unsigned timeIdx) const
+    void initial(PrimaryVariables& values,
+                 const Context& OPM_UNUSED context,
+                 unsigned OPM_UNUSED spaceIdx,
+                 unsigned OPM_UNUSED timeIdx) const
     {
         FluidState fluidState;
         fluidState.setTemperature(temperature_);
@@ -542,26 +556,28 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     // \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[1] > this->boundingBoxMax()[1] - eps_; }
 
-    void computeHeatCondParams_(HeatConductionLawParams &params, Scalar poro)
+    void computeHeatCondParams_(HeatConductionLawParams& params, Scalar poro)
     {
         Scalar lambdaGranite = 2.8; // [W / (K m)]
 

--- a/tests/problems/groundwaterproblem.hh
+++ b/tests/problems/groundwaterproblem.hh
@@ -34,6 +34,7 @@
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 #include <opm/material/fluidsystems/LiquidPhase.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -157,7 +158,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    GroundWaterProblem(Simulator &simulator)
+    GroundWaterProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -263,25 +264,32 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return 273.15 + 10; } // 10C
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return 0.4; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
+    const DimMatrix& intrinsicPermeability(const Context& context,
+                                           unsigned spaceIdx,
                                            unsigned timeIdx) const
     {
-        return isInLens_(context.pos(spaceIdx, timeIdx)) ? intrinsicPermLens_
-                                                         : intrinsicPerm_;
+        if (isInLens_(context.pos(spaceIdx, timeIdx)))
+            return intrinsicPermLens_;
+        else
+            return intrinsicPerm_;
     }
 
     //! \}
@@ -294,10 +302,10 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
+    void boundary(BoundaryRateVector& values, const Context& context,
                   unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
 
         if (onLowerBoundary_(globalPos) || onUpperBoundary_(globalPos)) {
             Scalar pressure;
@@ -333,10 +341,12 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
-                 unsigned timeIdx) const
+    void initial(PrimaryVariables& values,
+                 const Context& OPM_UNUSED context,
+                 unsigned OPM_UNUSED spaceIdx,
+                 unsigned OPM_UNUSED timeIdx) const
     {
-        // const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        // const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
         values[pressure0Idx] = 1.0e+5; // + 9.81*1.23*(20-globalPos[dim-1]);
     }
 
@@ -344,20 +354,22 @@ public:
      * \copydoc FvBaseProblem::source
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[dim - 1] < eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[dim - 1] > this->boundingBoxMax()[dim - 1] - eps_; }
 
-    bool isInLens_(const GlobalPosition &pos) const
+    bool isInLens_(const GlobalPosition& pos) const
     {
         return lensLowerLeft_[0] <= pos[0] && pos[0] <= lensUpperRight_[0]
                && lensLowerLeft_[1] <= pos[1] && pos[1] <= lensUpperRight_[1];

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -40,6 +40,7 @@
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Dnapl.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
@@ -223,7 +224,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    LensProblem(Simulator &simulator)
+    LensProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -311,10 +312,10 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
+    const DimMatrix& intrinsicPermeability(const Context& context, unsigned spaceIdx,
                                            unsigned timeIdx) const
     {
-        const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
 
         if (isInLens_(globalPos))
             return lensK_;
@@ -325,17 +326,19 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return 0.4; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
+    const MaterialLawParams& materialLawParams(const Context& context,
                                                unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
 
         if (isInLens_(globalPos))
             return lensMaterialParams_;
@@ -346,7 +349,9 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; }
 
     //! \}
@@ -409,10 +414,12 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values,
-                  const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
+                  unsigned spaceIdx,
+                  unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(pos) || onRightBoundary_(pos)) {
             // free flow boundary
@@ -441,7 +448,7 @@ public:
             }
 
             // specify a full fluid state using pw and Sw
-            const MaterialLawParams &matParams = this->materialLawParams(context, spaceIdx, timeIdx);
+            const MaterialLawParams& matParams = this->materialLawParams(context, spaceIdx, timeIdx);
 
             Opm::ImmiscibleFluidState<Scalar, FluidSystem,
                                       /*storeEnthalpy=*/false> fs;
@@ -482,9 +489,9 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    void initial(PrimaryVariables& values, const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
         Scalar depth = this->boundingBoxMax()[1] - pos[1];
 
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
@@ -504,7 +511,7 @@ public:
         Scalar pw = 1e5 - densityW * this->gravity()[1] * depth;
 
         // calculate the capillary pressure
-        const MaterialLawParams &matParams = this->materialLawParams(context, spaceIdx, timeIdx);
+        const MaterialLawParams& matParams = this->materialLawParams(context, spaceIdx, timeIdx);
         Scalar pC[numPhases];
         MaterialLaw::capillaryPressures(pC, matParams, fs);
 
@@ -523,14 +530,16 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool isInLens_(const GlobalPosition &pos) const
+    bool isInLens_(const GlobalPosition& pos) const
     {
         for (unsigned i = 0; i < dim; ++i) {
             if (pos[i] < lensLowerLeft_[i] - eps_ || pos[i] > lensUpperRight_[i]
@@ -540,19 +549,19 @@ private:
         return true;
     }
 
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[1] > this->boundingBoxMax()[1] - eps_; }
 
-    bool onInlet_(const GlobalPosition &pos) const
+    bool onInlet_(const GlobalPosition& pos) const
     {
         Scalar width = this->boundingBoxMax()[0] - this->boundingBoxMin()[0];
         Scalar lambda = (this->boundingBoxMax()[0] - pos[0]) / width;

--- a/tests/problems/obstacleproblem.hh
+++ b/tests/problems/obstacleproblem.hh
@@ -38,6 +38,7 @@
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 #include <opm/material/heatconduction/Somerton.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -178,7 +179,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    ObstacleProblem(Simulator &simulator)
+    ObstacleProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -195,11 +196,11 @@ public:
         // initialize the tables of the fluid system
         Scalar Tmin = temperature_ - 1.0;
         Scalar Tmax = temperature_ + 1.0;
-        int nT = 3;
+        unsigned nT = 3;
 
         Scalar pmin = 1.0e5 * 0.75;
         Scalar pmax = 2.0e5 * 1.25;
-        int np = 1000;
+        unsigned np = 1000;
 
         FluidSystem::init(Tmin, Tmax, nT, pmin, pmax, np);
 
@@ -298,15 +299,19 @@ public:
      * This problem simply assumes a constant temperature.
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
-                                           unsigned timeIdx) const
+    const DimMatrix&
+    intrinsicPermeability(const Context& context,
+                          unsigned spaceIdx,
+                          unsigned timeIdx) const
     {
         if (isFineMaterial_(context.pos(spaceIdx, timeIdx)))
             return fineK_;
@@ -317,9 +322,11 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& context,
+                    unsigned spaceIdx,
+                    unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
         if (isFineMaterial_(pos))
             return finePorosity_;
         else
@@ -330,10 +337,12 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
-                                               unsigned spaceIdx, unsigned timeIdx) const
+    const MaterialLawParams&
+    materialLawParams(const Context& context,
+                      unsigned spaceIdx,
+                      unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
         if (isFineMaterial_(pos))
             return fineMaterialParams_;
         else
@@ -347,8 +356,9 @@ public:
      * medium is granite.
      */
     template <class Context>
-    Scalar heatCapacitySolid(const Context &context, unsigned spaceIdx,
-                             unsigned timeIdx) const
+    Scalar heatCapacitySolid(const Context& OPM_UNUSED context,
+                             unsigned OPM_UNUSED spaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     {
         return 790     // specific heat capacity of granite [J / (kg K)]
                * 2700; // density of granite [kg/m^3]
@@ -359,9 +369,11 @@ public:
      */
     template <class Context>
     const HeatConductionLawParams &
-    heatConductionParams(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    heatConductionParams(const Context& context,
+                         unsigned spaceIdx,
+                         unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
         if (isFineMaterial_(pos))
             return fineHeatCondParams_;
         return coarseHeatCondParams_;
@@ -378,10 +390,12 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
-                  unsigned spaceIdx, unsigned timeIdx) const
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
+                  unsigned spaceIdx,
+                  unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         if (onInlet_(pos))
             values.setFreeFlow(context, spaceIdx, timeIdx, inletFluidState_);
@@ -402,10 +416,12 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values,
+                 const Context& context,
+                 unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const auto &matParams = materialLawParams(context, spaceIdx, timeIdx);
+        const auto& matParams = materialLawParams(context, spaceIdx, timeIdx);
         values.assignMassConservative(outletFluidState_, matParams);
     }
 
@@ -416,8 +432,10 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = 0.0; }
 
     //! \}
@@ -427,17 +445,17 @@ private:
      * \brief Returns whether a given global position is in the
      *        fine-permeability region or not.
      */
-    bool isFineMaterial_(const GlobalPosition &pos) const
+    bool isFineMaterial_(const GlobalPosition& pos) const
     { return 10 <= pos[0] && pos[0] <= 20 && 0 <= pos[1] && pos[1] <= 35; }
 
-    bool onInlet_(const GlobalPosition &globalPos) const
+    bool onInlet_(const GlobalPosition& globalPos) const
     {
         Scalar x = globalPos[0];
         Scalar y = globalPos[1];
         return x >= 60 - eps_ && y <= 10;
     }
 
-    bool onOutlet_(const GlobalPosition &globalPos) const
+    bool onOutlet_(const GlobalPosition& globalPos) const
     {
         Scalar x = globalPos[0];
         Scalar y = globalPos[1];
@@ -453,7 +471,7 @@ private:
     }
 
     template <class FluidState>
-    void initFluidState_(FluidState &fs, const MaterialLawParams &matParams, bool isInlet)
+    void initFluidState_(FluidState& fs, const MaterialLawParams& matParams, bool isInlet)
     {
         unsigned refPhaseIdx;
         unsigned otherPhaseIdx;
@@ -512,7 +530,7 @@ private:
                                          /*setEnthalpy=*/false);
     }
 
-    void computeHeatCondParams_(HeatConductionLawParams &params, Scalar poro)
+    void computeHeatCondParams_(HeatConductionLawParams& params, Scalar poro)
     {
         Scalar lambdaWater = 0.6;
         Scalar lambdaGranite = 2.8;

--- a/tests/problems/outflowproblem.hh
+++ b/tests/problems/outflowproblem.hh
@@ -31,6 +31,7 @@
 
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
 #include <opm/material/fluidsystems/H2ON2LiquidPhaseFluidSystem.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -135,7 +136,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    OutflowProblem(Simulator &simulator)
+    OutflowProblem(Simulator& simulator)
         : ParentType(simulator)
         , eps_(1e-6)
     { }
@@ -194,7 +195,9 @@ public:
      * This problem assumes a temperature.
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; } // in [K]
 
     /*!
@@ -203,8 +206,9 @@ public:
      * This problem uses a constant intrinsic permeability.
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
-                                           unsigned timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& OPM_UNUSED context,
+                                           unsigned OPM_UNUSED spaceIdx,
+                                           unsigned OPM_UNUSED timeIdx) const
     { return perm_; }
 
     /*!
@@ -213,7 +217,9 @@ public:
      * This problem uses a constant porosity.
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return porosity_; }
 
 #if 0
@@ -222,7 +228,7 @@ public:
      *
      */
     template <class Context>
-    Scalar tortuosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar tortuosity(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     { return tortuosity_; }
 
     /*!
@@ -230,7 +236,7 @@ public:
      *
      */
     template <class Context>
-    Scalar dispersivity(const Context &context,
+    Scalar dispersivity(const Context& context,
                         unsigned spaceIdx, unsigned timeIdx) const
     { return 0; }
 #endif
@@ -246,10 +252,10 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
+    void boundary(BoundaryRateVector& values, const Context& context,
                   unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(globalPos)) {
             Opm::CompositionalFluidState<Scalar, FluidSystem,
@@ -288,7 +294,9 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values,
+                 const Context& context,
+                 unsigned spaceIdx,
                  unsigned timeIdx) const
     {
         Opm::CompositionalFluidState<Scalar, FluidSystem, /*storeEnthalpy=*/false> fs;
@@ -304,21 +312,23 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
     template <class FluidState, class Context>
-    void initialFluidState_(FluidState &fs, const Context &context,
+    void initialFluidState_(FluidState& fs, const Context& context,
                             unsigned spaceIdx, unsigned timeIdx) const
     {
         Scalar T = temperature(context, spaceIdx, timeIdx);

--- a/tests/problems/powerinjectionproblem.hh
+++ b/tests/problems/powerinjectionproblem.hh
@@ -28,6 +28,9 @@
 #ifndef EWOMS_POWER_INJECTION_PROBLEM_HH
 #define EWOMS_POWER_INJECTION_PROBLEM_HH
 
+#include <ewoms/models/immiscible/immisciblemodel.hh>
+#include <ewoms/io/cubegridmanager.hh>
+
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
@@ -36,10 +39,9 @@
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/components/Air.hpp>
-#include <ewoms/models/immiscible/immisciblemodel.hh>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
-#include <ewoms/io/cubegridmanager.hh>
 
 #include <dune/common/version.hh>
 #include <dune/common/fvector.hh>
@@ -193,7 +195,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    PowerInjectionProblem(Simulator &simulator)
+    PowerInjectionProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -269,38 +271,46 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, unsigned spaceIdx,
-                                           unsigned timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& OPM_UNUSED context,
+                                           unsigned OPM_UNUSED spaceIdx,
+                                           unsigned OPM_UNUSED timeIdx) const
     { return K_; }
 
     /*!
      * \copydoc ForchheimerBaseProblem::ergunCoefficient
      */
     template <class Context>
-    Scalar ergunCoefficient(const Context &context, unsigned spaceIdx,
-                            unsigned timeIdx) const
+    Scalar ergunCoefficient(const Context& OPM_UNUSED context,
+                            unsigned OPM_UNUSED spaceIdx,
+                            unsigned OPM_UNUSED timeIdx) const
     { return 0.3866; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return 0.558; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
-                                               unsigned spaceIdx, unsigned timeIdx) const
+    const MaterialLawParams&
+    materialLawParams(const Context& OPM_UNUSED context,
+                      unsigned OPM_UNUSED spaceIdx,
+                      unsigned OPM_UNUSED timeIdx) const
     { return materialParams_; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return temperature_; }
 
     //! \}
@@ -317,10 +327,12 @@ public:
      * left and a free-flow boundary on the right.
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
-                  unsigned spaceIdx, unsigned timeIdx) const
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
+                  unsigned spaceIdx,
+                  unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(pos)) {
             RateVector massRate(0.0);
@@ -348,8 +360,10 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
-                 unsigned timeIdx) const
+    void initial(PrimaryVariables& values,
+                 const Context& OPM_UNUSED context,
+                 unsigned OPM_UNUSED spaceIdx,
+                 unsigned OPM_UNUSED timeIdx) const
     {
         // assign the primary variables
         values.assignNaive(initialFluidState_);
@@ -362,17 +376,19 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
     void setupInitialFluidState_()

--- a/tests/problems/richardslensproblem.hh
+++ b/tests/problems/richardslensproblem.hh
@@ -36,6 +36,7 @@
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/EffToAbsLaw.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -174,7 +175,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    RichardsLensProblem(Simulator &simulator)
+    RichardsLensProblem(Simulator& simulator)
         : ParentType(simulator)
         , pnRef_(1e5)
     {
@@ -270,21 +271,21 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::temperature
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& context, unsigned spaceIdx, unsigned timeIdx) const
     { return temperature(context.globalSpaceIndex(spaceIdx, timeIdx), timeIdx); }
 
-    Scalar temperature(unsigned globalSpaceIdx, unsigned timeIdx) const
+    Scalar temperature(unsigned OPM_UNUSED globalSpaceIdx, unsigned OPM_UNUSED timeIdx) const
     { return 273.15 + 10; } // -> 10°C
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::intrinsicPermeability
      */
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context,
+    const DimMatrix& intrinsicPermeability(const Context& context,
                                            unsigned spaceIdx,
                                            unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
         if (isInLens_(pos))
             return lensK_;
         return outerK_;
@@ -294,14 +295,16 @@ public:
      * \copydoc FvBaseMultiPhaseProblem::porosity
      */
     template <class Context>
-    Scalar porosity(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar porosity(const Context& OPM_UNUSED context,
+                    unsigned OPM_UNUSED spaceIdx,
+                    unsigned OPM_UNUSED timeIdx) const
     { return 0.4; }
 
     /*!
      * \copydoc FvBaseMultiPhaseProblem::materialLawParams
      */
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context,
+    const MaterialLawParams& materialLawParams(const Context& context,
                                                unsigned spaceIdx,
                                                unsigned timeIdx) const
     {
@@ -309,7 +312,8 @@ public:
         return materialLawParams(globalSpaceIdx, timeIdx);
     }
 
-    const MaterialLawParams& materialLawParams(unsigned globalSpaceIdx, unsigned timeIdx) const
+    const MaterialLawParams& materialLawParams(unsigned globalSpaceIdx,
+                                               unsigned OPM_UNUSED timeIdx) const
     {
         if (dofIsInLens_[globalSpaceIdx])
             return lensMaterialParams_;
@@ -322,14 +326,15 @@ public:
      * \copydetails Doxygen::contextParams
      */
     template <class Context>
-    Scalar referencePressure(const Context &context,
+    Scalar referencePressure(const Context& context,
                              unsigned spaceIdx,
                              unsigned timeIdx) const
     { return referencePressure(context.globalSpaceIndex(spaceIdx, timeIdx), timeIdx); }
 
     // the Richards model does not have an element context available at all places
     // where the reference pressure is required...
-    Scalar referencePressure(unsigned globalSpaceIdx, unsigned timeIdx) const
+    Scalar referencePressure(unsigned OPM_UNUSED globalSpaceIdx,
+                             unsigned OPM_UNUSED timeIdx) const
     { return pnRef_; }
 
     //! \}
@@ -343,15 +348,15 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values,
-                  const Context &context,
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
                   unsigned spaceIdx,
                   unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(pos) || onRightBoundary_(pos)) {
-            const auto &materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
+            const auto& materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
 
             Scalar Sw = 0.0;
             Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
@@ -388,12 +393,12 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values,
-                 const Context &context,
+    void initial(PrimaryVariables& values,
+                 const Context& context,
                  unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const auto &materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
+        const auto& materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
 
         Scalar Sw = 0.0;
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
@@ -412,35 +417,35 @@ public:
      * everywhere.
      */
     template <class Context>
-    void source(RateVector &rate,
-                const Context &context,
-                unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[1] > this->boundingBoxMax()[1] - eps_; }
 
-    bool onInlet_(const GlobalPosition &pos) const
+    bool onInlet_(const GlobalPosition& pos) const
     {
         Scalar width = this->boundingBoxMax()[0] - this->boundingBoxMin()[0];
         Scalar lambda = (this->boundingBoxMax()[0] - pos[0]) / width;
         return onUpperBoundary_(pos) && 0.5 < lambda && lambda < 2.0 / 3.0;
     }
 
-    bool isInLens_(const GlobalPosition &pos) const
+    bool isInLens_(const GlobalPosition& pos) const
     {
         for (unsigned i = 0; i < dimWorld; ++i) {
             if (pos[i] < lensLowerLeft_[i] || pos[i] > lensUpperRight_[i])

--- a/tests/problems/stokes2ctestproblem.hh
+++ b/tests/problems/stokes2ctestproblem.hh
@@ -28,7 +28,9 @@
 #define EWOMS_STOKES_2C_TEST_PROBLEM_HH
 
 #include <ewoms/models/stokes/stokesmodel.hh>
+
 #include <opm/material/fluidsystems/H2OAirFluidSystem.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -126,7 +128,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    Stokes2cTestProblem(Simulator &simulator)
+    Stokes2cTestProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -181,7 +183,9 @@ public:
      * This problem assumes a temperature of 10 degrees Celsius.
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return 273.15 + 10; /* -> 10 deg C */ }
 
     // \}
@@ -199,21 +203,21 @@ public:
      * upper edge.
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
-                  unsigned spaceIdx, unsigned timeIdx) const
+    void boundary(BoundaryRateVector& values,
+                  const Context& context,
+                  unsigned spaceIdx,
+                  unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLowerBoundary_(pos))
             values.setOutFlow(context, spaceIdx, timeIdx);
-        else if (onUpperBoundary_(pos)) {
+        else if (onUpperBoundary_(pos))
             // upper boundary is constraint!
             values = 0.0;
-        }
-        else {
+        else
             // left and right boundaries
             values.setNoFlow(context, spaceIdx, timeIdx);
-        }
     }
 
     //! \}
@@ -231,10 +235,12 @@ public:
      * 0.5% is set.
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values,
+                 const Context& context,
+                 unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const GlobalPosition &globalPos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& globalPos = context.pos(spaceIdx, timeIdx);
         values = 0.0;
 
         // parabolic profile
@@ -266,8 +272,10 @@ public:
      * is 0 everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     /*!
@@ -277,10 +285,12 @@ public:
      * initial conditions.
      */
     template <class Context>
-    void constraints(Constraints &constraints, const Context &context,
-                     unsigned spaceIdx, unsigned timeIdx) const
+    void constraints(Constraints& constraints,
+                     const Context& context,
+                     unsigned spaceIdx,
+                     unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         if (onUpperBoundary_(pos)) {
             constraints.setActive(true);
@@ -290,16 +300,16 @@ public:
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &globalPos) const
+    bool onLeftBoundary_(const GlobalPosition& globalPos) const
     { return globalPos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &globalPos) const
+    bool onRightBoundary_(const GlobalPosition& globalPos) const
     { return globalPos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &globalPos) const
+    bool onLowerBoundary_(const GlobalPosition& globalPos) const
     { return globalPos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &globalPos) const
+    bool onUpperBoundary_(const GlobalPosition& globalPos) const
     { return globalPos[1] > this->boundingBoxMax()[1] - eps_; }
 
     Scalar eps_;

--- a/tests/problems/stokesnitestproblem.hh
+++ b/tests/problems/stokesnitestproblem.hh
@@ -29,7 +29,9 @@
 
 #include <ewoms/models/stokes/stokesmodel.hh>
 #include <ewoms/io/simplexgridmanager.hh>
+
 #include <opm/material/fluidsystems/H2OAirFluidSystem.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -138,7 +140,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    StokesNiTestProblem(Simulator &simulator)
+    StokesNiTestProblem(Simulator& simulator)
         : ParentType(simulator)
     { }
 
@@ -199,10 +201,10 @@ public:
      * \copydoc FvBaseProblem::boundary
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
+    void boundary(BoundaryRateVector& values, const Context& context,
                   unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onUpperBoundary_(pos))
             values.setOutFlow(context, spaceIdx, timeIdx);
@@ -227,10 +229,10 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values, const Context& context, unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         Scalar moleFrac[numComponents];
 
@@ -276,8 +278,10 @@ public:
      * is 0 everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     /*!
@@ -287,10 +291,12 @@ public:
      * adjacent to the inlet.
      */
     template <class Context>
-    void constraints(Constraints &constraints, const Context &context,
-                     unsigned spaceIdx, unsigned timeIdx) const
+    void constraints(Constraints& constraints,
+                     const Context& context,
+                     unsigned spaceIdx,
+                     unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLowerBoundary_(pos) || onUpperBoundary_(pos)) {
             constraints.setActive(true);
@@ -301,25 +307,25 @@ public:
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[1] > this->boundingBoxMax()[1] - eps_; }
 
-    bool onBoundary_(const GlobalPosition &pos) const
+    bool onBoundary_(const GlobalPosition& pos) const
     {
         return onLeftBoundary_(pos) || onRightBoundary_(pos)
                || onLowerBoundary_(pos) || onUpperBoundary_(pos);
     }
 
-    bool inLens_(const GlobalPosition &pos) const
+    bool inLens_(const GlobalPosition& pos) const
     { return pos[0] < 0.75 && pos[0] > 0.25 && pos[1] < 0.75 && pos[1] > 0.25; }
 
     Scalar eps_;

--- a/tests/problems/stokestestproblem.hh
+++ b/tests/problems/stokestestproblem.hh
@@ -32,6 +32,7 @@
 
 #include <opm/material/fluidsystems/H2ON2FluidSystem.hpp>
 #include <opm/material/fluidsystems/GasPhase.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/yaspgrid.hh>
 #include <dune/grid/io/file/dgfparser/dgfyasp.hh>
@@ -132,7 +133,7 @@ public:
     /*!
      * \copydoc Doxygen::defaultProblemConstructor
      */
-    StokesTestProblem(Simulator &simulator)
+    StokesTestProblem(Simulator& simulator)
         : ParentType(simulator)
     { eps_ = 1e-6; }
 
@@ -175,7 +176,9 @@ public:
      * This problem assumes a constant temperature of 10 degrees Celsius.
      */
     template <class Context>
-    Scalar temperature(const Context &context, unsigned spaceIdx, unsigned timeIdx) const
+    Scalar temperature(const Context& OPM_UNUSED context,
+                       unsigned OPM_UNUSED spaceIdx,
+                       unsigned OPM_UNUSED timeIdx) const
     { return 273.15 + 10; } // -> 10 deg C
 
     //! \}
@@ -193,10 +196,10 @@ public:
      * a parabolic velocity profile via constraints.
      */
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
+    void boundary(BoundaryRateVector& values, const Context& context,
                   unsigned spaceIdx, unsigned timeIdx) const
     {
-        const GlobalPosition &pos = context.pos(spaceIdx, timeIdx);
+        const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         Scalar y = pos[1] - this->boundingBoxMin()[1];
         Scalar height = this->boundingBoxMax()[1] - this->boundingBoxMin()[1];
@@ -234,10 +237,10 @@ public:
      * \copydoc FvBaseProblem::initial
      */
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, unsigned spaceIdx,
+    void initial(PrimaryVariables& values, const Context& context, unsigned spaceIdx,
                  unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         Scalar y = pos[1] - this->boundingBoxMin()[1];
         Scalar height = this->boundingBoxMax()[1] - this->boundingBoxMin()[1];
@@ -264,8 +267,10 @@ public:
      * is 0 everywhere.
      */
     template <class Context>
-    void source(RateVector &rate, const Context &context, unsigned spaceIdx,
-                unsigned timeIdx) const
+    void source(RateVector& rate,
+                const Context& OPM_UNUSED context,
+                unsigned OPM_UNUSED spaceIdx,
+                unsigned OPM_UNUSED timeIdx) const
     { rate = Scalar(0.0); }
 
     /*!
@@ -275,10 +280,12 @@ public:
      * velocity profile using constraints.
      */
     template <class Context>
-    void constraints(Constraints &constraints, const Context &context,
-                     unsigned spaceIdx, unsigned timeIdx) const
+    void constraints(Constraints& constraints,
+                     const Context& context,
+                     unsigned spaceIdx,
+                     unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(pos) || onRightBoundary_(pos)) {
             constraints.setActive(true);
@@ -289,19 +296,19 @@ public:
     //! \}
 
 private:
-    bool onLeftBoundary_(const GlobalPosition &pos) const
+    bool onLeftBoundary_(const GlobalPosition& pos) const
     { return pos[0] < this->boundingBoxMin()[0] + eps_; }
 
-    bool onRightBoundary_(const GlobalPosition &pos) const
+    bool onRightBoundary_(const GlobalPosition& pos) const
     { return pos[0] > this->boundingBoxMax()[0] - eps_; }
 
-    bool onLowerBoundary_(const GlobalPosition &pos) const
+    bool onLowerBoundary_(const GlobalPosition& pos) const
     { return pos[1] < this->boundingBoxMin()[1] + eps_; }
 
-    bool onUpperBoundary_(const GlobalPosition &pos) const
+    bool onUpperBoundary_(const GlobalPosition& pos) const
     { return pos[1] > this->boundingBoxMax()[1] - eps_; }
 
-    bool onBoundary_(const GlobalPosition &pos) const
+    bool onBoundary_(const GlobalPosition& pos) const
     {
         return onLeftBoundary_(pos) || onRightBoundary_(pos)
                || onLowerBoundary_(pos) || onUpperBoundary_(pos);

--- a/tests/test_quadrature.cc
+++ b/tests/test_quadrature.cc
@@ -41,6 +41,14 @@
 
 #include <ewoms/disc/vcfv/vcfvstencil.hh>
 
+#include <opm/material/common/Unused.hpp>
+
+#if HAVE_DUNE_ALUGRID
+#define EWOMS_NO_ALUGRID_UNUSED
+#else
+#define EWOMS_NO_ALUGRID_UNUSED OPM_UNUSED
+#endif
+
 const unsigned dim = 3;
 typedef double Scalar;
 typedef Ewoms::QuadrialteralQuadratureGeometry<Scalar, dim> QuadratureGeom;
@@ -102,7 +110,7 @@ void testIdenityMapping()
 }
 
 template <class Grid>
-void writeTetrahedronSubControlVolumes(const Grid &grid)
+void writeTetrahedronSubControlVolumes(const Grid& EWOMS_NO_ALUGRID_UNUSED grid)
 {
 #if HAVE_DUNE_ALUGRID
     typedef typename Grid::LeafGridView GridView;
@@ -134,14 +142,14 @@ void writeTetrahedronSubControlVolumes(const Grid &grid)
         }
     }
 
-    int cornerOffset = 0;
+    unsigned cornerOffset = 0;
     eIt = gridView.template begin<0>();
     for (; eIt != eEndIt; ++eIt) {
         stencil.update(*eIt);
         for (unsigned scvIdx = 0; scvIdx < stencil.numDof(); ++scvIdx) {
             const auto &scvLocalGeom = stencil.subControlVolume(scvIdx).localGeometry();
 
-            std::vector<unsigned int> vertexIndices;
+            std::vector<unsigned> vertexIndices;
             for (unsigned i = 0; i < scvLocalGeom.numCorners; ++i) {
                 vertexIndices.push_back(cornerOffset);
                 ++cornerOffset;
@@ -185,7 +193,7 @@ void testTetrahedron()
 }
 
 template <class Grid>
-void writeCubeSubControlVolumes(const Grid &grid)
+void writeCubeSubControlVolumes(const Grid& EWOMS_NO_ALUGRID_UNUSED grid)
 {
 #if HAVE_DUNE_ALUGRID
     typedef typename Grid::LeafGridView GridView;
@@ -215,7 +223,7 @@ void writeCubeSubControlVolumes(const Grid &grid)
         }
     }
 
-    int cornerOffset = 0;
+    unsigned cornerOffset = 0;
     eIt = gridView.template begin<0>();
     for (; eIt != eEndIt; ++eIt) {
         stencil.update(*eIt);
@@ -318,7 +326,7 @@ void testQuadrature()
             const auto &scvLocalGeom = stencil.subControlVolume(scvIdx).localGeometry();
 
             Dune::GeometryType geomType = scvLocalGeom.type();
-            static const int quadratureOrder = 2;
+            static const unsigned quadratureOrder = 2;
             const auto &rule
                 = Dune::QuadratureRules<Scalar, dim>::rule(geomType,
                                                            quadratureOrder);

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -167,7 +167,7 @@ class Tutorial1Problem
 public:
     //! The constructor of the problem. This only _allocates_ the memory required by the
     //! problem. The constructor is supposed to _never ever_ throw an exception.
-    Tutorial1Problem(Simulator &simulator)
+    Tutorial1Problem(Simulator& simulator)
         : ParentType(simulator)
         , eps_(3e-6)
     { }
@@ -200,36 +200,37 @@ public:
 
     //! Returns the temperature at a given position.
     template <class Context>
-    Scalar temperature(const Context &context, int spaceIdx, int timeIdx) const
+    Scalar temperature(const Context& /*context*/,
+                       unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const
     { return 283.15; }
 
     //! Returns the intrinsic permeability tensor [m^2] at a position.
     template <class Context>
-    const DimMatrix &intrinsicPermeability(const Context &context, /*@\label{tutorial1:permeability}@*/
-                                           int spaceIdx, int timeIdx) const
+    const DimMatrix& intrinsicPermeability(const Context& /*context*/, /*@\label{tutorial1:permeability}@*/
+                                           unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const
     { return K_; }
 
     //! Defines the porosity [-] of the medium at a given position
     template <class Context>
-    Scalar porosity(const Context &context,
-                    int spaceIdx, int timeIdx) const /*@\label{tutorial1:porosity}@*/
+    Scalar porosity(const Context& /*context*/,
+                    unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const /*@\label{tutorial1:porosity}@*/
     { return 0.2; }
 
     //! Returns the parameter object for the material law at a given position
     template <class Context>
-    const MaterialLawParams &materialLawParams(const Context &context, /*@\label{tutorial1:matLawParams}@*/
-                                               int spaceIdx, int timeIdx) const
+    const MaterialLawParams& materialLawParams(const Context& /*context*/, /*@\label{tutorial1:matLawParams}@*/
+                                               unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const
     { return materialParams_; }
 
     //! Evaluates the boundary conditions.
     template <class Context>
-    void boundary(BoundaryRateVector &values, const Context &context,
-                  int spaceIdx, int timeIdx) const
+    void boundary(BoundaryRateVector& values, const Context& context,
+                  unsigned spaceIdx, unsigned timeIdx) const
     {
-        const auto &pos = context.pos(spaceIdx, timeIdx);
+        const auto& pos = context.pos(spaceIdx, timeIdx);
         if (pos[0] < eps_) {
             // Free-flow conditions on left boundary
-            const auto &materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
+            const auto& materialParams = this->materialLawParams(context, spaceIdx, timeIdx);
 
             Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
             Scalar Sw = 1.0;
@@ -261,8 +262,8 @@ public:
     //! position of the domain [kg/(m^3 * s)]. Positive values mean that
     //! mass is created.
     template <class Context>
-    void source(RateVector &source, const Context &context, int spaceIdx,
-                int timeIdx) const
+    void source(RateVector& source, const Context& /*context*/,
+                unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const
     {
         source[contiWettingEqIdx] = 0.0;
         source[contiNonWettingEqIdx] = 0.0;
@@ -270,8 +271,8 @@ public:
 
     //! Evaluates the initial value at a given position in the domain.
     template <class Context>
-    void initial(PrimaryVariables &values, const Context &context, int spaceIdx,
-                 int timeIdx) const
+    void initial(PrimaryVariables& values, const Context& context,
+                 unsigned spaceIdx, unsigned timeIdx) const
     {
         Opm::ImmiscibleFluidState<Scalar, FluidSystem> fs;
 
@@ -285,8 +286,7 @@ public:
 
         // set pressure of the wetting phase to 200 kPa = 2 bar
         Scalar pC[numPhases];
-        MaterialLaw::capillaryPressures(pC, materialLawParams(context, spaceIdx,
-                                                              timeIdx),
+        MaterialLaw::capillaryPressures(pC, materialLawParams(context, spaceIdx, timeIdx),
                                         fs);
         fs.setPressure(wettingPhaseIdx, 200e3);
         fs.setPressure(nonWettingPhaseIdx, 200e3 + pC[nonWettingPhaseIdx] - pC[nonWettingPhaseIdx]);


### PR DESCRIPTION
i.e., using clang 3.8 to compile the test suite with the following
flags:

```
-Weverything
-Wno-documentation
-Wno-documentation-unknown-command
-Wno-c++98-compat
-Wno-c++98-compat-pedantic
-Wno-undef
-Wno-padded
-Wno-global-constructors
-Wno-exit-time-destructors
-Wno-weak-vtables
-Wno-float-equal
```

should not produce any warnings anymore. In my opinion the only flag
which would produce beneficial warnings is -Wdocumentation. This has
not been fixed in this patch because writing documentation is left for
another day (or, more likely, year).

note that this patch consists of a heavy dose of the OPM_UNUSED macro
and plenty of static_casts (to fix signedness issues). Fixing the
singedness issues were quite a nightmare and the fact that the Dune
API is quite inconsistent in that regard was not exactly helpful. :/

Finally this patch includes quite a few formatting changes (e.g., all
occurences of 'T &t' should be changed to `T& t`) and some fixes for
minor issues which I've found during the excercise.

I've made sure that all unit tests the test suite still pass
successfully and I've made sure that flow_ebos still works for Norne
and that it did not regress w.r.t. performance.

(Note that this patch does not fix compiler warnings triggered `ebos`
and `flow_ebos` but only those caused by the basic infrastructure or
the unit tests.)