### PR TITLE
fix a signedness issue when retrieving parameters

### DIFF
--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -210,7 +210,7 @@ public:
     {
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
                              "The maximum allowed error between of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverOverlapSize,
+        EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
                              "The size of the algebraic overlap for the linear solver");
         EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,
                              "The maximum number of iterations of the linear solver");
@@ -388,7 +388,7 @@ private:
                                             simulator_.model().dofMapper());
 
         // create the overlapping Jacobian matrix
-        unsigned overlapSize = static_cast<unsigned>(EWOMS_GET_PARAM(TypeTag, int, LinearSolverOverlapSize));
+        unsigned overlapSize = EWOMS_GET_PARAM(TypeTag, unsigned, LinearSolverOverlapSize);
         overlappingMatrix_ = new OverlappingMatrix(M,
                                                    borderListCreator.borderList(),
                                                    borderListCreator.blackList(),

--- a/tests/problems/co2injectionproblem.hh
+++ b/tests/problems/co2injectionproblem.hh
@@ -307,7 +307,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemTemperatureHigh,
                              "The upper temperature [K] for tabulation of the "
                              "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, int, FluidSystemNumTemperature,
+        EWOMS_REGISTER_PARAM(TypeTag, unsigned, FluidSystemNumTemperature,
                              "The number of intervals between the lower and "
                              "upper temperature");
 
@@ -317,7 +317,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, FluidSystemPressureHigh,
                              "The upper pressure [Pa] for tabulation of the "
                              "fluid system");
-        EWOMS_REGISTER_PARAM(TypeTag, int, FluidSystemNumPressure,
+        EWOMS_REGISTER_PARAM(TypeTag, unsigned, FluidSystemNumPressure,
                              "The number of intervals between the lower and "
                              "upper pressure");
 


### PR DESCRIPTION
the issue only bites if the tests are compiled in debug mode, so it
has only been discovered now.