### PR TITLE
Transmissibility edge weights

### DIFF
--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
 #include <vector>
+#include <unordered_set>
 #include <array>
 
 namespace Ewoms {
@@ -234,6 +235,16 @@ public:
      */
     void equilCartesianCoordinate(unsigned cellIdx, std::array<int,3>& ijk) const
     { return asImp_().equilCartesianIndexMapper().cartesianCoordinate(cellIdx, ijk); }
+
+    /*!
+     * \brief Return the names of the wells which do not penetrate any cells on the local
+     *        process.
+     *
+     * This is a kludge around the fact that for distributed grids, not all wells are
+     * seen by all proccesses.
+     */
+    std::unordered_set<std::string> defunctWellNames() const
+    { return std::unordered_set<std::string>(); }
 
 private:
     Implementation& asImp_()

--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -137,8 +137,8 @@ public:
         tmp.push_back(ParseModePair(Opm::ParseContext::PARSE_RANDOM_SLASH , Opm::InputError::IGNORE));
         Opm::ParseContext parseContext(tmp);
 
-        deck_ = std::make_shared< Opm::Deck >( parser.parseFile(fileName , parseContext) );
-        eclState_ =  std::make_shared< Opm::EclipseState >(*deck_, parseContext);
+        deck_ = parser.parseFile(fileName , parseContext);
+        eclState_.reset(new Opm::EclipseState(deck_, parseContext));
 
         asImp_().createGrids_();
 
@@ -148,36 +148,20 @@ public:
     /*!
      * \brief Return a pointer to the parsed ECL deck
      */
-    std::shared_ptr< const Opm::Deck > deck() const
+    const Opm::Deck& deck() const
     { return deck_; }
 
-    std::shared_ptr< Opm::Deck > deck()
+    Opm::Deck& deck()
     { return deck_; }
 
     /*!
      * \brief Return a pointer to the internalized ECL deck
      */
-    std::shared_ptr< const Opm::EclipseState > eclState() const
-    { return eclState_; }
+    const Opm::EclipseState& eclState() const
+    { return *eclState_; }
 
-    std::shared_ptr< Opm::EclipseState > eclState()
-    { return eclState_; }
-
-    /*!
-     * \brief Return a pointer to the internalized schedule of the ECL deck
-     */
-    const Opm::Schedule* schedule() const
-    { return &eclState()->getSchedule(); }
-
-    /*!
-     * \brief Return a pointer to the EclipseGrid object
-     *
-     * The EclipseGrid class is provided by the opm-parser module and is used to
-     * internalize the cornerpoint grid representation and, amongst others, can be used
-     * to write EGRID files (which tends to be difficult with a plain Dune::CpGrid)
-     */
-    const Opm::EclipseGrid* eclGrid() const
-    { return &eclState()->getInputGrid(); }
+    Opm::EclipseState& eclState()
+    { return *eclState_; }
 
     /*!
      * \brief Returns the name of the case.
@@ -259,8 +243,8 @@ private:
     { return *static_cast<const Implementation*>(this); }
 
     std::string caseName_;
-    std::shared_ptr< Opm::Deck > deck_;
-    std::shared_ptr< Opm::EclipseState > eclState_;
+    Opm::Deck deck_;
+    std::unique_ptr<Opm::EclipseState> eclState_;
 };
 
 } // namespace Ewoms

--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -28,8 +28,11 @@
 #define EWOMS_ECL_CP_GRID_MANAGER_HH
 
 #include "eclbasegridmanager.hh"
+#include "ecltransmissibility.hh"
 
 #include <dune/grid/CpGrid.hpp>
+
+#include <dune/common/version.hh>
 
 namespace Ewoms {
 template <class TypeTag>
@@ -59,6 +62,7 @@ class EclCpGridManager : public EclBaseGridManager<TypeTag>
 
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementMapper) ElementMapper;
 
 public:
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
@@ -135,9 +139,55 @@ public:
         MPI_Comm_rank(MPI_COMM_WORLD, &mpiRank);
         MPI_Comm_size(MPI_COMM_WORLD, &mpiSize);
 
-        // distribute the grid and switch to the distributed view.
-        grid_->loadBalance();
-        grid_->switchToDistributedView();
+        if (mpiSize > 1) {
+            // the CpGrid's loadBalance() method likes to have the transmissibilities as
+            // its edge weights. since this is (kind of) a layering violation and
+            // transmissibilities are relatively expensive to compute, we only do it if
+            // more than a single process is involved in the simulation.
+            cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);
+            EclTransmissibility<TypeTag> eclTrans(*this);
+            eclTrans.update();
+
+            // convert to transmissibility for faces
+            // TODO: grid_->numFaces() is not generic. use grid_->size(1) instead? (might
+            // not work)
+            const auto& gridView = grid_->leafGridView();
+            unsigned numFaces = grid_->numFaces();
+            std::vector<double> faceTrans(numFaces, 0.0);
+            ElementMapper elemMapper(this->gridView());
+            auto elemIt = gridView.template begin</*codim=*/0>();
+            const auto& elemEndIt = gridView.template end</*codim=*/0>();
+            for (; elemIt != elemEndIt; ++ elemIt) {
+                const auto& elem = *elemIt;
+                auto isIt = gridView.ibegin(elem);
+                const auto& isEndIt = gridView.iend(elem);
+                for (; isIt != isEndIt; ++ isIt) {
+                    const auto& is = *isIt;
+                    if (!is.neighbor())
+                        continue;
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+                    unsigned I = elemMapper.index(is.inside());
+                    unsigned J = elemMapper.index(is.outside());
+#else
+                    unsigned I = elemMapper.map(is.inside());
+                    unsigned J = elemMapper.map(is.outside());
+#endif
+
+                    // FIXME (?): this is not portable!
+                    unsigned faceIdx = is.id();
+
+                    faceTrans[faceIdx] = eclTrans.transmissibility(I, J);
+                }
+            }
+
+            //distribute the grid and switch to the distributed view.
+            grid_->loadBalance(&this->eclState(), faceTrans.data());
+            grid_->switchToDistributedView();
+
+            delete cartesianIndexMapper_;
+            cartesianIndexMapper_ = nullptr;
+        }
 #endif
 
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);

--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -159,11 +159,11 @@ public:
 protected:
     void createGrids_()
     {
-        const auto& gridProps = this->eclState()->get3DProperties();
+        const auto& gridProps = this->eclState().get3DProperties();
         const std::vector<double>& porv = gridProps.getDoubleGridProperty("PORV").getData();
 
         grid_ = new Dune::CpGrid();
-        grid_->processEclipseFormat(this->eclState()->getInputGrid(),
+        grid_->processEclipseFormat(this->eclState().getInputGrid(),
                                     /*isPeriodic=*/false,
                                     /*flipNormals=*/false,
                                     /*clipZ=*/false,
@@ -174,7 +174,7 @@ protected:
         // is allergic to distributed grids and the simulation grid is distributed before
         // the initial condition is calculated.
         equilGrid_ = new Dune::CpGrid();
-        equilGrid_->processEclipseFormat(this->eclState()->getInputGrid(),
+        equilGrid_->processEclipseFormat(this->eclState().getInputGrid(),
                                          /*isPeriodic=*/false,
                                          /*flipNormals=*/false,
                                          /*clipZ=*/false,

--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -182,7 +182,7 @@ public:
             }
 
             //distribute the grid and switch to the distributed view.
-            grid_->loadBalance(&this->eclState(), faceTrans.data());
+            defunctWellNames_ = std::get<1>(grid_->loadBalance(&this->eclState(), faceTrans.data()));
             grid_->switchToDistributedView();
 
             delete cartesianIndexMapper_;
@@ -205,6 +205,9 @@ public:
      */
     const CartesianIndexMapper& equilCartesianIndexMapper() const
     { return *equilCartesianIndexMapper_; }
+
+    std::unordered_set<std::string> defunctWellNames() const
+    { return defunctWellNames_; }
 
 protected:
     void createGrids_()
@@ -236,6 +239,8 @@ protected:
     EquilGrid* equilGrid_;
     CartesianIndexMapper* cartesianIndexMapper_;
     CartesianIndexMapper* equilCartesianIndexMapper_;
+
+    std::unordered_set<std::string> defunctWellNames_;
 };
 
 } // namespace Ewoms

--- a/ebos/ecldeckunits.hh
+++ b/ebos/ecldeckunits.hh
@@ -84,8 +84,8 @@ public:
 
     EclDeckUnits(const Simulator& simulator)
     {
-        const auto& eclDeck = simulator.gridManager().deck();
-        const Opm::UnitSystem& deckUnitSystem = eclDeck->getActiveUnitSystem();
+        const auto& deck = simulator.gridManager().deck();
+        const Opm::UnitSystem& deckUnitSystem = deck.getActiveUnitSystem();
 
         deckToSiFactor_.resize(numDimensions);
         deckToSiOffset_.resize(numDimensions, 0.0);

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -118,13 +118,13 @@ public:
 
         auto equilMaterialLawManager =
             std::make_shared<Opm::EclMaterialLawManager<EquilTraits> >();
-        equilMaterialLawManager->initFromDeck(*deck, *eclState, compressedToCartesianEquilElemIdx);
+        equilMaterialLawManager->initFromDeck(deck, eclState, compressedToCartesianEquilElemIdx);
 
         // create the data structures which are used by initStateEquil()
         Opm::parameter::ParameterGroup tmpParam;
         Opm::BlackoilPropertiesFromDeck opmBlackoilProps(
-            *gridManager.deck(),
-            *gridManager.eclState(),
+            gridManager.deck(),
+            gridManager.eclState(),
             equilMaterialLawManager,
             Opm::UgGridHelpers::numCells(equilGrid),
             Opm::UgGridHelpers::globalCell(equilGrid),
@@ -140,8 +140,8 @@ public:
         // do the actual computation.
         Opm::initStateEquil(equilGrid,
                             opmBlackoilProps,
-                            *gridManager.deck(),
-                            *gridManager.eclState(),
+                            gridManager.deck(),
+                            gridManager.eclState(),
                             simulator.problem().gravity()[dimWorld - 1],
                             opmBlackoilState);
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -326,8 +326,8 @@ public:
         this->gravity_ = 0.0;
 
         // the "NOGRAV" keyword from Frontsim disables gravity...
-        auto deck = simulator.gridManager().deck();
-        if (!deck->hasKeyword("NOGRAV") && EWOMS_GET_PARAM(TypeTag, bool, EnableGravity))
+        const auto& deck = simulator.gridManager().deck();
+        if (!deck.hasKeyword("NOGRAV") && EWOMS_GET_PARAM(TypeTag, bool, EnableGravity))
             this->gravity_[dim - 1] = 9.80665;
 
         initFluidSystem_();
@@ -338,7 +338,7 @@ public:
         readInitialCondition_();
 
         // Set the start time of the simulation
-        const auto& timeMap = simulator.gridManager().schedule()->getTimeMap();
+        const auto& timeMap = simulator.gridManager().eclState().getSchedule().getTimeMap();
         tm curTime = boost::posix_time::to_tm(timeMap.getStartTime(/*timeStepIdx=*/0));
 
         Scalar startTime = std::mktime(&curTime);
@@ -393,8 +393,8 @@ public:
     {
         // Proceed to the next report step
         Simulator& simulator = this->simulator();
-        auto eclState = this->simulator().gridManager().eclState();
-        const auto& schedule = eclState->getSchedule();
+        auto& eclState = this->simulator().gridManager().eclState();
+        const auto& schedule = eclState.getSchedule();
         const auto& events = schedule.getEvents();
         const auto& timeMap = schedule.getTimeMap();
 
@@ -411,7 +411,7 @@ public:
             // has changed, the grid may need be re-created which has some serious
             // implications on e.g., the solution of the simulation.)
             const auto& miniDeck = schedule.getModifierDeck(nextEpisodeIdx);
-            eclState->applyModifierDeck(miniDeck);
+            eclState.applyModifierDeck(miniDeck);
 
             // re-compute all quantities which may possibly be affected.
             transmissibilities_.update();
@@ -520,7 +520,7 @@ public:
         const auto& eclState = simulator.gridManager().eclState();
         int episodeIdx = simulator.episodeIndex();
 
-        const auto& timeMap = eclState->getSchedule().getTimeMap();
+        const auto& timeMap = eclState.getSchedule().getTimeMap();
         int numReportSteps = timeMap.size() - 1;
         if (episodeIdx + 1 >= numReportSteps) {
             simulator.setFinished(true);
@@ -889,16 +889,16 @@ private:
 
     void readRockParameters_()
     {
-        auto deck = this->simulator().gridManager().deck();
-        auto eclState = this->simulator().gridManager().eclState();
+        const auto& deck = this->simulator().gridManager().deck();
+        const auto& eclState = this->simulator().gridManager().eclState();
         const auto& gridManager = this->simulator().gridManager();
 
         // the ROCK keyword has not been specified, so we don't need
         // to read rock parameters
-        if (!deck->hasKeyword("ROCK"))
+        if (!deck.hasKeyword("ROCK"))
             return;
 
-        const auto& rockKeyword = deck->getKeyword("ROCK");
+        const auto& rockKeyword = deck.getKeyword("ROCK");
         rockParams_.resize(rockKeyword.size());
         for (size_t rockRecordIdx = 0; rockRecordIdx < rockKeyword.size(); ++ rockRecordIdx) {
             const auto& rockRecord = rockKeyword.getRecord(rockRecordIdx);
@@ -910,11 +910,11 @@ private:
 
         // PVTNUM has not been specified, so everything is in the first region and we
         // don't need to care...
-        if (!eclState->get3DProperties().hasDeckIntGridProperty("PVTNUM"))
+        if (!eclState.get3DProperties().hasDeckIntGridProperty("PVTNUM"))
             return;
 
         const std::vector<int>& pvtnumData =
-            eclState->get3DProperties().getIntGridProperty("PVTNUM").getData();
+            eclState.get3DProperties().getIntGridProperty("PVTNUM").getData();
         unsigned numElem = gridManager.gridView().size(0);
         rockTableIdx_.resize(numElem);
         for (size_t elemIdx = 0; elemIdx < numElem; ++ elemIdx) {
@@ -928,9 +928,9 @@ private:
     void readMaterialParameters_()
     {
         const auto& gridManager = this->simulator().gridManager();
-        auto deck = gridManager.deck();
-        auto eclState = gridManager.eclState();
-        const auto& props = eclState->get3DProperties();
+        const auto& deck = gridManager.deck();
+        const auto& eclState = gridManager.eclState();
+        const auto& props = eclState.get3DProperties();
 
         size_t numDof = this->model().numGridDof();
 
@@ -984,7 +984,7 @@ private:
             compressedToCartesianElemIdx[elemIdx] = gridManager.cartesianIndex(elemIdx);
 
         materialLawManager_ = std::make_shared<EclMaterialLawManager>();
-        materialLawManager_->initFromDeck(*deck, *eclState, compressedToCartesianElemIdx);
+        materialLawManager_->initFromDeck(deck, eclState, compressedToCartesianElemIdx);
         ////////////////////////////////
     }
 
@@ -992,8 +992,8 @@ private:
     {
         const auto& gridManager = this->simulator().gridManager();
         const auto& eclState = gridManager.eclState();
-        const auto& eclGrid = eclState->getInputGrid();
-        const auto& props = eclState->get3DProperties();
+        const auto& eclGrid = eclState.getInputGrid();
+        const auto& props = eclState.get3DProperties();
 
         size_t numDof = this->model().numGridDof();
 
@@ -1044,18 +1044,18 @@ private:
 
     void initFluidSystem_()
     {
-        auto deck = this->simulator().gridManager().deck();
-        auto eclState = this->simulator().gridManager().eclState();
+        const auto& deck = this->simulator().gridManager().deck();
+        const auto& eclState = this->simulator().gridManager().eclState();
 
-        FluidSystem::initFromDeck(*deck, *eclState);
+        FluidSystem::initFromDeck(deck, eclState);
    }
 
     void readInitialCondition_()
     {
         const auto& gridManager = this->simulator().gridManager();
-        auto deck = gridManager.deck();
+        const auto& deck = gridManager.deck();
 
-        if (!deck->hasKeyword("EQUIL"))
+        if (!deck.hasKeyword("EQUIL"))
             readExplicitInitialCondition_();
         else
             readEquilInitialCondition_();
@@ -1087,32 +1087,32 @@ private:
     void readExplicitInitialCondition_()
     {
         const auto& gridManager = this->simulator().gridManager();
-        auto deck = gridManager.deck();
-        auto eclState = gridManager.eclState();
+        const auto& deck = gridManager.deck();
+        const auto& eclState = gridManager.eclState();
 
         // since the values specified in the deck do not need to be consistent, we use an
         // initial condition that conserves the total mass specified by these values.
         useMassConservativeInitialCondition_ = true;
 
         // make sure all required quantities are enables
-        if (FluidSystem::phaseIsActive(waterPhaseIdx) && !deck->hasKeyword("SWAT"))
+        if (FluidSystem::phaseIsActive(waterPhaseIdx) && !deck.hasKeyword("SWAT"))
             OPM_THROW(std::runtime_error,
                       "The ECL input file requires the presence of the SWAT keyword if "
                       "the water phase is active");
-        if (FluidSystem::phaseIsActive(gasPhaseIdx) && !deck->hasKeyword("SGAS"))
+        if (FluidSystem::phaseIsActive(gasPhaseIdx) && !deck.hasKeyword("SGAS"))
             OPM_THROW(std::runtime_error,
                       "The ECL input file requires the presence of the SGAS keyword if "
                       "the gas phase is active");
 
-        if (!deck->hasKeyword("PRESSURE"))
+        if (!deck.hasKeyword("PRESSURE"))
              OPM_THROW(std::runtime_error,
                       "The ECL input file requires the presence of the PRESSURE "
                       "keyword if the model is initialized explicitly");
-        if (FluidSystem::enableDissolvedGas() && !deck->hasKeyword("RS"))
+        if (FluidSystem::enableDissolvedGas() && !deck.hasKeyword("RS"))
             OPM_THROW(std::runtime_error,
                       "The ECL input file requires the RS keyword to be present if"
                       " dissolved gas is enabled");
-        if (FluidSystem::enableVaporizedOil() && !deck->hasKeyword("RV"))
+        if (FluidSystem::enableVaporizedOil() && !deck.hasKeyword("RV"))
             OPM_THROW(std::runtime_error,
                       "The ECL input file requires the RV keyword to be present if"
                       " vaporized oil is enabled");
@@ -1126,27 +1126,27 @@ private:
 
         std::vector<double> waterSaturationData;
         if (FluidSystem::phaseIsActive(waterPhaseIdx))
-            waterSaturationData = deck->getKeyword("SWAT").getSIDoubleData();
+            waterSaturationData = deck.getKeyword("SWAT").getSIDoubleData();
         else
             waterSaturationData.resize(numCartesianCells, 0.0);
 
         std::vector<double> gasSaturationData;
         if (FluidSystem::phaseIsActive(gasPhaseIdx))
-            gasSaturationData = deck->getKeyword("SGAS").getSIDoubleData();
+            gasSaturationData = deck.getKeyword("SGAS").getSIDoubleData();
         else
             gasSaturationData.resize(numCartesianCells, 0.0);
 
         const std::vector<double>& pressureData =
-            deck->getKeyword("PRESSURE").getSIDoubleData();
+            deck.getKeyword("PRESSURE").getSIDoubleData();
         const std::vector<double> *rsData = 0;
         if (FluidSystem::enableDissolvedGas())
-            rsData = &deck->getKeyword("RS").getSIDoubleData();
+            rsData = &deck.getKeyword("RS").getSIDoubleData();
         const std::vector<double> *rvData = 0;
         if (FluidSystem::enableVaporizedOil())
-            rvData = &deck->getKeyword("RV").getSIDoubleData();
+            rvData = &deck.getKeyword("RV").getSIDoubleData();
         // initial reservoir temperature
         const std::vector<double>& tempiData =
-            eclState->get3DProperties().getDoubleGridProperty("TEMPI").getData();
+            eclState.get3DProperties().getDoubleGridProperty("TEMPI").getData();
 
         // make sure that the size of the data arrays is correct
 #ifndef NDEBUG
@@ -1297,7 +1297,7 @@ private:
     void updatePvtnum_()
     {
         const auto& eclState = this->simulator().gridManager().eclState();
-        const auto& eclProps = eclState->get3DProperties();
+        const auto& eclProps = eclState.get3DProperties();
 
         if (!eclProps.hasDeckIntGridProperty("PVTNUM"))
             return;

--- a/ebos/eclsummarywriter.hh
+++ b/ebos/eclsummarywriter.hh
@@ -106,7 +106,7 @@ public:
         const auto& deck = simulator.gridManager().deck();
 
         // populate the set of quantities to write
-        if (deck->hasKeyword("ALL"))
+        if (deck.hasKeyword("ALL"))
             handleAllKeyword__();
         else
             addPresentSummaryKeywords_(deck);
@@ -334,9 +334,9 @@ private:
     bool writeWopt_() const
     { return summaryKeywords_.count("WOPT") > 0; }
 
-    void addVariables_(std::shared_ptr< const Opm::EclipseState > eclState)
+    void addVariables_(const Opm::EclipseState& eclState)
     {
-        const auto& wellsVector = eclState->getSchedule().getWells();
+        const auto& wellsVector = eclState.getSchedule().getWells();
         for (size_t wellIdx = 0; wellIdx < wellsVector.size(); ++ wellIdx) {
             const auto& eclWell = wellsVector[wellIdx];
             auto& wellInfo = ertWellInfo_[eclWell->name()];
@@ -517,9 +517,9 @@ private:
     }
 
     // add all quantities which are present in the summary section of the deck
-    void addPresentSummaryKeywords_(std::shared_ptr< const Opm::Deck > deck)
+    void addPresentSummaryKeywords_(const Opm::Deck& deck)
     {
-        Opm::Section summarySection(*deck, "SUMMARY");
+        Opm::Section summarySection(deck, "SUMMARY");
         auto kwIt = summarySection.begin();
         auto kwEndIt = summarySection.end();
         // skip the first keyword as this is "SUMMARY". bug in opm-parser?

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -103,14 +103,14 @@ public:
 
         const auto& gridManager = simulator_.gridManager();
         const auto& eclState = gridManager.eclState();
-        const auto& simConfig = eclState->getSimulationConfig();
+        const auto& simConfig = eclState.getSimulationConfig();
 
         enableThresholdPressure_ = simConfig.hasThresholdPressure();
         if (!enableThresholdPressure_)
             return;
 
         numEquilRegions_ =
-            deck->getKeyword("EQLDIMS").getRecord(0).getItem("NTEQUL").template get<int>(0);
+            deck.getKeyword("EQLDIMS").getRecord(0).getItem("NTEQUL").template get<int>(0);
         if (numEquilRegions_ > 0xff) {
             // make sure that the index of an equilibration region can be stored in a
             // single byte
@@ -124,7 +124,7 @@ public:
 
         // internalize the data specified using the EQLNUM keyword
         const std::vector<int>& equilRegionData =
-            eclState->get3DProperties().getIntGridProperty("EQLNUM").getData();
+            eclState.get3DProperties().getIntGridProperty("EQLNUM").getData();
         elemEquilRegion_.resize(numElements, 0);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
             int cartElemIdx = gridManager.cartesianIndex(elemIdx);
@@ -233,7 +233,7 @@ private:
         const auto& gridView = gridManager.gridView();
         const auto& elementMapper = simulator_.model().elementMapper();
         const auto& eclState = simulator_.gridManager().eclState();
-        const Opm::SimulationConfig& simConfig = eclState->getSimulationConfig();
+        const Opm::SimulationConfig& simConfig = eclState.getSimulationConfig();
         const auto& thpres = simConfig.getThresholdPressure();
 
         // set the threshold pressures for all EQUIL region boundaries which have a
@@ -241,7 +241,6 @@ private:
         auto elemIt = gridView.template begin</*codim=*/ 0>();
         const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
         for (; elemIt != elemEndIt; ++elemIt) {
-
             const auto& elem = *elemIt;
             if (elem.partitionType() != Dune::InteriorEntity)
                 continue;

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -101,12 +101,12 @@ public:
         const auto& gridView = simulator_.gridView();
         const auto& elementMapper = simulator_.model().elementMapper();
         const auto& cartMapper = gridManager.cartesianIndexMapper();
-        const auto eclState = gridManager.eclState();
-        const auto eclGrid = eclState->getInputGrid();
-        const auto& transMult = eclState->getTransMult();
+        const auto& eclState = gridManager.eclState();
+        const auto& eclGrid = eclState.getInputGrid();
+        const auto& transMult = eclState.getTransMult();
 
         const std::vector<double>& ntg =
-            eclState->get3DProperties().getDoubleGridProperty("NTG").getData();
+            eclState.get3DProperties().getDoubleGridProperty("NTG").getData();
 
         unsigned numElements = elementMapper.size();
 

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -95,9 +95,9 @@ public:
      *
      * I.e., well positions, names etc...
      */
-    void init(std::shared_ptr< const Opm::EclipseState > eclState)
+    void init(const Opm::EclipseState& eclState)
     {
-        const auto& deckSchedule = eclState->getSchedule();
+        const auto& deckSchedule = eclState.getSchedule();
 
         // create the wells which intersect with the current process' grid
         for (size_t deckWellIdx = 0; deckWellIdx < deckSchedule.numWells(); ++deckWellIdx)
@@ -121,11 +121,11 @@ public:
      * \brief This should be called the problem before each simulation
      *        episode to adapt the well controls.
      */
-    void beginEpisode(std::shared_ptr< const Opm::EclipseState > eclState, bool wasRestarted=false)
+    void beginEpisode(const Opm::EclipseState& eclState, bool wasRestarted=false)
     {
         unsigned episodeIdx = simulator_.episodeIndex();
 
-        const auto& deckSchedule = eclState->getSchedule();
+        const auto& deckSchedule = eclState.getSchedule();
         WellCompletionsMap wellCompMap;
         computeWellCompletionsMap_(episodeIdx, wellCompMap);
 
@@ -567,12 +567,12 @@ public:
      * "Something" can either be the well topology (i.e., which grid blocks are contained
      * in which well) or it can be a well parameter like the bottom hole pressure...
      */
-    bool wellsChanged(std::shared_ptr< const Opm::EclipseState > eclState, unsigned reportStepIdx) const
+    bool wellsChanged(const Opm::EclipseState& eclState, unsigned reportStepIdx) const
     {
         if (wellTopologyChanged_(eclState, reportStepIdx))
             return true;
 
-        const auto& schedule = eclState->getSchedule();
+        const auto& schedule = eclState.getSchedule();
         if (schedule.getTimeMap().numTimesteps() <= (unsigned) reportStepIdx)
             // for the "until the universe dies" episode, the wells don't change
             return false;
@@ -585,7 +585,7 @@ public:
     }
 
 protected:
-    bool wellTopologyChanged_(std::shared_ptr< const Opm::EclipseState > eclState, unsigned reportStepIdx) const
+    bool wellTopologyChanged_(const Opm::EclipseState& eclState, unsigned reportStepIdx) const
     {
         if (reportStepIdx == 0) {
             // the well topology has always been changed relative to before the
@@ -593,7 +593,7 @@ protected:
             return true;
         }
 
-        const auto& schedule = eclState->getSchedule();
+        const auto& schedule = eclState.getSchedule();
         if (schedule.getTimeMap().numTimesteps() <= (unsigned) reportStepIdx)
             // for the "until the universe dies" episode, the wells don't change
             return false;
@@ -666,11 +666,11 @@ protected:
 
     void computeWellCompletionsMap_(unsigned reportStepIdx, WellCompletionsMap& cartesianIdxToCompletionMap)
     {
-        auto eclStatePtr = simulator_.gridManager().eclState();
-        const auto& deckSchedule = eclStatePtr->getSchedule();
+        const auto& eclState = simulator_.gridManager().eclState();
+        const auto& deckSchedule = eclState.getSchedule();
 
 #ifndef NDEBUG
-        const auto& eclGrid = eclStatePtr->getInputGrid();
+        const auto& eclGrid = eclState.getInputGrid();
         assert( int(eclGrid.getNX()) == simulator_.gridManager().cartesianDimensions()[ 0 ] );
         assert( int(eclGrid.getNY()) == simulator_.gridManager().cartesianDimensions()[ 1 ] );
         assert( int(eclGrid.getNZ()) == simulator_.gridManager().cartesianDimensions()[ 2 ] );
@@ -718,8 +718,8 @@ protected:
 
     void updateWellParameters_(unsigned reportStepIdx, const WellCompletionsMap& wellCompletions)
     {
-        auto eclStatePtr = simulator_.gridManager().eclState();
-        const auto& deckSchedule = eclStatePtr->getSchedule();
+        const auto& eclState = simulator_.gridManager().eclState();
+        const auto& deckSchedule = eclState.getSchedule();
         const std::vector<const Opm::Well*>& deckWells = deckSchedule.getWells(reportStepIdx);
 
         // set the reference depth for all wells

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -86,7 +86,7 @@ class EclWriterHelper
         std::string egridFileName(egridRawFileName);
         std::free(egridRawFileName);
 
-        ErtGrid ertGrid(*writer.simulator_.gridManager().eclGrid(),
+        ErtGrid ertGrid(writer.simulator_.gridManager().eclState().getInputGrid(),
                         writer.simulator_.gridManager().grid(),
                         writer.simulator_.gridManager().cartesianIndexMapper(),
                         writer.simulator_.problem().deckUnits());

--- a/ebos/ertwrappers.hh
+++ b/ebos/ertwrappers.hh
@@ -346,19 +346,19 @@ public:
     template <class Simulator>
     void writeHeader(const Simulator& simulator, unsigned reportStepIdx)
     {
-        const auto& eclGrid = simulator.gridManager().eclGrid();
+        const auto& eclGrid = simulator.gridManager().eclState().getInputGrid();
         const auto& eclState = simulator.gridManager().eclState();
-        const auto& eclSchedule = eclState->getSchedule();
+        const auto& eclSchedule = eclState.getSchedule();
 
         double secondsElapsed = simulator.time() + simulator.timeStepSize();
         double daysElapsed = secondsElapsed/(24*60*60);
 
         ecl_rsthead_type rstHeader;
         rstHeader.sim_time = simulator.startTime() + secondsElapsed;
-        rstHeader.nactive = eclGrid->getNumActive();
-        rstHeader.nx = eclGrid->getNX();
-        rstHeader.ny = eclGrid->getNY();
-        rstHeader.nz = eclGrid->getNZ();
+        rstHeader.nactive = eclGrid.getNumActive();
+        rstHeader.nx = eclGrid.getNX();
+        rstHeader.ny = eclGrid.getNY();
+        rstHeader.nz = eclGrid.getNZ();
         rstHeader.nwells = eclSchedule.numWells(reportStepIdx);
         rstHeader.niwelz = numIwellItemsPerWell;
         rstHeader.nzwelz = numZwelStringsPerWell;
@@ -568,8 +568,8 @@ public:
     ErtSummary(const Simulator& simulator)
     {
         const auto& gridManager = simulator.gridManager();
-        const auto& eclGrid = gridManager.eclGrid();
-        const auto& timeMap = gridManager.schedule()->getTimeMap();
+        const auto& eclGrid = gridManager.eclState().getInputGrid();
+        const auto& timeMap = gridManager.eclState().getSchedule().getTimeMap();
 
         std::string caseName = gridManager.caseName();
 
@@ -584,9 +584,9 @@ public:
                                           /*joinString=*/":",
                                           startTime,
                                           /*timeIsInDays=*/true, // if not, it's hours...
-                                          eclGrid->getNX(),
-                                          eclGrid->getNY(),
-                                          eclGrid->getNZ());
+                                          eclGrid.getNX(),
+                                          eclGrid.getNY(),
+                                          eclGrid.getNZ());
     }
 
     ~ErtSummary()

--- a/ewoms/io/basegridmanager.hh
+++ b/ewoms/io/basegridmanager.hh
@@ -71,6 +71,8 @@ public:
         : simulator_(simulator)
     {}
 
+    BaseGridManager(const BaseGridManager&) = delete;
+
     /*!
      * \brief Returns a reference to the grid view to be used.
      */


### PR DESCRIPTION
this makes creating the grid a bit slower because the
transmissibilities need to be calculated twice: once for the
sequential grid and once for the distributed one. while corresponds to
the way `flow_legacy` does the load balancing and it should allow
better results, this does not seem to be the case for the Norne deck
if ZOLTAN is not available:

After loadbalancing process 3 has 4413 cells.
After loadbalancing process 2 has 12390 cells.
After loadbalancing process 0 has 13629 cells.
After loadbalancing process 1 has 21253 cells.

i.e., process 1 is responsible for about 4 times the number of cells
as process 3.

Note that this PR includes #102 (which should go in before).