### PR TITLE
dune.module: add a opm-core suggestion

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Url: http://opm-project.org/ewoms
 MaintainerName: Andreas Lauser
 Maintainer: and@poware.org
 Depends: dune-grid (>= 2.3) dune-istl  (>= 2.3) opm-common opm-material
-Suggests: dune-localfunctions (>= 2.3) dune-fem dune-alugrid opm-parser opm-grid
+Suggests: dune-localfunctions (>= 2.3) dune-fem dune-alugrid opm-parser opm-grid opm-core


### PR DESCRIPTION
opm-core is required for ebos and since it is now no longer an implicit dependency of opm-grid, we need to add it here. (more precisely: ebos uses it for the hydrostatic-conditions-as-initial-solution part.)  without this, dunecontrol does not include opm-core.