### PR TITLE
make it possible to specify a separate floating-point type of the linear solver

### DIFF
--- a/ewoms/linear/foreignoverlapfrombcrsmatrix.hh
+++ b/ewoms/linear/foreignoverlapfrombcrsmatrix.hh
@@ -58,17 +58,17 @@ namespace Linear {
  * The foreign overlap are all (row) indices which overlap with the
  * some of the current process's local indices.
  */
-template <class BCRSMatrix>
 class ForeignOverlapFromBCRSMatrix
 {
-    ForeignOverlapFromBCRSMatrix(const ForeignOverlapFromBCRSMatrix& )
-    {}
-
 public:
+    // overlaps should never be copied!
+    ForeignOverlapFromBCRSMatrix(const ForeignOverlapFromBCRSMatrix&) = delete;
+
     /*!
      * \brief Constructs the foreign overlap given a BCRS matrix and
      *        an initial list of border indices.
      */
+    template <class BCRSMatrix>
     ForeignOverlapFromBCRSMatrix(const BCRSMatrix& A,
                                  const BorderList& borderList,
                                  const BlackList& blackList,
@@ -347,6 +347,7 @@ protected:
     // extend the foreign overlaps by 'overlapSize' levels. this uses
     // a greedy algorithm which extends the region by one level and
     // then calls itself recursively...
+    template <class BCRSMatrix>
     void extendForeignOverlap_(const BCRSMatrix& A,
                                SeedList& seedList,
                                BorderDistance borderDistance,
@@ -464,6 +465,7 @@ protected:
         return -1;
     }
 
+    template <class BCRSMatrix>
     void addNonNeighborOverlapIndices_(const BCRSMatrix& OPM_UNUSED A,
                                        SeedList& seedList,
                                        BorderDistance borderDist)

--- a/ewoms/linear/overlappingbcrsmatrix.hh
+++ b/ewoms/linear/overlappingbcrsmatrix.hh
@@ -114,6 +114,12 @@ public:
         }
     }
 
+    ParentType& asParent()
+    { return *this; }
+
+    const ParentType& asParent() const
+    { return *this; }
+
     /*!
      * \brief Returns the domestic overlap for the process.
      */

--- a/ewoms/linear/overlappingblockvector.hh
+++ b/ewoms/linear/overlappingblockvector.hh
@@ -105,6 +105,7 @@ public:
      * \brief Assign an overlapping block vector from a
      *        non-overlapping one, border entries are added.
      */
+    template <class BlockVector>
     void assignAddBorder(const BlockVector& nativeBlockVector)
     {
         size_t numDomestic = overlap_->numDomestic();
@@ -113,9 +114,9 @@ public:
         for (unsigned domRowIdx = 0; domRowIdx < numDomestic; ++domRowIdx) {
             Index nativeRowIdx = overlap_->domesticToNative(static_cast<Index>(domRowIdx));
             if (nativeRowIdx < 0)
-                (*this)[static_cast<unsigned>(domRowIdx)] = 0.0;
+                (*this)[domRowIdx] = 0.0;
             else
-                (*this)[static_cast<unsigned>(domRowIdx)] = nativeBlockVector[static_cast<unsigned>(nativeRowIdx)];
+                (*this)[domRowIdx] = nativeBlockVector[nativeRowIdx];
         }
 
         // add up the contents of border rows, for the remaining rows,
@@ -127,7 +128,8 @@ public:
      * \brief Assign an overlapping block vector from a non-overlapping one, border
      *        entries are assigned using their respective master ranks.
      */
-    void assign(const BlockVector& nativeBlockVector)
+    template <class NativeBlockVector>
+    void assign(const NativeBlockVector& nativeBlockVector)
     {
         size_t numDomestic = overlap_->numDomestic();
 
@@ -149,7 +151,8 @@ public:
      * \brief Assign the local values to a non-overlapping block
      *        vector.
      */
-    void assignTo(BlockVector& nativeBlockVector) const
+    template <class NativeBlockVector>
+    void assignTo(NativeBlockVector& nativeBlockVector) const
     {
         // assign the local rows
         size_t numNative = overlap_->numNative();

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -261,14 +261,13 @@ public:
         }
 
         Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 100.0;
-        Scalar linearSolverFixPointTolerance = 100*std::numeric_limits<Scalar>::epsilon();
         typedef typename GridView::CollectiveCommunication Comm;
         auto *convCrit =
             new Ewoms::WeightedResidualReductionCriterion<Vector, Comm>(
                 simulator_.gridView().comm(),
                 residWeightVec,
-                /*fixPointTolerance=*/linearSolverFixPointTolerance,
                 /*residualReductionTolerance=*/linearSolverTolerance,
+                /*fixPointTolerance=*/0.0,
                 /*absoluteResidualTolerance=*/linearSolverAbsTolerance);
 
         // done creating the convergence criterion

--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -319,14 +319,13 @@ public:
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
         Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 100.0;
-        Scalar linearSolverFixPointTolerance = 100*std::numeric_limits<Scalar>::epsilon();
         typedef typename GridView::CollectiveCommunication Comm;
         auto *convCrit =
             new Ewoms::WeightedResidualReductionCriterion<OverlappingVector, Comm>(
                 simulator_.gridView().comm(),
                 residWeightVec,
-                /*fixPointTolerance=*/linearSolverFixPointTolerance,
                 /*residualReductionTolerance=*/linearSolverTolerance,
+                /*fixPointTolerance=*/0.0,
                 /*absoluteResidualTolerance=*/linearSolverAbsTolerance);
 
         // done creating the convergence criterion

--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -73,6 +73,10 @@ NEW_PROP_TAG(LinearSolverBackend);
 NEW_PROP_TAG(LinearSolverWrapper);
 NEW_PROP_TAG(PreconditionerWrapper);
 
+
+//! The floating point type used internally by the linear solver
+NEW_PROP_TAG(LinearSolverScalar);
+
 /*!
  * \brief The size of the algebraic overlap of the linear solver.
  *
@@ -195,9 +199,9 @@ public:
         : simulator_(simulator)
         , gridSequenceNumber_( -1 )
     {
-        overlappingMatrix_ = 0;
-        overlappingb_ = 0;
-        overlappingx_ = 0;
+        overlappingMatrix_ = nullptr;
+        overlappingb_ = nullptr;
+        overlappingx_ = nullptr;
     }
 
     ~ParallelIterativeSolverBackend()
@@ -569,12 +573,11 @@ EWOMS_WRAP_ISTL_SOLVER(RestartedGMRes, Ewoms::RestartedGMResSolver)
     class PreconditionerWrapper##PREC_NAME                                      \
     {                                                                           \
         typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                 \
-        typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) JacobianMatrix; \
-        typedef typename GET_PROP_TYPE(TypeTag,                                 \
-                                       OverlappingVector) OverlappingVector;    \
+        typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix; \
+        typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector; \
                                                                                 \
     public:                                                                     \
-        typedef ISTL_PREC_TYPE<JacobianMatrix, OverlappingVector,               \
+        typedef ISTL_PREC_TYPE<OverlappingMatrix, OverlappingVector,            \
                                OverlappingVector> SequentialPreconditioner;     \
         PreconditionerWrapper##PREC_NAME()                                      \
         {}                                                                      \
@@ -586,9 +589,10 @@ EWOMS_WRAP_ISTL_SOLVER(RestartedGMRes, Ewoms::RestartedGMResSolver)
                                  "preconditioner");                             \
         }                                                                       \
                                                                                 \
-        void prepare(JacobianMatrix& matrix)                                    \
+        void prepare(OverlappingMatrix& matrix)                                 \
         {                                                                       \
-            Scalar relaxationFactor= EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);\
+            Scalar relaxationFactor =                                           \
+                EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);     \
             seqPreCond_ = new SequentialPreconditioner(matrix,                  \
                                                        relaxationFactor);       \
         }                                                                       \
@@ -630,24 +634,41 @@ SET_INT_PROP(ParallelIterativeLinearSolver, PreconditionerOrder, 0);
 //! set the GMRes restart parameter to 10 by default
 SET_INT_PROP(ParallelIterativeLinearSolver, GMResRestart, 10);
 
-SET_TYPE_PROP(ParallelIterativeLinearSolver, OverlappingMatrix,
-              Ewoms::Linear::OverlappingBCRSMatrix<typename GET_PROP_TYPE(
-                  TypeTag, JacobianMatrix)>);
-SET_TYPE_PROP(ParallelIterativeLinearSolver, Overlap,
+//! by default use the same kind of floating point values for the linearization and for
+//! the linear solve
+SET_TYPE_PROP(ParallelIterativeLinearSolver,
+              LinearSolverScalar,
+              typename GET_PROP_TYPE(TypeTag, Scalar));
+
+SET_PROP(ParallelIterativeLinearSolver, OverlappingMatrix)
+{
+    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
+    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> VectorBlock;
+    typedef Dune::BCRSMatrix<VectorBlock> NonOverlappingMatrix;
+    typedef Ewoms::Linear::OverlappingBCRSMatrix<NonOverlappingMatrix> type;
+};
+
+SET_TYPE_PROP(ParallelIterativeLinearSolver,
+              Overlap,
               typename GET_PROP_TYPE(TypeTag, OverlappingMatrix)::Overlap);
+
 SET_PROP(ParallelIterativeLinearSolver, OverlappingVector)
 {
-    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) Vector;
+    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
+    typedef Dune::FieldVector<LinearSolverScalar, numEq> VectorBlock;
     typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef Ewoms::Linear::OverlappingBlockVector<typename Vector::block_type,
-                                                  Overlap> type;
+    typedef Ewoms::Linear::OverlappingBlockVector<VectorBlock, Overlap> type;
 };
+
 SET_PROP(ParallelIterativeLinearSolver, OverlappingScalarProduct)
 {
     typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
     typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
     typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector, Overlap> type;
 };
+
 SET_PROP(ParallelIterativeLinearSolver, OverlappingLinearOperator)
 {
     typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
@@ -656,11 +677,16 @@ SET_PROP(ParallelIterativeLinearSolver, OverlappingLinearOperator)
                                                OverlappingVector> type;
 };
 
-SET_TYPE_PROP(ParallelIterativeLinearSolver, LinearSolverBackend,
+SET_TYPE_PROP(ParallelIterativeLinearSolver,
+              LinearSolverBackend,
               Ewoms::Linear::ParallelIterativeSolverBackend<TypeTag>);
-SET_TYPE_PROP(ParallelIterativeLinearSolver, LinearSolverWrapper,
+
+SET_TYPE_PROP(ParallelIterativeLinearSolver,
+              LinearSolverWrapper,
               Ewoms::Linear::SolverWrapperBiCGStab<TypeTag>);
-SET_TYPE_PROP(ParallelIterativeLinearSolver, PreconditionerWrapper,
+
+SET_TYPE_PROP(ParallelIterativeLinearSolver,
+              PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
 
 //! set the default overlap size to 2

--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -644,8 +644,8 @@ SET_PROP(ParallelIterativeLinearSolver, OverlappingMatrix)
 {
     static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
     typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> VectorBlock;
-    typedef Dune::BCRSMatrix<VectorBlock> NonOverlappingMatrix;
+    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> MatrixBlock;
+    typedef Dune::BCRSMatrix<MatrixBlock> NonOverlappingMatrix;
     typedef Ewoms::Linear::OverlappingBCRSMatrix<NonOverlappingMatrix> type;
 };
 

--- a/ewoms/linear/weightedresidreductioncriterion.hh
+++ b/ewoms/linear/weightedresidreductioncriterion.hh
@@ -65,18 +65,15 @@ public:
 
     WeightedResidualReductionCriterion(const CollectiveCommunication& comm,
                                        const Vector& residWeights,
-                                       Scalar fixPointTolerance,
                                        Scalar residualReductionTolerance,
+                                       Scalar fixPointTolerance,
                                        Scalar absResidualTolerance = 0.0)
         : comm_(comm),
           residWeightVec_(residWeights),
           fixPointTolerance_(fixPointTolerance),
           residualReductionTolerance_(residualReductionTolerance),
           absResidualTolerance_(absResidualTolerance)
-    {
-        Scalar minFixPointTolerance = 100*std::numeric_limits<Scalar>::epsilon();
-        fixPointTolerance_ = std::max(fixPointTolerance_, minFixPointTolerance);
-    }
+    { }
 
     /*!
      * \brief Sets the relative weight of each row of the residual.

--- a/tests/lens_immiscible_ecfv.cc
+++ b/tests/lens_immiscible_ecfv.cc
@@ -42,6 +42,10 @@ SET_TAG_PROP(LensProblemEcfv, SpatialDiscretizationSplice, EcfvDiscretization);
 
 // use automatic differentiation for this simulator
 SET_TAG_PROP(LensProblemEcfv, LocalLinearizerSplice, AutoDiffLocalLinearizer);
+
+// this problem works fine if the linear solver uses single precision scalars
+SET_TYPE_PROP(LensProblemEcfv, LinearSolverScalar, float);
+
 }}
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The floating point type which ought to be used internally by the iterative linear solvers can now be specified via the "LinearSolverScalar" property. It defaults to "Scalar", so this patch does not change the default behaviour.

The most common case of this is probably to use single precision floating point scalars for the linear solver and to do the linearization using double precision. For the lens_immiscible_ecfv test problem with two grid refinements, the performance improvements seem to be considerable: On my machine the linear solver speedup is almost 50%. On the flip-side, there are precission problems, so the tolerance of the Newton-Raphson solver must be relaxed when using single-precision for the linear solver.

The exact command which I used for that measurement is:

```
./bin/lens_immiscible_ecfv --newton-raw-tolerance=1e-6 --grid-global-refinements=2
```

In the future, making the linear solver automatically switch between `float` and `double` might solve the precision problems, but I need to think a bit about how to implement this.