### PR TITLE
Linear solver tuning

### DIFF
--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -260,7 +260,7 @@ public:
             }
         }
 
-        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 100.0;
+        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 10.0;
         typedef typename GridView::CollectiveCommunication Comm;
         auto *convCrit =
             new Ewoms::WeightedResidualReductionCriterion<Vector, Comm>(

--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -318,7 +318,7 @@ public:
         }
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 100.0;
+        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 10.0;
         typedef typename GridView::CollectiveCommunication Comm;
         auto *convCrit =
             new Ewoms::WeightedResidualReductionCriterion<OverlappingVector, Comm>(

--- a/ewoms/linear/paralleliterativebackend.hh
+++ b/ewoms/linear/paralleliterativebackend.hh
@@ -692,7 +692,7 @@ SET_TYPE_PROP(ParallelIterativeLinearSolver,
 SET_INT_PROP(ParallelIterativeLinearSolver, LinearSolverOverlapSize, 2);
 
 //! set the default number of maximum iterations for the linear solver
-SET_INT_PROP(ParallelIterativeLinearSolver, LinearSolverMaxIterations, 250);
+SET_INT_PROP(ParallelIterativeLinearSolver, LinearSolverMaxIterations, 1000);
 } // namespace Properties
 } // namespace Ewoms
 


### PR DESCRIPTION
this changes the default value for the maximum number of linear iterations of the non-AMG solvers from 250 to 1000 and relaxes the absolute tolerance for the linear solvers.

This improves the performance of some tests while the chances that it causes regressions elsewhere are pretty slim IMO. 