### PR TITLE
ebos: update the PffGridVector for transmissibility after geologic events

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -416,6 +416,7 @@ public:
             // re-compute all quantities which may possibly be affected.
             transmissibilities_.update();
             updatePorosity_();
+            updatePffDofData_();
         }
 
         // Opm::TimeMap deals with points in time, so the number of time intervals (i.e.,


### PR DESCRIPTION
this regression was found by @totto82. it was introduced when the explicit prefetching feature was added. Since it only affected decks with geology changes in the SCHEDULE section (a.k.a. Model 2), analysing this issue must have been a *huge* nightmare, so I owe @totto82 at least one beer.