### PR TITLE
fix minor output bug

### DIFF
--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -413,6 +413,11 @@ public:
                 updateTime_ += updateTimer_.realTimeElapsed();
                 updateTimer_.halt();
 
+                if (asImp_().verbose_())
+                    // make sure that the line currently holding the cursor is prestine
+                    std::cout << clearRemainingLine
+                              << std::flush;
+
                 // tell the implementation that we're done with this iteration
                 prePostProcessTimer.start();
                 asImp_().endIteration_(nextSolution, currentSolution);


### PR DESCRIPTION
the "update..." message of the newton loop was not cleared and if the
end-of-iteration message was shorter than the update message, it was
suffixed by a few junk characters.