### PR TITLE
Improve timer

### DIFF
--- a/ewoms/common/timer.hh
+++ b/ewoms/common/timer.hh
@@ -49,8 +49,6 @@ class Timer
 {
     struct TimeData
     {
-        // The timespec data structure is more accurate than Linux (or at least POSIX)
-        // specific. for other operating systems, we use Dune::Timer
         std::chrono::high_resolution_clock::time_point realtimeData;
         std::clock_t cputimeData;
     };
@@ -187,13 +185,24 @@ public:
         return globalVal;
     }
 
+    /*!
+     * \brief Adds the time of another timer to the current one
+     */
+    Timer& operator+=(const Timer& other)
+    {
+        realTimeElapsed_ += other.realTimeElapsed();
+        cpuTimeElapsed_ += other.cpuTimeElapsed();
+
+        return *this;
+    }
+
 private:
     // measure the current time and put it into the object passed via
     // the argument.
     static void measure_(TimeData& timeData)
     {
-        // This method is more accurate than  Linux (or at least POSIX) specific. for other operating
-        // systems, we use Dune::Timer
+        // Note: On Linux -- or rather fully POSIX compliant systems -- using
+        // clock_gettime() would be more accurate for the CPU time.
         timeData.realtimeData = std::chrono::high_resolution_clock::now();
         timeData.cputimeData = std::clock();
     }

--- a/ewoms/common/timer.hh
+++ b/ewoms/common/timer.hh
@@ -68,91 +68,122 @@ public:
     }
 
     /*!
-     * \brief Stop counting the time resources used by the simulation.
+     * \brief Stop counting the time resources.
+     *
+     * Returns the wall clock time the timer was active.
      */
-    void stop()
+    double stop()
     {
+        if (!isStopped_) {
+            TimeData stopTime;
+
+            measure_(stopTime);
+
+            const auto& t1 = startTime_.realtimeData;
+            const auto& t2 = stopTime.realtimeData;
+            std::chrono::duration<double> dt =
+                std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1);
+
+            realTimeElapsed_ += dt.count();
+            cpuTimeElapsed_ +=
+                static_cast<double>(stopTime.cputimeData
+                                    - startTime_.cputimeData)/CLOCKS_PER_SEC;
+        }
+
         isStopped_ = true;
-        measure_(stopTime_);
+
+        return realTimeElapsed_;
     }
 
     /*!
-     * \brief Stop the measurement and always return 0 for all timing values
+     * \brief Stop the measurement reset all timing values
      */
     void halt()
     {
         isStopped_ = true;
-
-        measure_(startTime_);
-        stopTime_ = startTime_;
+        cpuTimeElapsed_ = 0.0;
+        realTimeElapsed_ = 0.0;
     }
 
     /*!
-     * \brief Return the real time [s] elapsed
-     *
-     * If stop() was not yet called, this returns the time elapsed
-     * since the last call to start().
+     * \brief Make the current point in time t=0 but do not change the status of the timer.
+     */
+    void reset()
+    {
+        cpuTimeElapsed_ = 0.0;
+        realTimeElapsed_ = 0.0;
+
+        measure_(startTime_);
+    }
+
+    /*!
+     * \brief Return the  real time [s] elapsed  during the periods the  timer was active
+     *        since the last reset.
      */
     double realTimeElapsed() const
     {
-        TimeData stopTime(stopTime_);
+        if (isStopped_)
+            return realTimeElapsed_;
 
-        if (!isStopped_)
-            measure_(stopTime);
+        TimeData stopTime;
+
+        measure_(stopTime);
 
         const auto& t1 = startTime_.realtimeData;
         const auto& t2 = stopTime.realtimeData;
-
         std::chrono::duration<double> dt =
             std::chrono::duration_cast<std::chrono::duration<double> >(t2 - t1);
-        return dt.count();
+
+        return realTimeElapsed_ + dt.count();
     }
 
     /*!
-     * \brief Return the CPU time [s] used by all threads of the local process
+     * \brief This is an alias for realTimeElapsed()
      *
-     * If stop() was not yet called, this returns the time elapsed
-     * since the last call to start().
+     * Its main purpose is to make the API of the class a superset of Dune::Timer
+     */
+    double elapsed() const
+    { return realTimeElapsed(); }
+
+    /*!
+     * \brief Return the CPU time [s] used by all threads of the local process for the
+     *        periods the timer was active
      */
     double cpuTimeElapsed() const
     {
-        TimeData stopTime(stopTime_);
+        if (isStopped_)
+            return cpuTimeElapsed_;
 
-        if (!isStopped_)
-            measure_(stopTime);
+        TimeData stopTime;
+
+        measure_(stopTime);
 
         const auto& t1 = startTime_.cputimeData;
         const auto& t2 = stopTime.cputimeData;
 
-        return static_cast<double>(t2 - t1)/CLOCKS_PER_SEC;
+        return cpuTimeElapsed_ + static_cast<double>(t2 - t1)/CLOCKS_PER_SEC;
     }
 
     /*!
-     * \brief Return the CPU time [s] used by all threads of the all processes of the simulation
+     * \brief Return the CPU time [s] used by all threads of the all processes of program
      *
-     * If stop() was not yet called, this returns the time elapsed
-     * since the last call to start(). Note that this method must be
-     * called synchronously by all processes of the simulation...
+     * The value returned only differs from cpuTimeElapsed() if MPI is used.
      */
     double globalCpuTimeElapsed() const
     {
-        TimeData stopTime(stopTime_);
-
-        if (!isStopped_)
-            measure_(stopTime);
-
         double val = cpuTimeElapsed();
         double globalVal = val;
 
 #if HAVE_MPI
         MPI_Reduce(&val,
-            &globalVal,
-            /*count=*/1,
-            MPI_DOUBLE,
-            MPI_SUM,
-            /*rootRank=*/0,
-            MPI_COMM_WORLD);
+                   &globalVal,
+                   /*count=*/1,
+                   MPI_DOUBLE,
+                   MPI_SUM,
+                   /*rootRank=*/0,
+                   MPI_COMM_WORLD);
 #endif
+
         return globalVal;
     }
 
@@ -168,8 +199,9 @@ private:
     }
 
     bool isStopped_;
+    double cpuTimeElapsed_;
+    double realTimeElapsed_;
     TimeData startTime_;
-    TimeData stopTime_;
 };
 } // namespace Ewoms
 

--- a/ewoms/common/timerguard.hh
+++ b/ewoms/common/timerguard.hh
@@ -1,0 +1,58 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Ewoms::TimerGuard
+ */
+#ifndef EWOMS_TIMER_GUARD_HH
+#define EWOMS_TIMER_GUARD_HH
+
+#include "timer.hh"
+
+namespace Ewoms {
+/*!
+ * \ingroup Common
+ *
+ * \brief A simple class which makes sure that a timer gets stopped if an exception is
+ *        thrown.
+ */
+class TimerGuard
+{
+public:
+    TimerGuard(Timer& timer)
+        : timer_(timer)
+    { }
+
+    ~TimerGuard()
+    {
+        timer_.stop();
+    }
+
+private:
+    Timer& timer_;
+};
+
+} // namespace Ewoms
+
+#endif


### PR DESCRIPTION
because it seems to be the spirit of the season, here are some timer related improvements: With this, `Ewoms::Timer` uses basically the same semantics as `Dune::Timer`. In contrast to `Dune::Timer`, `Ewoms::Timer` objects can be summed up, measure CPU time and support determining the total CPU time of the whole MPI parallel simulation.

another neat (IMO) addition of this PR is `Ewoms::TimerGuard` which ensures that a timer is stopped once the `TimerGuard` object goes out of scope. This is particularly useful if a function is terminated by an exception thrown by a called function.