### PR TITLE
Refactor the linear solver backends and the convergence criteria

### DIFF
--- a/ewoms/common/genericguard.hh
+++ b/ewoms/common/genericguard.hh
@@ -1,0 +1,60 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \copydoc Ewoms::GenericGuard
+ */
+#ifndef EWOMS_GENERIC_GUARD_HH
+#define EWOMS_GENERIC_GUARD_HH
+
+namespace Ewoms {
+/*!
+ * \ingroup Common
+ *
+ * \brief A simple class which makes sure that a cleanup function is called once the
+ *        object is destroyed.
+ *
+ * This class is particularly useful in conjunction with lambdas for code that might
+ * throw exceptions.
+ */
+template <class Callback>
+class GenericGuard
+{
+public:
+    GenericGuard(Callback& callback)
+        : callback_(callback)
+    { }
+
+    ~GenericGuard()
+    {
+        callback_();
+    }
+
+private:
+    Callback& callback_;
+};
+
+} // namespace Ewoms
+
+#endif

--- a/ewoms/common/genericguard.hh
+++ b/ewoms/common/genericguard.hh
@@ -44,15 +44,33 @@ class GenericGuard
 public:
     GenericGuard(Callback& callback)
         : callback_(callback)
+        , isEnabled_(true)
     { }
 
     ~GenericGuard()
     {
-        callback_();
+        if (isEnabled_)
+            callback_();
     }
+
+    /*!
+     * \brief Specify whether the guard object is "on duty" or not.
+     *
+     * If the guard object is destroyed while it is "off-duty", the cleanup callback is
+     * not called. At construction, guards are on duty.
+     */
+    void setEnabled(bool value)
+    { isEnabled_ = value; }
+
+    /*!
+     * \brief Returns whether the guard object is "on duty" or not.
+     */
+    bool enabled() const
+    { return isEnabled_; }
 
 private:
     Callback& callback_;
+    bool isEnabled_;
 };
 
 } // namespace Ewoms

--- a/ewoms/linear/bicgstabsolver.hh
+++ b/ewoms/linear/bicgstabsolver.hh
@@ -236,6 +236,9 @@ public:
                 OPM_THROW(Opm::NumericalProblem,
                           "Breakdown of the BiCGStab solver (division by zero)");
             alpha = rho_i/denom;
+            if (std::abs(alpha) <= breakdownEps)
+                OPM_THROW(Opm::NumericalProblem,
+                          "Breakdown of the BiCGStab solver (stagnation detected)");
 
             // h = x_(i-1) + alpha*y
             // s = r_(i-1) - alpha*v_i
@@ -291,6 +294,9 @@ public:
                 OPM_THROW(Opm::NumericalProblem,
                           "Breakdown of the BiCGStab solver (division by zero)");
             omega = scalarProduct_.dot(t, s)/denom;
+            if (std::abs(omega) <= breakdownEps)
+                OPM_THROW(Opm::NumericalProblem,
+                          "Breakdown of the BiCGStab solver (stagnation detected)");
 
             // x_i = h + omega_i*z
             // x = h; // not necessary because x and h are the same object

--- a/ewoms/linear/combinedcriterion.hh
+++ b/ewoms/linear/combinedcriterion.hh
@@ -1,0 +1,240 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Ewoms::WeightedResidualReductionCriterion
+ */
+#ifndef EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
+#define EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
+
+#include "convergencecriterion.hh"
+
+#include <iostream>
+
+namespace Ewoms {
+namespace Linear {
+
+/*! \addtogroup Linear
+ * \{
+ */
+
+/*!
+ * \brief Convergence criterion which looks at the absolute value of the residual and
+ *        fails if the linear solver stagnates.
+ *
+ * For the CombinedCriterion, the error of the solution is defined as \f[ e^k = \max_i\{
+ * \left| r^k_i \right| \}\;, \f]
+ *
+ * where \f$r^k = \mathbf{A} x^k - b \f$ is the residual for the k-th iterative solution
+ * vector \f$x^k\f$.
+ *
+ * In addition, to the reduction of the maximum residual, the linear solver is aborted
+ * early if the residual goes below or above absolute limits.
+ */
+template <class Vector, class CollectiveCommunication>
+class CombinedCriterion : public ConvergenceCriterion<Vector>
+{
+    typedef typename Vector::field_type Scalar;
+    typedef typename Vector::block_type BlockType;
+
+public:
+    CombinedCriterion(const CollectiveCommunication& comm)
+        : comm_(comm)
+    {}
+
+    CombinedCriterion(const CollectiveCommunication& comm,
+                                       Scalar residualReductionTolerance,
+                                       Scalar absResidualTolerance = 0.0,
+                                       Scalar maxResidual = 0.0)
+        : comm_(comm),
+          residualReductionTolerance_(residualReductionTolerance),
+          absResidualTolerance_(absResidualTolerance),
+          maxResidual_(maxResidual)
+    { }
+
+    /*!
+     * \brief Sets the residual reduction tolerance.
+     */
+    void setResidualReductionTolerance(Scalar tol)
+    { residualReductionTolerance_ = tol; }
+
+    /*!
+     * \brief Returns the tolerance of the residual reduction of the solution.
+     */
+    Scalar residualReductionTolerance() const
+    { return residualReductionTolerance_; }
+
+    /*!
+     * \brief Returns the reduction of the maximum of the residual compared to the
+     *        initial solution.
+     */
+    Scalar residualReduction() const
+    { return residualError_/std::max<Scalar>(1e-20, initialResidualError_); }
+
+    /*!
+     * \brief Sets the maximum absolute tolerated residual.
+     */
+    void setAbsResidualTolerance(Scalar tol)
+    { absResidualTolerance_ = tol; }
+
+    /*!
+     * \brief Returns the tolerated maximum of the the infinity norm of the absolute
+     *        residual.
+     */
+    Scalar absResidualTolerance() const
+    { return absResidualTolerance_; }
+
+    /*!
+     * \brief Returns the infinity norm of the absolute residual.
+     */
+    Scalar absResidual() const
+    { return residualError_; }
+
+    /*!
+     * \copydoc ConvergenceCriterion::setInitial(const Vector& , const Vector& )
+     */
+    void setInitial(const Vector& curSol, const Vector& curResid) override
+    {
+        updateErrors_(curSol, curSol, curResid);
+        hasFailed_ = false;
+
+        // to avoid divisions by zero, make sure that we don't use an initial error of 0
+        residualError_ = std::max<Scalar>(residualError_,
+                                          std::numeric_limits<Scalar>::min()*1e10);
+        initialResidualError_ = residualError_;
+        lastResidualError_ = residualError_;
+    }
+
+    /*!
+     * \copydoc ConvergenceCriterion::update(const Vector&, const Vector&, const Vector&)
+     */
+    void update(const Vector& curSol, const Vector& changeIndicator, const Vector& curResid) override
+    { updateErrors_(curSol, changeIndicator, curResid);  }
+
+    /*!
+     * \copydoc ConvergenceCriterion::converged()
+     */
+    bool converged() const override
+    {
+        // we're converged if the solution is better than the tolerance
+        // fix-point and residual tolerance.
+        return
+            residualReduction() <= residualReductionTolerance() ||
+            absResidual() <= absResidualTolerance();
+    }
+
+    /*!
+     * \copydoc ConvergenceCriterion::failed()
+     */
+    bool failed() const override
+    { return !converged() && (hasFailed_ || residualError_ > maxResidual_); }
+
+    /*!
+     * \copydoc ConvergenceCriterion::accuracy()
+     *
+     * For the accuracy we only take the residual into account,
+     */
+    Scalar accuracy() const override
+    { return residualError_/initialResidualError_; }
+
+    /*!
+     * \copydoc ConvergenceCriterion::printInitial()
+     */
+    void printInitial(std::ostream& os = std::cout) const override
+    {
+        os << std::setw(20) << "iteration ";
+        os << std::setw(20) << "residual ";
+        os << std::setw(20) << "reduction ";
+        os << std::setw(20) << "rate ";
+        os << std::endl;
+    }
+
+    /*!
+     * \copydoc ConvergenceCriterion::print()
+     */
+    void print(Scalar iter, std::ostream& os = std::cout) const override
+    {
+        static constexpr Scalar eps = std::numeric_limits<Scalar>::min()*1e10;
+
+        os << std::setw(20) << iter << " ";
+        os << std::setw(20) << absResidual() << " ";
+        os << std::setw(20) << accuracy() << " ";
+        os << std::setw(20) << lastResidualError_/std::max<Scalar>(residualError_, eps) << " ";
+        os << std::endl << std::flush;
+    }
+
+private:
+    // update the weighted absolute residual
+    void updateErrors_(const Vector& curSol, const Vector& changeIndicator,  const Vector& curResid)
+    {
+        lastResidualError_ = residualError_;
+        residualError_ = 0.0;
+        hasFailed_ = true;
+        for (size_t i = 0; i < curResid.size(); ++i) {
+            for (unsigned j = 0; j < BlockType::dimension; ++j) {
+                residualError_ =
+                    std::max<Scalar>(residualError_,
+                                     std::abs(curResid[i][j]));
+
+                if (hasFailed_ && changeIndicator[i][j] != 0.0)
+                    // only stagnation means that we've failed!
+                    hasFailed_ = false;
+            }
+        }
+
+        residualError_ = comm_.max(residualError_);
+        hasFailed_ = comm_.max(hasFailed_);
+    }
+
+    const CollectiveCommunication& comm_;
+
+    // the infinity norm of the residual of the last iteration
+    Scalar lastResidualError_;
+
+    // the infinity norm of the residual of the current iteration
+    Scalar residualError_;
+
+    // the infinity norm of the residual of the initial solution
+    Scalar initialResidualError_;
+
+    // the minimum reduction of the residual norm where the solution is to be considered
+    // converged
+    Scalar residualReductionTolerance_;
+
+    // the maximum residual norm for the residual for the solution to be considered to be
+    // converged
+    Scalar absResidualTolerance_;
+
+    // The maximum error which is tolerated before we fail.
+    Scalar maxResidual_;
+
+    // Should the attempt to solve the linear system of equations considered to be
+    // failed?
+    bool hasFailed_;
+};
+
+//! \} end documentation
+
+}} // end namespace Linear,Ewoms
+
+#endif

--- a/ewoms/linear/convergencecriterion.hh
+++ b/ewoms/linear/convergencecriterion.hh
@@ -101,10 +101,12 @@ public:
      *
      * \param curSol The current iterative solution of the linear system
      *               of equations
+     * \param changeIndicator A vector where all non-zero values indicate that the
+     *                        solution has changed since the last iteration.
      * \param curResid The residual vector of the current iterative
      *                 solution of the linear system of equations
      */
-    virtual void update(const Vector& curSol, const Vector& curResid) = 0;
+    virtual void update(const Vector& curSol, const Vector& changeIndicator, const Vector& curResid) = 0;
 
     /*!
      * \brief Returns true if and only if the convergence criterion is

--- a/ewoms/linear/fixpointcriterion.hh
+++ b/ewoms/linear/fixpointcriterion.hh
@@ -111,18 +111,22 @@ public:
      * \brief Set the maximum allowed weighted maximum difference between two
      * iterations
      */
+    /*!
+     * \brief Set the maximum allowed maximum difference between two
+     *        iterationsfor the solution considered to be converged.
+     */
     void setTolerance(Scalar tol)
     { tolerance_ = tol; }
 
     /*!
-     * \brief Return the maximum allowed weighted maximum difference between two
-     * iterations
+     * \brief Return the maximum allowed weighted difference between two
+     *        iterations for the solution considered to be converged.
      */
     Scalar tolerance() const
     { return tolerance_; }
 
     /*!
-     * \copydoc ConvergenceCriterion::setInitial(const Vector& , const Vector& )
+     * \copydoc ConvergenceCriterion::setInitial(const Vector&, const Vector&)
      */
     void setInitial(const Vector& curSol, const Vector& OPM_UNUSED curResid)
     {
@@ -131,18 +135,19 @@ public:
     }
 
     /*!
-     * \copydoc ConvergenceCriterion::update(const Vector& , const Vector& )
+     * \copydoc ConvergenceCriterion::update(const Vector&, const Vector&, const Vector&)
      */
-    void update(const Vector& curSol, const Vector& OPM_UNUSED curResid)
+    void update(const Vector& curSol,
+                const Vector& OPM_UNUSED changeIndicator,
+                const Vector& OPM_UNUSED curResid)
     {
         assert(curSol.size() == lastSol_.size());
 
         delta_ = 0.0;
         for (size_t i = 0; i < curSol.size(); ++i) {
             for (size_t j = 0; j < BlockType::dimension; ++j) {
-                delta_ = std::max<Scalar>(delta_, weight(i, j)
-                                                  * std::abs(curSol[i][j]
-                                                             - lastSol_[i][j]));
+                delta_ =
+                    std::max(delta_, weight(i, j)*std::abs(curSol[i][j] - lastSol_[i][j]));
             }
         }
 
@@ -154,7 +159,7 @@ public:
      * \copydoc ConvergenceCriterion::converged()
      */
     bool converged() const
-    { return delta_ < tolerance(); }
+    { return accuracy() < tolerance(); }
 
     /*!
      * \copydoc ConvergenceCriterion::accuracy()

--- a/ewoms/linear/istlpreconditionerwrappers.hh
+++ b/ewoms/linear/istlpreconditionerwrappers.hh
@@ -1,0 +1,155 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \brief Provides wrapper classes for the (non-AMG) preconditioners provided by
+ *        dune-istl.
+ *
+ * In conjunction with a suitable solver backend, preconditioner wrappers work by
+ * specifying the "PreconditionerWrapper" property:
+ * \code
+ * SET_TYPE_PROP(YourTypeTag, PreconditionerWrapper,
+ *               Ewoms::Linear::PreconditionerWrapper$PRECONDITIONER<TypeTag>);
+ * \endcode
+ *
+ * Where the choices possible for '\c $PRECONDITIONER' are:
+ * - \c Jacobi: A Jacobi preconditioner
+ * - \c GaussSeidel: A Gauss-Seidel preconditioner
+ * - \c SSOR: A symmetric successive overrelaxation (SSOR) preconditioner
+ * - \c SOR: A successive overrelaxation (SOR) preconditioner
+ * - \c ILUn: An ILU(n) preconditioner
+ * - \c ILU0: A specialized (and optimized) ILU(0) preconditioner
+ */
+#ifndef EWOMS_ISTL_PRECONDITIONER_WRAPPERS_HH
+#define EWOMS_ISTL_PRECONDITIONER_WRAPPERS_HH
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+
+#include <dune/istl/preconditioners.hh>
+
+namespace Ewoms {
+namespace Properties {
+NEW_PROP_TAG(Scalar);
+NEW_PROP_TAG(JacobianMatrix);
+NEW_PROP_TAG(OverlappingMatrix);
+NEW_PROP_TAG(OverlappingVector);
+NEW_PROP_TAG(PreconditionerOrder);
+NEW_PROP_TAG(PreconditionerRelaxation);
+} // namespace Properties
+
+namespace Linear {
+#define EWOMS_WRAP_ISTL_PRECONDITIONER(PREC_NAME, ISTL_PREC_TYPE)               \
+    template <class TypeTag>                                                    \
+    class PreconditionerWrapper##PREC_NAME                                      \
+    {                                                                           \
+        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                 \
+        typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) JacobianMatrix; \
+        typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector; \
+                                                                                \
+    public:                                                                     \
+        typedef ISTL_PREC_TYPE<JacobianMatrix, OverlappingVector,               \
+                               OverlappingVector> SequentialPreconditioner;     \
+        PreconditionerWrapper##PREC_NAME()                                      \
+        {}                                                                      \
+                                                                                \
+        static void registerParameters()                                        \
+        {                                                                       \
+            EWOMS_REGISTER_PARAM(TypeTag, int, PreconditionerOrder,             \
+                                 "The order of the preconditioner");            \
+            EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,     \
+                                 "The relaxation factor of the "                \
+                                 "preconditioner");                             \
+        }                                                                       \
+                                                                                \
+        void prepare(JacobianMatrix& matrix)                                    \
+        {                                                                       \
+            int order = EWOMS_GET_PARAM(TypeTag, int, PreconditionerOrder);     \
+            Scalar relaxationFactor = EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);   \
+            seqPreCond_ = new SequentialPreconditioner(matrix, order,           \
+                                                       relaxationFactor);       \
+        }                                                                       \
+                                                                                \
+        SequentialPreconditioner& get()                                         \
+        { return *seqPreCond_; }                                                \
+                                                                                \
+        void cleanup()                                                          \
+        { delete seqPreCond_; }                                                 \
+                                                                                \
+    private:                                                                    \
+        SequentialPreconditioner *seqPreCond_;                                  \
+    };
+
+// the same as the EWOMS_WRAP_ISTL_PRECONDITIONER macro, but without
+// an 'order' argument for the preconditioner's constructor
+#define EWOMS_WRAP_ISTL_SIMPLE_PRECONDITIONER(PREC_NAME, ISTL_PREC_TYPE)        \
+    template <class TypeTag>                                                    \
+    class PreconditionerWrapper##PREC_NAME                                      \
+    {                                                                           \
+        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                 \
+        typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix; \
+        typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector; \
+                                                                                \
+    public:                                                                     \
+        typedef ISTL_PREC_TYPE<OverlappingMatrix, OverlappingVector,            \
+                               OverlappingVector> SequentialPreconditioner;     \
+        PreconditionerWrapper##PREC_NAME()                                      \
+        {}                                                                      \
+                                                                                \
+        static void registerParameters()                                        \
+        {                                                                       \
+            EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,     \
+                                 "The relaxation factor of the "                \
+                                 "preconditioner");                             \
+        }                                                                       \
+                                                                                \
+        void prepare(OverlappingMatrix& matrix)                                 \
+        {                                                                       \
+            Scalar relaxationFactor =                                           \
+                EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);     \
+            seqPreCond_ = new SequentialPreconditioner(matrix,                  \
+                                                       relaxationFactor);       \
+        }                                                                       \
+                                                                                \
+        SequentialPreconditioner& get()                                         \
+        { return *seqPreCond_; }                                                \
+                                                                                \
+        void cleanup()                                                          \
+        { delete seqPreCond_; }                                                 \
+                                                                                \
+    private:                                                                    \
+        SequentialPreconditioner *seqPreCond_;                                  \
+    };
+
+EWOMS_WRAP_ISTL_PRECONDITIONER(Jacobi, Dune::SeqJac)
+// EWOMS_WRAP_ISTL_PRECONDITIONER(Richardson, Dune::Richardson)
+EWOMS_WRAP_ISTL_PRECONDITIONER(GaussSeidel, Dune::SeqGS)
+EWOMS_WRAP_ISTL_PRECONDITIONER(SOR, Dune::SeqSOR)
+EWOMS_WRAP_ISTL_PRECONDITIONER(SSOR, Dune::SeqSSOR)
+EWOMS_WRAP_ISTL_SIMPLE_PRECONDITIONER(ILU0, Dune::SeqILU0)
+EWOMS_WRAP_ISTL_PRECONDITIONER(ILUn, Dune::SeqILUn)
+
+#undef EWOMS_WRAP_ISTL_PRECONDITIONER
+}} // namespace Linear, Ewoms
+
+#endif

--- a/ewoms/linear/istlsolverwrappers.hh
+++ b/ewoms/linear/istlsolverwrappers.hh
@@ -1,0 +1,174 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \brief Provides wrapper classes for the iterative linear solvers available in
+ *        dune-istl.
+ *
+ * In conjunction with a suitable solver backend, solver wrappers work by specifying the
+ * "SolverWrapper" property:
+ * \code
+ * SET_TYPE_PROP(YourTypeTag, LinearSolverWrapper,
+ *               Ewoms::Linear::SolverWrapper$SOLVER<TypeTag>);
+ * \endcode
+ *
+ * The possible choices for '\c $SOLVER' are:
+ * - \c Richardson: A fixpoint solver using the Richardson iteration
+ * - \c SteepestDescent: The steepest descent solver
+ * - \c ConjugatedGradients: A conjugated gradients solver
+ * - \c BiCGStab: A stabilized bi-conjugated gradients solver
+ * - \c MinRes: A solver based on the  minimized residual algorithm
+ * - \c RestartedGMRes: A restarted GMRES solver
+ */
+#ifndef EWOMS_ISTL_SOLVER_WRAPPERS_HH
+#define EWOMS_ISTL_SOLVER_WRAPPERS_HH
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+
+#include <dune/istl/solvers.hh>
+
+namespace Ewoms {
+namespace Properties {
+NEW_PROP_TAG(Scalar);
+NEW_PROP_TAG(JacobianMatrix);
+NEW_PROP_TAG(OverlappingMatrix);
+NEW_PROP_TAG(OverlappingVector);
+NEW_PROP_TAG(GMResRestart);
+} // namespace Properties
+
+namespace Linear {
+
+/*!
+ * \brief Macro to create a wrapper around an ISTL solver
+ */
+#define EWOMS_WRAP_ISTL_SOLVER(SOLVER_NAME, ISTL_SOLVER_NAME)                      \
+    template <class TypeTag>                                                       \
+    class SolverWrapper##SOLVER_NAME                                               \
+    {                                                                              \
+        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                    \
+        typedef typename GET_PROP_TYPE(TypeTag,                                    \
+                                       OverlappingMatrix) OverlappingMatrix;       \
+        typedef typename GET_PROP_TYPE(TypeTag,                                    \
+                                       OverlappingVector) OverlappingVector;       \
+                                                                                   \
+    public:                                                                        \
+        typedef ISTL_SOLVER_NAME<OverlappingVector> RawSolver;                     \
+                                                                                   \
+        SolverWrapper##SOLVER_NAME()                                               \
+        {}                                                                         \
+                                                                                   \
+        static void registerParameters()                                           \
+        {}                                                                         \
+                                                                                   \
+        template <class LinearOperator, class ScalarProduct, class Preconditioner> \
+        std::shared_ptr<RawSolver> get(LinearOperator& parOperator,                \
+                                       ScalarProduct& parScalarProduct,            \
+                                       Preconditioner& parPreCond)                 \
+        {                                                                          \
+            Scalar tolerance = EWOMS_GET_PARAM(TypeTag, Scalar,                    \
+                                               LinearSolverTolerance);             \
+            int maxIter = EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations);\
+                                                                                   \
+            int verbosity = 0;                                                     \
+            if (parOperator.overlap().myRank() == 0)                               \
+                verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);  \
+            solver_ = std::make_shared<RawSolver>(parOperator, parScalarProduct,   \
+                                                  parPreCond, tolerance, maxIter,  \
+                                                  verbosity);                      \
+                                                                                   \
+            return solver_;                                                        \
+        }                                                                          \
+                                                                                   \
+        void cleanup()                                                             \
+        { delete solver_; }                                                        \
+                                                                                   \
+    private:                                                                       \
+        std::shared_ptr<RawSolver> solver_;                                        \
+    };
+
+EWOMS_WRAP_ISTL_SOLVER(Richardson, Dune::LoopSolver)
+EWOMS_WRAP_ISTL_SOLVER(SteepestDescent, Dune::GradientSolver)
+EWOMS_WRAP_ISTL_SOLVER(ConjugatedGradients, Dune::CGSolver)
+EWOMS_WRAP_ISTL_SOLVER(BiCGStab, Dune::BiCGSTABSolver)
+EWOMS_WRAP_ISTL_SOLVER(MinRes, Dune::MINRESSolver)
+
+/*!
+ * \brief Solver wrapper for the restarted GMRES solver of dune-istl.
+ *
+ * dune-istl uses a slightly different API for this solver than for the others...
+ */
+template <class TypeTag>
+class SolverWrapperRestartedGMRes
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
+
+public:
+    typedef Dune::RestartedGMResSolver<OverlappingVector> RawSolver;
+
+    SolverWrapperRestartedGMRes()
+    {}
+
+    static void registerParameters()
+    {
+        EWOMS_REGISTER_PARAM(TypeTag, int, GMResRestart,
+                             "Number of iterations after which the GMRES linear solver is restarted");
+    }
+
+    template <class LinearOperator, class ScalarProduct, class Preconditioner>
+    std::shared_ptr<RawSolver> get(LinearOperator& parOperator,
+                                   ScalarProduct& parScalarProduct,
+                                   Preconditioner& parPreCond)
+    {
+        Scalar tolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
+        int maxIter = EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations);
+
+        int verbosity = 0;
+        if (parOperator.overlap().myRank() == 0)
+            verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
+        int restartAfter = EWOMS_GET_PARAM(TypeTag, int, GMResRestart);
+        solver_ = std::make_shared<RawSolver>(parOperator,
+                                              parScalarProduct,
+                                              parPreCond,
+                                              tolerance,
+                                              restartAfter,
+                                              maxIter,
+                                              verbosity);
+
+        return solver_;
+    }
+
+    void cleanup()
+    { delete solver_; }
+
+private:
+    std::shared_ptr<RawSolver> solver_;
+};
+
+#undef EWOMS_WRAP_ISTL_SOLVER
+
+}} // namespace Linear, Ewoms
+
+#endif

--- a/ewoms/linear/istlsolverwrappers.hh
+++ b/ewoms/linear/istlsolverwrappers.hh
@@ -161,7 +161,7 @@ public:
     }
 
     void cleanup()
-    { delete solver_; }
+    { solver_.reset(); }
 
 private:
     std::shared_ptr<RawSolver> solver_;

--- a/ewoms/linear/overlappingbcrsmatrix.hh
+++ b/ewoms/linear/overlappingbcrsmatrix.hh
@@ -635,7 +635,7 @@ private:
         MpiBuffer<block_type> &mpiRecvBuff = *entryValuesRecvBuff_[peerRank];
 
         MpiBuffer<Index> &mpiRowIndicesRecvBuff = *rowIndicesRecvBuff_[peerRank];
-        MpiBuffer<Index> &mpiRowSizesRecvBuff = *rowSizesRecvBuff_[peerRank];
+        MpiBuffer<unsigned> &mpiRowSizesRecvBuff = *rowSizesRecvBuff_[peerRank];
         MpiBuffer<Index> &mpiColIndicesRecvBuff = *entryColIndicesRecvBuff_[peerRank];
 
         mpiRecvBuff.receive(peerRank);

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -27,27 +27,13 @@
 #ifndef EWOMS_PARALLEL_AMG_BACKEND_HH
 #define EWOMS_PARALLEL_AMG_BACKEND_HH
 
-#include <ewoms/linear/parallelbicgstabbackend.hh>
-#include <ewoms/linear/superlubackend.hh>
-#include <ewoms/linear/vertexborderlistfromgrid.hh>
-#include <ewoms/linear/overlappingbcrsmatrix.hh>
-#include <ewoms/linear/overlappingblockvector.hh>
-#include <ewoms/linear/overlappingpreconditioner.hh>
-#include <ewoms/linear/overlappingscalarproduct.hh>
-#include <ewoms/linear/overlappingoperator.hh>
-#include <ewoms/common/propertysystem.hh>
-#include <ewoms/common/parametersystem.hh>
+#include "parallelbasebackend.hh"
+#include "bicgstabsolver.hh"
+#include "combinedcriterion.hh"
 
-#include <dune/istl/preconditioners.hh>
-#include <dune/istl/solvers.hh>
 #include <dune/istl/paamg/amg.hh>
 #include <dune/istl/paamg/pinfo.hh>
-#include <dune/istl/schwarz.hh>
 #include <dune/istl/owneroverlapcopy.hh>
-
-#include <dune/common/parallel/indexset.hh>
-#include <dune/common/version.hh>
-#include <dune/common/parallel/mpicollectivecommunication.hh>
 
 #include <iostream>
 
@@ -58,19 +44,19 @@ class ParallelAmgBackend;
 }
 
 namespace Properties {
-NEW_TYPE_TAG(ParallelAmgLinearSolver, INHERITS_FROM(ParallelBiCGStabLinearSolver));
+NEW_TYPE_TAG(ParallelAmgLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
 NEW_PROP_TAG(AmgCoarsenTarget);
+NEW_PROP_TAG(LinearSolverMaxError);
 
 //! The target number of DOFs per processor for the parallel algebraic
 //! multi-grid solver
 SET_INT_PROP(ParallelAmgLinearSolver, AmgCoarsenTarget, 5000);
 
+SET_SCALAR_PROP(ParallelAmgLinearSolver, LinearSolverMaxError, 1e7);
+
 SET_TYPE_PROP(ParallelAmgLinearSolver, LinearSolverBackend,
               Ewoms::Linear::ParallelAmgBackend<TypeTag>);
-
-SET_TYPE_PROP(ParallelAmgLinearSolver, LinearSolverScalar,
-              typename GET_PROP_TYPE(TypeTag, Scalar));
 } // namespace Properties
 
 namespace Linear {
@@ -81,18 +67,20 @@ namespace Linear {
  *        algebraic multi-grid (AMG) linear solver from DUNE-ISTL.
  */
 template <class TypeTag>
-class ParallelAmgBackend
+class ParallelAmgBackend : public ParallelBaseBackend<TypeTag>
 {
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverBackend) Implementation;
+    typedef ParallelBaseBackend<TypeTag> ParentType;
 
-    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef typename GET_PROP_TYPE(TypeTag, BorderListCreator) BorderListCreator;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
+
+    typedef typename ParentType::ParallelOperator ParallelOperator;
+    typedef typename ParentType::OverlappingVector OverlappingVector;
+    typedef typename ParentType::ParallelPreconditioner ParallelPreconditioner;
+    typedef typename ParentType::ParallelScalarProduct ParallelScalarProduct;
 
     static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
     typedef Dune::FieldVector<LinearSolverScalar, numEq> VectorBlock;
@@ -133,208 +121,82 @@ class ParallelAmgBackend
     typedef Dune::Amg::AMG<FineOperator, Vector, ParallelSmoother> AMG;
 #endif
 
+    typedef BiCGStabSolver<ParallelOperator,
+                           OverlappingVector,
+                           AMG> RawLinearSolver;
+
 public:
     ParallelAmgBackend(const Simulator& simulator)
-        : simulator_(simulator)
+        : ParentType(simulator)
     { }
-
-    ~ParallelAmgBackend()
-    { cleanup_(); }
 
     static void registerParameters()
     {
-        ParallelBiCGStabSolverBackend<TypeTag>::registerParameters();
+        ParentType::registerParameters();
 
+        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverMaxError,
+                             "The maximum residual error which the linear solver tolerates"
+                             " without giving up");
         EWOMS_REGISTER_PARAM(TypeTag, int, AmgCoarsenTarget,
                              "The coarsening target for the agglomerations of "
                              "the AMG preconditioner");
     }
 
-    /*!
-     * \brief Causes the solve() method to discared the structure of the linear system of
-     *        equations the next time it is called.
-     */
-    void eraseMatrix()
-    { cleanup_(); }
+protected:
+    friend ParentType;
 
-    template <class NativeBCRSMatrix>
-    void prepareMatrix(const NativeBCRSMatrix& M)
+    bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
+    { return solver->apply(*this->overlappingx_); }
+
+    std::shared_ptr<AMG> preparePreconditioner_()
     {
-        if (!overlappingMatrix_) {
-            // make sure that the overlapping matrix and block vectors
-            // have been created
-            prepare_(M);
-        }
-
-        // copy the values of the non-overlapping linear system of
-        // equations to the overlapping one. On ther border, we add up
-        // the values of all processes (using the assignAdd() methods)
-        overlappingMatrix_->assignAdd(M);
-    }
-
-    template <class NativeBCRSMatrix, class NativeVector>
-    void prepareRhs(const NativeBCRSMatrix& M, NativeVector& b)
-    {
-        if (!overlappingMatrix_) {
-            // make sure that the overlapping matrix and block vectors
-            // have been created
-            prepare_(M);
-        }
-
-        overlappingb_->assignAddBorder(b);
-
-        // copy the result back to the non-overlapping vector. This is
-        // necessary here as assignAddBorder() might modify the
-        // residual vector for the border entities and we need the
-        // "globalized" residual in b...
-        overlappingb_->assignTo(b);
-    }
-
-    /*!
-     * \brief Actually solve the linear system of equations.
-     *
-     * \return true if the residual reduction could be achieved, else false.
-     */
-    template <class NativeVector>
-    bool solve(NativeVector& x)
-    {
-        int verbosity = 0;
-        if (simulator_.gridManager().gridView().comm().rank() == 0)
-            verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
-
-        (*overlappingx_) = 0.0;
-
-        /////////////
-        // set-up the AMG preconditioner
-        /////////////
-        // create the parallel scalar product and the parallel operator
-#if HAVE_MPI
-        auto fineOperator = std::make_shared<FineOperator>(*overlappingMatrix_, *istlComm_);
-#else
-        auto fineOperator = std::make_shared<FineOperator>(*overlappingMatrix_);
-#endif
-
-#if HAVE_MPI
-        auto scalarProduct = std::make_shared<FineScalarProduct>(*istlComm_);
-#else
-        auto scalarProduct = std::make_shared<FineScalarProduct>();
-#endif
-
-        setupAmg_(*fineOperator);
-
-        /////////////
-        // set-up the linear solver
-        /////////////
-        if (verbosity > 1 && simulator_.gridManager().gridView().comm().rank() == 0)
-            std::cout << "Creating the solver\n" << std::flush;
-
-        /////
-        // create a residual reduction convergence criterion
-
-        // set the weighting of the residuals
-        Vector residWeightVec(*overlappingx_);
-        residWeightVec = 0.0;
-        const auto& overlap = overlappingMatrix_->overlap();
-        for (Index localIdx = 0; localIdx < static_cast<Index>(overlap.numLocal()); ++localIdx) {
-            Index nativeIdx = overlap.domesticToNative(localIdx);
-            for (unsigned eqIdx = 0; eqIdx < Vector::block_type::dimension; ++eqIdx) {
-                residWeightVec[static_cast<unsigned>(localIdx)][eqIdx] =
-                    this->simulator_.model().eqWeight(static_cast<unsigned>(nativeIdx), eqIdx);
-            }
-        }
-
-        Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 10.0;
-        typedef typename GridView::CollectiveCommunication Comm;
-        auto convCrit =
-            std::make_shared<Ewoms::Linear::WeightedResidualReductionCriterion<Vector, Comm> >(
-                simulator_.gridView().comm(),
-                residWeightVec,
-                /*residualReductionTolerance=*/linearSolverTolerance,
-                /*fixPointTolerance=*/0.0,
-                /*absoluteResidualTolerance=*/linearSolverAbsTolerance,
-                /*maxError=*/EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverMaxError));
-
-        // done creating the convergence criterion
-        /////
-
-        /////
-        // create the actual linear solver
-        Ewoms::Linear::BiCGStabSolver<FineOperator, Vector, AMG>
-            bicgstabSolver(amg_, convCrit, scalarProduct);
-        /////
-
-        //////
-        // actually run the linear solver
-        try {
-            int verbosity = 0;
-            if (overlappingMatrix_->overlap().myRank() == 0)
-                verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
-            bicgstabSolver.setVerbosity(verbosity);
-            bicgstabSolver.setMaxIterations(EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations));
-            bicgstabSolver.setLinearOperator(fineOperator.get());
-            bicgstabSolver.setRhs(overlappingb_.get());
-            bicgstabSolver.apply(*overlappingx_);
-        }
-        catch (...) {
-            return false;
-        }
-
-        const SolverReport report = bicgstabSolver.report();
-        if (!report.converged())
-            return false;
-
-        // copy the result back to the non-overlapping vector
-        overlappingx_->assignTo(x);
-
-        return report.converged();
-    }
-
-private:
-    Implementation& asImp_()
-    { return *static_cast<Implementation *>(this); }
-
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation *>(this); }
-
-    template <class NativeBCRSMatrix>
-    void prepare_(const NativeBCRSMatrix& M)
-    {
-        BorderListCreator borderListCreator(simulator_.gridView(),
-                                            simulator_.model().dofMapper());
-
-        auto& blackList = borderListCreator.blackList();
-
-        // create the overlapping Jacobian matrix
-        unsigned overlapSize = EWOMS_GET_PARAM(TypeTag, unsigned, LinearSolverOverlapSize);
-        overlappingMatrix_ = std::make_shared<OverlappingMatrix>(M,
-                                                                 borderListCreator.borderList(),
-                                                                 blackList,
-                                                                 overlapSize);
-
-        // create the overlapping vectors for the residual and the
-        // solution
-        overlappingb_ = std::make_shared<OverlappingVector>(overlappingMatrix_->overlap());
-        overlappingx_ = std::make_shared<OverlappingVector>(*overlappingb_);
-
-        // writeOverlapToVTK_();
-
 #if HAVE_MPI
         // create and initialize DUNE's OwnerOverlapCopyCommunication
         // using the domestic overlap
         istlComm_ = std::make_shared<OwnerOverlapCopyCommunication>(MPI_COMM_WORLD);
-        setupAmgIndexSet_(overlappingMatrix_->overlap(), istlComm_->indexSet());
+        setupAmgIndexSet_(this->overlappingMatrix_->overlap(), istlComm_->indexSet());
         istlComm_->remoteIndices().template rebuild<false>();
 #endif
+
+        // create the parallel scalar product and the parallel operator
+#if HAVE_MPI
+        fineOperator_ = std::make_shared<FineOperator>(*this->overlappingMatrix_, *istlComm_);
+#else
+        fineOperator_ = std::make_shared<FineOperator>(*this->overlappingMatrix_);
+#endif
+
+        setupAmg_();
+
+        return amg_;
     }
 
-    void cleanup_()
+    std::shared_ptr<RawLinearSolver> prepareSolver_(ParallelOperator& parOperator,
+                                                    ParallelScalarProduct& parScalarProduct,
+                                                    AMG& parPreCond)
     {
-        amg_.reset();
-        istlComm_.reset();
-        overlappingMatrix_.reset();
-        overlappingb_.reset();
-        overlappingx_.reset();
+        const auto& gridView = this->simulator_.gridView();
+        typedef CombinedCriterion<OverlappingVector, decltype(gridView.comm())> CCC;
+
+        Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
+        Scalar linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance() / 10.0;
+
+        convCrit_.reset(new CCC(gridView.comm(),
+                                /*residualReductionTolerance=*/linearSolverTolerance,
+                                /*absoluteResidualTolerance=*/linearSolverAbsTolerance,
+                                EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverMaxError)));
+
+        auto bicgstabSolver =
+            std::make_shared<RawLinearSolver>(parPreCond, *convCrit_, parScalarProduct);
+
+        int verbosity = 0;
+        if (parOperator.overlap().myRank() == 0)
+            verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
+        bicgstabSolver->setVerbosity(verbosity);
+        bicgstabSolver->setMaxIterations(EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations));
+        bicgstabSolver->setLinearOperator(&parOperator);
+        bicgstabSolver->setRhs(this->overlappingb_);
+
+        return bicgstabSolver;
     }
 
 #if HAVE_MPI
@@ -366,21 +228,16 @@ private:
     }
 #endif
 
-    void setupAmg_(FineOperator& fineOperator)
+    void setupAmg_()
     {
         if (amg_)
             amg_.reset();
 
         int verbosity = 0;
-        if (simulator_.gridManager().gridView().comm().rank() == 0)
+        if (this->simulator_.gridManager().gridView().comm().rank() == 0)
             verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
 
-        auto rank = simulator_.gridManager().gridView().comm().rank();
-        if (verbosity > 1 && rank == 0)
-            std::cout << "Setting up the AMG preconditioner\n";
-
-        typedef typename Dune::Amg::SmootherTraits<ParallelSmoother>::Arguments
-        SmootherArgs;
+        typedef typename Dune::Amg::SmootherTraits<ParallelSmoother>::Arguments SmootherArgs;
 
         SmootherArgs smootherArgs;
         smootherArgs.iterations = 1;
@@ -411,22 +268,20 @@ private:
 
 // instantiate the AMG preconditioner
 #if HAVE_MPI
-        amg_ = std::make_shared<AMG>(fineOperator, coarsenCriterion, smootherArgs, *istlComm_);
+        amg_ = std::make_shared<AMG>(*fineOperator_, coarsenCriterion, smootherArgs, *istlComm_);
 #else
-        amg_ = std::make_shared<AMG>(fineOperator, coarsenCriterion, smootherArgs);
+        amg_ = std::make_shared<AMG>(*fineOperator_, coarsenCriterion, smootherArgs);
 #endif
     }
 
-    const Simulator& simulator_;
+    std::unique_ptr<ConvergenceCriterion<OverlappingVector> > convCrit_;
 
+    std::shared_ptr<FineOperator> fineOperator_;
     std::shared_ptr<AMG> amg_;
 
 #if HAVE_MPI
     std::shared_ptr<OwnerOverlapCopyCommunication> istlComm_;
 #endif
-    std::shared_ptr<OverlappingMatrix> overlappingMatrix_;
-    std::shared_ptr<OverlappingVector> overlappingb_;
-    std::shared_ptr<OverlappingVector> overlappingx_;
 };
 
 } // namespace Linear

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -145,9 +145,6 @@ public:
 protected:
     friend ParentType;
 
-    bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
-    { return solver->apply(*this->overlappingx_); }
-
     std::shared_ptr<AMG> preparePreconditioner_()
     {
 #if HAVE_MPI
@@ -169,6 +166,9 @@ protected:
 
         return amg_;
     }
+
+    void cleanupPreconditioner_()
+    { /* nothing to do */ }
 
     std::shared_ptr<RawLinearSolver> prepareSolver_(ParallelOperator& parOperator,
                                                     ParallelScalarProduct& parScalarProduct,
@@ -198,6 +198,12 @@ protected:
 
         return bicgstabSolver;
     }
+
+    bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
+    { return solver->apply(*this->overlappingx_); }
+
+    void cleanupSolver_()
+    { /* nothing to do */ }
 
 #if HAVE_MPI
     template <class ParallelIndexSet>

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -1,0 +1,485 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Ewoms::Linear::ParallelBaseBackend
+ */
+#ifndef EWOMS_PARALLEL_BASE_BACKEND_HH
+#define EWOMS_PARALLEL_BASE_BACKEND_HH
+
+#include <ewoms/linear/overlappingbcrsmatrix.hh>
+#include <ewoms/linear/overlappingblockvector.hh>
+#include <ewoms/linear/overlappingpreconditioner.hh>
+#include <ewoms/linear/overlappingscalarproduct.hh>
+#include <ewoms/linear/overlappingoperator.hh>
+#include <ewoms/linear/parallelbasebackend.hh>
+#include <ewoms/linear/istlpreconditionerwrappers.hh>
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+
+#include <dune/grid/io/file/vtk/vtkwriter.hh>
+
+#include <dune/common/fvector.hh>
+
+#include <sstream>
+#include <memory>
+#include <iostream>
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(ParallelBaseLinearSolver);
+
+// forward declaration of the required property tags
+NEW_PROP_TAG(Simulator);
+NEW_PROP_TAG(Scalar);
+NEW_PROP_TAG(JacobianMatrix);
+NEW_PROP_TAG(GlobalEqVector);
+NEW_PROP_TAG(VertexMapper);
+NEW_PROP_TAG(GridView);
+
+NEW_PROP_TAG(BorderListCreator);
+NEW_PROP_TAG(Overlap);
+NEW_PROP_TAG(OverlappingVector);
+NEW_PROP_TAG(OverlappingMatrix);
+NEW_PROP_TAG(OverlappingScalarProduct);
+NEW_PROP_TAG(OverlappingLinearOperator);
+
+//! The type of the linear solver to be used
+NEW_PROP_TAG(LinearSolverBackend);
+
+//! the preconditioner used by the linear solver
+NEW_PROP_TAG(PreconditionerWrapper);
+
+
+//! The floating point type used internally by the linear solver
+NEW_PROP_TAG(LinearSolverScalar);
+
+/*!
+ * \brief The size of the algebraic overlap of the linear solver.
+ *
+ * Algebraic overlaps can be thought as being the same as the overlap
+ * of a grid, but it is only existant for the linear system of
+ * equations.
+ */
+NEW_PROP_TAG(LinearSolverOverlapSize);
+
+/*!
+ * \brief Maximum accepted error of the solution of the linear solver.
+ */
+NEW_PROP_TAG(LinearSolverTolerance);
+
+/*!
+ * \brief Specifies the verbosity of the linear solver
+ *
+ * By default it is 0, i.e. it doesn't print anything. Setting this
+ * property to 1 prints aggregated convergence rates, 2 prints the
+ * convergence rate of every iteration of the scheme.
+ */
+NEW_PROP_TAG(LinearSolverVerbosity);
+
+//! Maximum number of iterations eyecuted by the linear solver
+NEW_PROP_TAG(LinearSolverMaxIterations);
+
+//! The order of the sequential preconditioner
+NEW_PROP_TAG(PreconditionerOrder);
+
+//! The relaxation factor of the preconditioner
+NEW_PROP_TAG(PreconditionerRelaxation);
+}} // namespace Properties, Ewoms
+
+namespace Ewoms {
+namespace Linear {
+/*!
+ * \ingroup Linear
+ *
+ * \brief Provides the common code which is required by most linear solvers.
+ *
+ * This class provides access to all preconditioners offered by dune-istl using the
+ * PreconditionerWrapper property:
+ * \code
+ * SET_TYPE_PROP(YourTypeTag, PreconditionerWrapper,
+ *               Ewoms::Linear::PreconditionerWrapper$PRECONDITIONER<TypeTag>);
+ * \endcode
+ *
+ * Where the choices possible for '\c $PRECONDITIONER' are:
+ * - \c Jacobi: A Jacobi preconditioner
+ * - \c GaussSeidel: A Gauss-Seidel preconditioner
+ * - \c SSOR: A symmetric successive overrelaxation (SSOR) preconditioner
+ * - \c SOR: A successive overrelaxation (SOR) preconditioner
+ * - \c ILUn: An ILU(n) preconditioner
+ * - \c ILU0: An ILU(0) preconditioner. The results of this
+ *            preconditioner are the same as setting the
+ *            PreconditionerOrder property to 0 and using the ILU(n)
+ *            preconditioner. The reason for the existence of ILU0 is
+ *            that it is computationally cheaper because it does not
+ *            need to consider things which are only required for
+ *            higher orders
+ */
+template <class TypeTag>
+class ParallelBaseBackend
+{
+protected:
+    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverBackend) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) Matrix;
+    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) Vector;
+    typedef typename GET_PROP_TYPE(TypeTag, BorderListCreator) BorderListCreator;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
+
+    typedef typename GET_PROP_TYPE(TypeTag, PreconditionerWrapper) PreconditionerWrapper;
+    typedef typename PreconditionerWrapper::SequentialPreconditioner SequentialPreconditioner;
+
+    typedef Ewoms::Linear::OverlappingPreconditioner<SequentialPreconditioner,
+                                                     Overlap> ParallelPreconditioner;
+    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector,
+                                                    Overlap> ParallelScalarProduct;
+    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix,
+                                               OverlappingVector,
+                                               OverlappingVector> ParallelOperator;
+
+    enum { dimWorld = GridView::dimensionworld };
+
+public:
+    ParallelBaseBackend(const Simulator& simulator)
+        : simulator_(simulator)
+        , gridSequenceNumber_( -1 )
+    {
+        overlappingMatrix_ = nullptr;
+        overlappingb_ = nullptr;
+        overlappingx_ = nullptr;
+    }
+
+    ~ParallelBaseBackend()
+    { cleanup_(); }
+
+    /*!
+     * \brief Register all run-time parameters for the linear solver.
+     */
+    static void registerParameters()
+    {
+        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
+                             "The maximum allowed error between of the linear solver");
+        EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
+                             "The size of the algebraic overlap for the linear solver");
+        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,
+                             "The maximum number of iterations of the linear solver");
+        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverVerbosity,
+                             "The verbosity level of the linear solver");
+
+        PreconditionerWrapper::registerParameters();
+    }
+
+    /*!
+     * \brief Causes the solve() method to discared the structure of the linear system of
+     *        equations the next time it is called.
+     */
+    void eraseMatrix()
+    { cleanup_(); }
+
+    void prepareMatrix(const Matrix& M)
+    {
+        // make sure that the overlapping matrix and block vectors
+        // have been created
+        prepare_(M);
+
+        // copy the interior values of the non-overlapping linear system of
+        // equations to the overlapping one. On ther border, we add up
+        // the values of all processes (using the assignAdd() methods)
+        overlappingMatrix_->assignFromNative(M);
+
+        asImp_().rescale_();
+
+        // synchronize all entries from their master processes and add entries on the
+        // process border
+        overlappingMatrix_->syncAdd();
+        // the entries on the border have already been added in prepareRhs()
+        overlappingb_->sync();
+    }
+
+    void prepareRhs(const Matrix& M, Vector& b)
+    {
+        // make sure that the overlapping matrix and block vectors
+        // have been created
+        prepare_(M);
+
+        overlappingb_->assignAddBorder(b);
+
+        // copy the result back to the non-overlapping vector. This is
+        // necessary here as assignAddBorder() might modify the
+        // residual vector for the border entities and we need the
+        // "globalized" residual in b...
+        overlappingb_->assignTo(b);
+    }
+
+    /*!
+     * \brief Actually solve the linear system of equations.
+     *
+     * \return true if the residual reduction could be achieved, else false.
+     */
+    bool solve(Vector& x)
+    {
+        (*overlappingx_) = 0.0;
+
+        auto parPreCond = asImp_().preparePreconditioner_();
+
+        // create the parallel scalar product and the parallel operator
+        ParallelScalarProduct parScalarProduct(overlappingMatrix_->overlap());
+        ParallelOperator parOperator(*overlappingMatrix_);
+
+        // retrieve the linear solver
+        auto solver = asImp_().prepareSolver_(parOperator,
+                                              parScalarProduct,
+                                              *parPreCond);
+
+        // run the linear solver and have some fun
+        bool result = asImp_().runSolver_(solver);
+
+        // copy the result back to the non-overlapping vector
+        overlappingx_->assignTo(x);
+
+        // return the result of the solver
+        return result;
+    }
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation *>(this); }
+
+    const Implementation& asImp_() const
+    { return *static_cast<const Implementation *>(this); }
+
+    void prepare_(const Matrix& M)
+    {
+        // if grid has changed the sequence number has changed too
+        int curSeqNum = simulator_.gridManager().gridSequenceNumber();
+        if( gridSequenceNumber_ == curSeqNum && overlappingMatrix_)
+            // the grid has not changed since the overlappingMatrix_has been created, so
+            // there's noting to do
+            return;
+
+        cleanup_();
+        gridSequenceNumber_ = curSeqNum;
+
+        BorderListCreator borderListCreator(simulator_.gridView(),
+                                            simulator_.model().dofMapper());
+
+        // create the overlapping Jacobian matrix
+        unsigned overlapSize = EWOMS_GET_PARAM(TypeTag, unsigned, LinearSolverOverlapSize);
+        overlappingMatrix_ = new OverlappingMatrix(M,
+                                                   borderListCreator.borderList(),
+                                                   borderListCreator.blackList(),
+                                                   overlapSize);
+
+        // create the overlapping vectors for the residual and the
+        // solution
+        overlappingb_ = new OverlappingVector(overlappingMatrix_->overlap());
+        overlappingx_ = new OverlappingVector(*overlappingb_);
+
+        // writeOverlapToVTK_();
+    }
+
+    void rescale_()
+    {
+        size_t numNative = overlappingMatrix_->overlap().numNative();
+
+        // rescale the overlapping linear system of equations by the equation weights
+        auto rowIt = overlappingMatrix_->begin();
+        const auto& rowEndIt = overlappingMatrix_->end();
+        for (; rowIt != rowEndIt; ++ rowIt) {
+            unsigned rowIdx = rowIt.index();
+
+            if (rowIdx >= numNative || simulator_.model().dofTotalVolume(rowIdx) <= 0.0)
+                continue; // the row represents a non-local degree of freedom
+
+            auto colIt = rowIt->begin();
+            const auto& colEndIt = rowIt->end();
+            for (; colIt != colEndIt; ++ colIt) {
+                auto& entry = *colIt;
+                for (unsigned i = 0; i < entry.rows; ++i)
+                    entry[i] *= simulator_.model().eqWeight(rowIdx, i);
+            }
+
+            auto& rhsEntry = (*overlappingb_)[rowIdx];
+            for (unsigned i = 0; i < rhsEntry.size(); ++i)
+                rhsEntry[i] *= simulator_.model().eqWeight(rowIdx, i);
+        }
+    }
+
+    void cleanup_()
+    {
+        // create the overlapping Jacobian matrix and vectors
+        delete overlappingMatrix_;
+        delete overlappingb_;
+        delete overlappingx_;
+
+        overlappingMatrix_ = 0;
+        overlappingb_ = 0;
+        overlappingx_ = 0;
+    }
+
+    std::shared_ptr<ParallelPreconditioner> preparePreconditioner_()
+    {
+        int preconditionerIsReady = 1;
+        try {
+            // update sequential preconditioner
+            precWrapper_.prepare(*overlappingMatrix_);
+        }
+        catch (const Dune::Exception& e) {
+            std::cout << "Preconditioner threw exception \"" << e.what()
+                      << " on rank " << overlappingMatrix_->overlap().myRank()
+                      << "\n"  << std::flush;
+            preconditionerIsReady = 0;
+        }
+
+        // make sure that the preconditioner is also ready on all peer
+        // ranks.
+        preconditionerIsReady = simulator_.gridView().comm().min(preconditionerIsReady);
+        if (!preconditionerIsReady)
+            OPM_THROW(Opm::NumericalProblem, "Creating the preconditioner failed");
+
+        // create the parallel preconditioner
+        return std::make_shared<ParallelPreconditioner>(precWrapper_.get(), overlappingMatrix_->overlap());
+    }
+
+    void writeOverlapToVTK_()
+    {
+        for (int lookedAtRank = 0;
+             lookedAtRank < simulator_.gridView().comm().size(); ++lookedAtRank) {
+            std::cout << "writing overlap for rank " << lookedAtRank << "\n"  << std::flush;
+            typedef Dune::BlockVector<Dune::FieldVector<Scalar, 1> > VtkField;
+            int n = simulator_.gridView().size(/*codim=*/dimWorld);
+            VtkField isInOverlap(n);
+            VtkField rankField(n);
+            isInOverlap = 0.0;
+            rankField = 0.0;
+            assert(rankField.two_norm() == 0.0);
+            assert(isInOverlap.two_norm() == 0.0);
+            auto vIt = simulator_.gridView().template begin</*codim=*/dimWorld>();
+            const auto& vEndIt = simulator_.gridView().template end</*codim=*/dimWorld>();
+            const auto& overlap = overlappingMatrix_->overlap();
+            for (; vIt != vEndIt; ++vIt) {
+                int nativeIdx = simulator_.model().vertexMapper().map(*vIt);
+                int localIdx = overlap.foreignOverlap().nativeToLocal(nativeIdx);
+                if (localIdx < 0)
+                    continue;
+                rankField[nativeIdx] = simulator_.gridView().comm().rank();
+                if (overlap.peerHasIndex(lookedAtRank, localIdx))
+                    isInOverlap[nativeIdx] = 1.0;
+            }
+
+            typedef Dune::VTKWriter<GridView> VtkWriter;
+            VtkWriter writer(simulator_.gridView(), Dune::VTK::conforming);
+            writer.addVertexData(isInOverlap, "overlap");
+            writer.addVertexData(rankField, "rank");
+
+            std::ostringstream oss;
+            oss << "overlap_rank=" << lookedAtRank;
+            writer.write(oss.str().c_str(), Dune::VTK::ascii);
+        }
+    }
+
+    const Simulator& simulator_;
+    int gridSequenceNumber_;
+
+    OverlappingMatrix *overlappingMatrix_;
+    OverlappingVector *overlappingb_;
+    OverlappingVector *overlappingx_;
+
+    PreconditionerWrapper precWrapper_;
+};
+}} // namespace Linear, Ewoms
+
+namespace Ewoms {
+namespace Properties {
+//! make the linear solver shut up by default
+SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverVerbosity, 0);
+
+//! set the preconditioner relaxation parameter to 1.0 by default
+SET_SCALAR_PROP(ParallelBaseLinearSolver, PreconditionerRelaxation, 1.0);
+
+//! set the preconditioner order to 0 by default
+SET_INT_PROP(ParallelBaseLinearSolver, PreconditionerOrder, 0);
+
+//! by default use the same kind of floating point values for the linearization and for
+//! the linear solve
+SET_TYPE_PROP(ParallelBaseLinearSolver,
+              LinearSolverScalar,
+              typename GET_PROP_TYPE(TypeTag, Scalar));
+
+SET_PROP(ParallelBaseLinearSolver, OverlappingMatrix)
+{
+    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
+    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> MatrixBlock;
+    typedef Dune::BCRSMatrix<MatrixBlock> NonOverlappingMatrix;
+    typedef Ewoms::Linear::OverlappingBCRSMatrix<NonOverlappingMatrix> type;
+};
+
+SET_TYPE_PROP(ParallelBaseLinearSolver,
+              Overlap,
+              typename GET_PROP_TYPE(TypeTag, OverlappingMatrix)::Overlap);
+
+SET_PROP(ParallelBaseLinearSolver, OverlappingVector)
+{
+    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
+    typedef Dune::FieldVector<LinearSolverScalar, numEq> VectorBlock;
+    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
+    typedef Ewoms::Linear::OverlappingBlockVector<VectorBlock, Overlap> type;
+};
+
+SET_PROP(ParallelBaseLinearSolver, OverlappingScalarProduct)
+{
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
+    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
+    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector, Overlap> type;
+};
+
+SET_PROP(ParallelBaseLinearSolver, OverlappingLinearOperator)
+{
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
+    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
+    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix, OverlappingVector,
+                                               OverlappingVector> type;
+};
+
+SET_TYPE_PROP(ParallelBaseLinearSolver,
+              PreconditionerWrapper,
+              Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
+
+//! set the default overlap size to 2
+SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverOverlapSize, 2);
+
+//! set the default number of maximum iterations for the linear solver
+SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverMaxIterations, 1000);
+} // namespace Properties
+} // namespace Ewoms
+
+#endif

--- a/ewoms/linear/parallelbicgstabbackend.hh
+++ b/ewoms/linear/parallelbicgstabbackend.hh
@@ -27,95 +27,30 @@
 #ifndef EWOMS_PARALLEL_BICGSTAB_BACKEND_HH
 #define EWOMS_PARALLEL_BICGSTAB_BACKEND_HH
 
-#include "overlappingbcrsmatrix.hh"
-#include "overlappingblockvector.hh"
-#include "overlappingpreconditioner.hh"
-#include "overlappingscalarproduct.hh"
-#include "overlappingoperator.hh"
+#include "parallelbasebackend.hh"
 #include "bicgstabsolver.hh"
-#include "weightedresidreductioncriterion.hh"
-
-#include <ewoms/common/propertysystem.hh>
-#include <ewoms/common/parametersystem.hh>
-
-#include <dune/grid/io/file/vtk/vtkwriter.hh>
-#include <dune/istl/preconditioners.hh>
-#include <dune/common/fvector.hh>
+#include "combinedcriterion.hh"
 
 #include <memory>
-#include <sstream>
-#include <iostream>
+
+namespace Ewoms {
+namespace Linear {
+template <class TypeTag>
+class ParallelBiCGStabSolverBackend;
+}} // namespace Linear, Ewoms
 
 namespace Ewoms {
 namespace Properties {
-NEW_TYPE_TAG(ParallelBiCGStabLinearSolver);
+NEW_TYPE_TAG(ParallelBiCGStabLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
-// forward declaration of the required property tags
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(JacobianMatrix);
-NEW_PROP_TAG(GlobalEqVector);
-NEW_PROP_TAG(VertexMapper);
-NEW_PROP_TAG(GridView);
-
-NEW_PROP_TAG(BorderListCreator);
-NEW_PROP_TAG(Overlap);
-NEW_PROP_TAG(OverlappingVector);
-NEW_PROP_TAG(OverlappingMatrix);
-NEW_PROP_TAG(OverlappingScalarProduct);
-NEW_PROP_TAG(OverlappingLinearOperator);
-
-//! The type of the linear solver to be used
-NEW_PROP_TAG(LinearSolverBackend);
-NEW_PROP_TAG(PreconditionerWrapper);
-
-//! The floating point type used internally by the linear solver
-NEW_PROP_TAG(LinearSolverScalar);
-
-//! The number of "inner" equations (number of equations in a dense matrix block)
-NEW_PROP_TAG(NumEq);
-
-/*!
- * \brief The size of the algebraic overlap of the linear solver.
- *
- * Algebraic overlaps can be thought as being the same as the overlap
- * of a grid, but it is only existant for the linear system of
- * equations.
- */
-NEW_PROP_TAG(LinearSolverOverlapSize);
-
-/*!
- * \brief Maximum accepted error of the solution of the linear solver.
- */
-NEW_PROP_TAG(LinearSolverTolerance);
-
-/*!
- * \brief Specifies the maximum error which the linear solver may encounter before it
- *        gives up.
- *
- * By default this is 10^7.
- */
 NEW_PROP_TAG(LinearSolverMaxError);
 
-/*!
- * \brief Specifies the verbosity of the linear solver
- *
- * By default it is 0, i.e. it doesn't print anything. Setting this
- * property to 1 prints aggregated convergence rates, 2 prints the
- * convergence rate of every iteration of the scheme.
- */
-NEW_PROP_TAG(LinearSolverVerbosity);
+SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
+              LinearSolverBackend,
+              Ewoms::Linear::ParallelBiCGStabSolverBackend<TypeTag>);
 
-//! Maximum number of iterations eyecuted by the linear solver
-NEW_PROP_TAG(LinearSolverMaxIterations);
-
-//! The order of the sequential preconditioner
-NEW_PROP_TAG(PreconditionerOrder);
-
-//! The relaxation factor of the preconditioner
-NEW_PROP_TAG(PreconditionerRelaxation);
-} // namespace Properties
-} // namespace Ewoms
+SET_SCALAR_PROP(ParallelBiCGStabLinearSolver, LinearSolverMaxError, 1e7);
+}} // namespace Properties, Ewoms
 
 namespace Ewoms {
 namespace Linear {
@@ -146,482 +81,77 @@ namespace Linear {
  *            higher orders
  */
 template <class TypeTag>
-class ParallelBiCGStabSolverBackend
+class ParallelBiCGStabSolverBackend : public ParallelBaseBackend<TypeTag>
 {
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverBackend) Implementation;
+    typedef ParallelBaseBackend<TypeTag> ParentType;
 
-    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) Matrix;
-    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) Vector;
-    typedef typename GET_PROP_TYPE(TypeTag, BorderListCreator) BorderListCreator;
-    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
 
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
+    typedef typename ParentType::ParallelOperator ParallelOperator;
+    typedef typename ParentType::OverlappingVector OverlappingVector;
+    typedef typename ParentType::ParallelPreconditioner ParallelPreconditioner;
+    typedef typename ParentType::ParallelScalarProduct ParallelScalarProduct;
 
-    typedef typename GET_PROP_TYPE(TypeTag, PreconditionerWrapper) PreconditionerWrapper;
-    typedef typename PreconditionerWrapper::SequentialPreconditioner SequentialPreconditioner;
-
-    typedef Ewoms::Linear::OverlappingPreconditioner<SequentialPreconditioner,
-                                                     Overlap> ParallelPreconditioner;
-    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector,
-                                                    Overlap> ParallelScalarProduct;
-    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix,
-                                               OverlappingVector,
-                                               OverlappingVector> ParallelOperator;
-
-    enum { dimWorld = GridView::dimensionworld };
+    typedef BiCGStabSolver<ParallelOperator,
+                           OverlappingVector,
+                           ParallelPreconditioner> RawLinearSolver;
 
 public:
     ParallelBiCGStabSolverBackend(const Simulator& simulator)
-        : simulator_(simulator)
-        , gridSequenceNumber_( -1 )
-    {
-        overlappingMatrix_ = nullptr;
-        overlappingb_ = nullptr;
-        overlappingx_ = nullptr;
-    }
+        : ParentType(simulator)
+    { }
 
-    ~ParallelBiCGStabSolverBackend()
-    { cleanup_(); }
-
-    /*!
-     * \brief Register all run-time parameters for the linear solver.
-     */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
-                             "The maximum allowed error between of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
-                             "The size of the algebraic overlap for the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,
-                             "The maximum number of iterations of the linear solver");
+        ParentType::registerParameters();
+
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverMaxError,
-                             "The maximum error which the linear solver tolerates without giving up");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverVerbosity,
-                             "The verbosity level of the linear solver");
-
-        PreconditionerWrapper::registerParameters();
+                             "The maximum residual error which the linear solver tolerates"
+                             " without giving up");
     }
 
-    /*!
-     * \brief Causes the solve() method to discared the structure of the linear system of
-     *        equations the next time it is called.
-     */
-    void eraseMatrix()
-    { cleanup_(); }
+protected:
+    friend ParentType;
 
-    void prepareMatrix(const Matrix& M)
+    std::shared_ptr<RawLinearSolver> prepareSolver_(ParallelOperator& parOperator,
+                                                    ParallelScalarProduct& parScalarProduct,
+                                                    ParallelPreconditioner& parPreCond)
     {
-        // make sure that the overlapping matrix and block vectors
-        // have been created
-        prepare_(M);
-
-        // copy the values of the non-overlapping linear system of
-        // equations to the overlapping one. On ther border, we add up
-        // the values of all processes (using the assignAdd() methods)
-        overlappingMatrix_->assignAdd(M);
-    }
-
-    void prepareRhs(const Matrix& M, Vector& b)
-    {
-        // make sure that the overlapping matrix and block vectors
-        // have been created
-        prepare_(M);
-
-        overlappingb_->assignAddBorder(b);
-
-        // copy the result back to the non-overlapping vector. This is
-        // necessary here as assignAddBorder() might modify the
-        // residual vector for the border entities and we need the
-        // "globalized" residual in b...
-        overlappingb_->assignTo(b);
-    }
-
-    /*!
-     * \brief Actually solve the linear system of equations.
-     *
-     * \return true if the residual reduction could be achieved, else false.
-     */
-    bool solve(Vector& x)
-    {
-        Scalar oldSingularLimit = Dune::FMatrixPrecision<Scalar>::singular_limit();
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-50);
-
-        (*overlappingx_) = 0.0;
-
-        int preconditionerIsReady;
-        try {
-            // update sequential preconditioner
-            precWrapper_.prepare(*overlappingMatrix_);
-            preconditionerIsReady = 1;
-        }
-        catch (const Dune::Exception& e) {
-            std::cout << "Preconditioner threw exception \"" << e.what()
-                      << " on rank " << overlappingMatrix_->overlap().myRank()
-                      << "\n"  << std::flush;
-            preconditionerIsReady = 0;
-        }
-        catch (...) {
-            std::cout << "Preconditioner threw exception on rank "
-                      << overlappingMatrix_->overlap().myRank()
-                      << "\n"  << std::flush;
-            preconditionerIsReady = 0;
-        }
-
-        // make sure that the preconditioner is also ready on all peer
-        // ranks.
-        preconditionerIsReady = simulator_.gridView().comm().min(preconditionerIsReady);
-        if (!preconditionerIsReady) {
-            Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-            return false;
-        }
-
-        /////
-        // create the parallel preconditioner
-        auto parPreCond =
-            std::make_shared<ParallelPreconditioner>(precWrapper_.get(),
-                                                     overlappingMatrix_->overlap());
-        /////
-
-        // create the parallel scalar product and the parallel operator
-        auto parScalarProduct =
-            std::make_shared<ParallelScalarProduct>(overlappingMatrix_->overlap());
-        ParallelOperator parOperator(*overlappingMatrix_);
-
-        /////
-        // create a residual reduction convergence criterion
-
-        // set the weighting of the residuals
-        OverlappingVector residWeightVec(*overlappingx_);
-        residWeightVec = 0.0;
-        const auto& overlap = overlappingMatrix_->overlap();
-        for (unsigned localIdx = 0; localIdx < overlap.numLocal(); ++localIdx) {
-            Index nativeIdx = overlap.domesticToNative(static_cast<Index>(localIdx));
-            for (unsigned eqIdx = 0; eqIdx < Vector::block_type::dimension; ++eqIdx) {
-                residWeightVec[localIdx][eqIdx] =
-                    this->simulator_.model().eqWeight(static_cast<unsigned>(nativeIdx), eqIdx);
-            }
-        }
+        const auto& gridView = this->simulator_.gridView();
+        typedef CombinedCriterion<OverlappingVector, decltype(gridView.comm())> CCC;
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        Scalar linearSolverAbsTolerance = simulator_.model().newtonMethod().tolerance() / 10.0;
-        typedef typename GridView::CollectiveCommunication Comm;
-        auto convCrit =
-            std::make_shared<Ewoms::Linear::WeightedResidualReductionCriterion<OverlappingVector, Comm> >(
-                simulator_.gridView().comm(),
-                residWeightVec,
-                /*residualReductionTolerance=*/linearSolverTolerance,
-                /*fixPointTolerance=*/0.0,
-                /*absoluteResidualTolerance=*/linearSolverAbsTolerance,
-                /*maxError=*/EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverMaxError));
+        Scalar linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance() / 10.0;
 
-        // done creating the convergence criterion
-        /////
+        convCrit_.reset(new CCC(gridView.comm(),
+                                /*residualReductionTolerance=*/linearSolverTolerance,
+                                /*absoluteResidualTolerance=*/linearSolverAbsTolerance,
+                                EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverMaxError)));
 
-        /////
-        // create the actual linear solver
-        Ewoms::Linear::BiCGStabSolver<ParallelOperator, OverlappingVector, ParallelPreconditioner>
-            bicgstabSolver(parPreCond, convCrit, parScalarProduct);
-        /////
+        auto bicgstabSolver =
+            std::make_shared<RawLinearSolver>(parPreCond, *convCrit_, parScalarProduct);
 
-        //////
-        // actually run the linear solver
-        try {
-            int verbosity = 0;
-            if (parOperator.overlap().myRank() == 0)
-                verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
-            bicgstabSolver.setVerbosity(verbosity);
-            bicgstabSolver.setMaxIterations(EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations));
-            bicgstabSolver.setLinearOperator(&parOperator);
-            bicgstabSolver.setRhs(overlappingb_);
-            bicgstabSolver.apply(*overlappingx_);
-            bicgstabSolver.report();
-        }
-        catch (...) {
-            Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-            return false;
-        }
+        int verbosity = 0;
+        if (parOperator.overlap().myRank() == 0)
+            verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
+        bicgstabSolver->setVerbosity(verbosity);
+        bicgstabSolver->setMaxIterations(EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations));
+        bicgstabSolver->setLinearOperator(&parOperator);
+        bicgstabSolver->setRhs(this->overlappingb_);
 
-        const SolverReport& report = bicgstabSolver.report();
-        //////
-
-        //////
-        // do some janitorial work and set the non-parallel solution vector
-        precWrapper_.cleanup();
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-
-        // copy the result back to the non-overlapping vector
-        overlappingx_->assignTo(x);
-
-        // return the result of the solver
-        return report.converged();
+        return bicgstabSolver;
     }
 
-private:
-    Implementation& asImp_()
-    { return *static_cast<Implementation *>(this); }
+    bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
+    { return solver->apply(*this->overlappingx_); }
 
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation *>(this); }
+    void cleanupSolver_()
+    { /* nothing to do */ }
 
-    void prepare_(const Matrix& M)
-    {
-        // if grid has changed the sequence number has changed too
-        int curSeqNum = simulator_.gridManager().gridSequenceNumber();
-        if( gridSequenceNumber_ == curSeqNum && overlappingMatrix_)
-            // the grid has not changed since the overlappingMatrix_has been created, so
-            // there's noting to do
-            return;
-
-        cleanup_();
-        gridSequenceNumber_ = curSeqNum;
-
-        BorderListCreator borderListCreator(simulator_.gridView(),
-                                            simulator_.model().dofMapper());
-
-        // create the overlapping Jacobian matrix
-        unsigned overlapSize = EWOMS_GET_PARAM(TypeTag, unsigned, LinearSolverOverlapSize);
-        overlappingMatrix_ = new OverlappingMatrix(M,
-                                                   borderListCreator.borderList(),
-                                                   borderListCreator.blackList(),
-                                                   overlapSize);
-
-        // create the overlapping vectors for the residual and the
-        // solution
-        overlappingb_ = new OverlappingVector(overlappingMatrix_->overlap());
-        overlappingx_ = new OverlappingVector(*overlappingb_);
-
-        // writeOverlapToVTK_();
-    }
-
-    void cleanup_()
-    {
-        // create the overlapping Jacobian matrix and vectors
-        delete overlappingMatrix_;
-        delete overlappingb_;
-        delete overlappingx_;
-
-        overlappingMatrix_ = 0;
-        overlappingb_ = 0;
-        overlappingx_ = 0;
-    }
-
-    void writeOverlapToVTK_()
-    {
-        for (int lookedAtRank = 0;
-             lookedAtRank < simulator_.gridView().comm().size(); ++lookedAtRank) {
-            std::cout << "writing overlap for rank " << lookedAtRank << "\n"  << std::flush;
-            typedef Dune::BlockVector<Dune::FieldVector<Scalar, 1> > VtkField;
-            int n = simulator_.gridView().size(/*codim=*/dimWorld);
-            VtkField isInOverlap(n);
-            VtkField rankField(n);
-            isInOverlap = 0.0;
-            rankField = 0.0;
-            assert(rankField.two_norm() == 0.0);
-            assert(isInOverlap.two_norm() == 0.0);
-            auto vIt = simulator_.gridView().template begin</*codim=*/dimWorld>();
-            const auto& vEndIt = simulator_.gridView().template end</*codim=*/dimWorld>();
-            const auto& overlap = overlappingMatrix_->overlap();
-            for (; vIt != vEndIt; ++vIt) {
-                int nativeIdx = simulator_.model().vertexMapper().map(*vIt);
-                int localIdx = overlap.foreignOverlap().nativeToLocal(nativeIdx);
-                if (localIdx < 0)
-                    continue;
-                rankField[nativeIdx] = simulator_.gridView().comm().rank();
-                if (overlap.peerHasIndex(lookedAtRank, localIdx))
-                    isInOverlap[nativeIdx] = 1.0;
-            }
-
-            typedef Dune::VTKWriter<GridView> VtkWriter;
-            VtkWriter writer(simulator_.gridView(), Dune::VTK::conforming);
-            writer.addVertexData(isInOverlap, "overlap");
-            writer.addVertexData(rankField, "rank");
-
-            std::ostringstream oss;
-            oss << "overlap_rank=" << lookedAtRank;
-            writer.write(oss.str().c_str(), Dune::VTK::ascii);
-        }
-    }
-
-    const Simulator& simulator_;
-    int gridSequenceNumber_;
-
-    OverlappingMatrix *overlappingMatrix_;
-    OverlappingVector *overlappingb_;
-    OverlappingVector *overlappingx_;
-
-    PreconditionerWrapper precWrapper_;
+    std::unique_ptr<ConvergenceCriterion<OverlappingVector> > convCrit_;
 };
 
-#define EWOMS_WRAP_ISTL_PRECONDITIONER(PREC_NAME, ISTL_PREC_TYPE)               \
-    template <class TypeTag>                                                    \
-    class PreconditionerWrapper##PREC_NAME                                      \
-    {                                                                           \
-        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                 \
-        typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) JacobianMatrix; \
-        typedef typename GET_PROP_TYPE(TypeTag,                                 \
-                                       OverlappingVector) OverlappingVector;    \
-                                                                                \
-    public:                                                                     \
-        typedef ISTL_PREC_TYPE<JacobianMatrix, OverlappingVector,               \
-                               OverlappingVector> SequentialPreconditioner;     \
-        PreconditionerWrapper##PREC_NAME()                                      \
-        {}                                                                      \
-                                                                                \
-        static void registerParameters()                                        \
-        {                                                                       \
-            EWOMS_REGISTER_PARAM(TypeTag, int, PreconditionerOrder,             \
-                                 "The order of the preconditioner");            \
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,     \
-                                 "The relaxation factor of the "                \
-                                 "preconditioner");                             \
-        }                                                                       \
-                                                                                \
-        void prepare(JacobianMatrix& matrix)                                    \
-        {                                                                       \
-            int order = EWOMS_GET_PARAM(TypeTag, int, PreconditionerOrder);     \
-            Scalar relaxationFactor = EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);   \
-            seqPreCond_ = new SequentialPreconditioner(matrix, order,           \
-                                                       relaxationFactor);       \
-        }                                                                       \
-                                                                                \
-        SequentialPreconditioner& get()                                         \
-        { return *seqPreCond_; }                                                \
-                                                                                \
-        void cleanup()                                                          \
-        { delete seqPreCond_; }                                                 \
-                                                                                \
-    private:                                                                    \
-        SequentialPreconditioner *seqPreCond_;                                  \
-    };
-
-// the same as the EWOMS_WRAP_ISTL_PRECONDITIONER macro, but without
-// an 'order' argument for the preconditioner's constructor
-#define EWOMS_WRAP_ISTL_SIMPLE_PRECONDITIONER(PREC_NAME, ISTL_PREC_TYPE)        \
-    template <class TypeTag>                                                    \
-    class PreconditionerWrapper##PREC_NAME                                      \
-    {                                                                           \
-        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                 \
-        typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix; \
-        typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector; \
-                                                                                \
-    public:                                                                     \
-        typedef ISTL_PREC_TYPE<OverlappingMatrix, OverlappingVector,            \
-                               OverlappingVector> SequentialPreconditioner;     \
-        PreconditionerWrapper##PREC_NAME()                                      \
-        {}                                                                      \
-                                                                                \
-        static void registerParameters()                                        \
-        {                                                                       \
-            EWOMS_REGISTER_PARAM(TypeTag, Scalar, PreconditionerRelaxation,     \
-                                 "The relaxation factor of the "                \
-                                 "preconditioner");                             \
-        }                                                                       \
-                                                                                \
-        void prepare(OverlappingMatrix& matrix)                                 \
-        {                                                                       \
-            Scalar relaxationFactor =                                           \
-                EWOMS_GET_PARAM(TypeTag, Scalar, PreconditionerRelaxation);     \
-            seqPreCond_ = new SequentialPreconditioner(matrix,                  \
-                                                       relaxationFactor);       \
-        }                                                                       \
-                                                                                \
-        SequentialPreconditioner& get()                                         \
-        { return *seqPreCond_; }                                                \
-                                                                                \
-        void cleanup()                                                          \
-        { delete seqPreCond_; }                                                 \
-                                                                                \
-    private:                                                                    \
-        SequentialPreconditioner *seqPreCond_;                                  \
-    };
-
-EWOMS_WRAP_ISTL_PRECONDITIONER(Jacobi, Dune::SeqJac)
-// EWOMS_WRAP_ISTL_PRECONDITIONER(Richardson, Dune::Richardson)
-EWOMS_WRAP_ISTL_PRECONDITIONER(GaussSeidel, Dune::SeqGS)
-EWOMS_WRAP_ISTL_PRECONDITIONER(SOR, Dune::SeqSOR)
-EWOMS_WRAP_ISTL_PRECONDITIONER(SSOR, Dune::SeqSSOR)
-EWOMS_WRAP_ISTL_SIMPLE_PRECONDITIONER(ILU0, Dune::SeqILU0)
-EWOMS_WRAP_ISTL_PRECONDITIONER(ILUn, Dune::SeqILUn)
-
-#undef EWOMS_WRAP_ISTL_PRECONDITIONER
-} // namespace Linear
-} // namespace Ewoms
-
-namespace Ewoms {
-namespace Properties {
-//! make the linear solver shut up by default
-SET_INT_PROP(ParallelBiCGStabLinearSolver, LinearSolverVerbosity, 0);
-
-//! set the preconditioner relaxation parameter to 1.0 by default
-SET_SCALAR_PROP(ParallelBiCGStabLinearSolver, PreconditionerRelaxation, 1.0);
-
-//! set the preconditioner order to 0 by default
-SET_INT_PROP(ParallelBiCGStabLinearSolver, PreconditionerOrder, 0);
-
-//! by default use the same kind of floating point values for the linearization and for
-//! the linear solve
-SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
-              LinearSolverScalar,
-              typename GET_PROP_TYPE(TypeTag, Scalar));
-
-SET_PROP(ParallelBiCGStabLinearSolver, OverlappingMatrix)
-{
-    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> MatrixBlock;
-    typedef Dune::BCRSMatrix<MatrixBlock> NonOverlappingMatrix;
-    typedef Ewoms::Linear::OverlappingBCRSMatrix<NonOverlappingMatrix> type;
-};
-
-SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
-              Overlap,
-              typename GET_PROP_TYPE(TypeTag, OverlappingMatrix)::Overlap);
-
-SET_PROP(ParallelBiCGStabLinearSolver, OverlappingVector)
-{
-    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef Dune::FieldVector<LinearSolverScalar, numEq> VectorBlock;
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef Ewoms::Linear::OverlappingBlockVector<VectorBlock, Overlap> type;
-};
-
-SET_PROP(ParallelBiCGStabLinearSolver, OverlappingScalarProduct)
-{
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector, Overlap> type;
-};
-
-SET_PROP(ParallelBiCGStabLinearSolver, OverlappingLinearOperator)
-{
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix, OverlappingVector,
-                                               OverlappingVector> type;
-};
-
-SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
-              LinearSolverBackend,
-              Ewoms::Linear::ParallelBiCGStabSolverBackend<TypeTag>);
-
-SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
-              PreconditionerWrapper,
-              Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
-
-//! set the default overlap size to 2
-SET_INT_PROP(ParallelBiCGStabLinearSolver, LinearSolverOverlapSize, 2);
-
-//! set the default for the maximum tolerated error of the linear solver to 10^7
-SET_SCALAR_PROP(ParallelBiCGStabLinearSolver, LinearSolverMaxError, 1e7);
-
-//! set the default number of maximum iterations for the linear solver
-SET_INT_PROP(ParallelBiCGStabLinearSolver, LinearSolverMaxIterations, 1000);
-} // namespace Properties
-} // namespace Ewoms
+}} // namespace Linear, Ewoms
 
 #endif

--- a/ewoms/linear/parallelistlbackend.hh
+++ b/ewoms/linear/parallelistlbackend.hh
@@ -27,86 +27,14 @@
 #ifndef EWOMS_PARALLEL_ISTL_BACKEND_HH
 #define EWOMS_PARALLEL_ISTL_BACKEND_HH
 
-#include <ewoms/linear/overlappingbcrsmatrix.hh>
-#include <ewoms/linear/overlappingblockvector.hh>
-#include <ewoms/linear/overlappingpreconditioner.hh>
-#include <ewoms/linear/overlappingscalarproduct.hh>
-#include <ewoms/linear/overlappingoperator.hh>
-#include <ewoms/linear/parallelbicgstabbackend.hh>
-
-#include <ewoms/common/propertysystem.hh>
-#include <ewoms/common/parametersystem.hh>
-
-#include <dune/grid/io/file/vtk/vtkwriter.hh>
-
-#include <dune/istl/solvers.hh>
-#include <dune/istl/preconditioners.hh>
-
-#include <dune/common/shared_ptr.hh>
-#include <dune/common/fvector.hh>
-
-#include <sstream>
-#include <iostream>
+#include "parallelbasebackend.hh"
+#include "istlsolverwrappers.hh"
 
 namespace Ewoms {
 namespace Properties {
-NEW_TYPE_TAG(ParallelIstlLinearSolver);
+NEW_TYPE_TAG(ParallelIstlLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
-// forward declaration of the required property tags
-NEW_PROP_TAG(Simulator);
-NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(JacobianMatrix);
-NEW_PROP_TAG(GlobalEqVector);
-NEW_PROP_TAG(VertexMapper);
-NEW_PROP_TAG(GridView);
-
-NEW_PROP_TAG(BorderListCreator);
-NEW_PROP_TAG(Overlap);
-NEW_PROP_TAG(OverlappingVector);
-NEW_PROP_TAG(OverlappingMatrix);
-NEW_PROP_TAG(OverlappingScalarProduct);
-NEW_PROP_TAG(OverlappingLinearOperator);
-
-//! The type of the linear solver to be used
-NEW_PROP_TAG(LinearSolverBackend);
 NEW_PROP_TAG(LinearSolverWrapper);
-NEW_PROP_TAG(PreconditionerWrapper);
-
-
-//! The floating point type used internally by the linear solver
-NEW_PROP_TAG(LinearSolverScalar);
-
-/*!
- * \brief The size of the algebraic overlap of the linear solver.
- *
- * Algebraic overlaps can be thought as being the same as the overlap
- * of a grid, but it is only existant for the linear system of
- * equations.
- */
-NEW_PROP_TAG(LinearSolverOverlapSize);
-
-/*!
- * \brief Maximum accepted error of the solution of the linear solver.
- */
-NEW_PROP_TAG(LinearSolverTolerance);
-
-/*!
- * \brief Specifies the verbosity of the linear solver
- *
- * By default it is 0, i.e. it doesn't print anything. Setting this
- * property to 1 prints aggregated convergence rates, 2 prints the
- * convergence rate of every iteration of the scheme.
- */
-NEW_PROP_TAG(LinearSolverVerbosity);
-
-//! Maximum number of iterations eyecuted by the linear solver
-NEW_PROP_TAG(LinearSolverMaxIterations);
-
-//! The order of the sequential preconditioner
-NEW_PROP_TAG(PreconditionerOrder);
-
-//! The relaxation factor of the preconditioner
-NEW_PROP_TAG(PreconditionerRelaxation);
 
 //! number of iterations between solver restarts for the GMRES solver
 NEW_PROP_TAG(GMResRestart);
@@ -146,450 +74,68 @@ namespace Linear {
  * - \c SSOR: A symmetric successive overrelaxation (SSOR) preconditioner
  * - \c SOR: A successive overrelaxation (SOR) preconditioner
  * - \c ILUn: An ILU(n) preconditioner
- * - \c ILU0: An ILU(0) preconditioner. The results of this
- *            preconditioner are the same as setting the
- *            PreconditionerOrder property to 0 and using the ILU(n)
- *            preconditioner. The reason for the existence of ILU0 is
- *            that it is computationally cheaper because it does not
- *            need to consider things which are only required for
- *            higher orders
- * - \c Solver: A BiCGSTAB solver wrapped into the preconditioner
- *              interface (may be useful for parallel computations)
+ * - \c ILU0: A specialized (and optimized) ILU(0) preconditioner
  */
 template <class TypeTag>
-class ParallelIstlSolverBackend
+class ParallelIstlSolverBackend : public ParallelBaseBackend<TypeTag>
 {
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverBackend) Implementation;
+    typedef ParallelBaseBackend<TypeTag> ParentType;
 
-    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) Matrix;
-    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) Vector;
-    typedef typename GET_PROP_TYPE(TypeTag, BorderListCreator) BorderListCreator;
-    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
-
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
-
-    typedef typename GET_PROP_TYPE(TypeTag, PreconditionerWrapper) PreconditionerWrapper;
-    typedef typename PreconditionerWrapper::SequentialPreconditioner SequentialPreconditioner;
-
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, LinearSolverWrapper) LinearSolverWrapper;
 
-    typedef Ewoms::Linear::OverlappingPreconditioner<SequentialPreconditioner,
-                                                     Overlap> ParallelPreconditioner;
-    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector,
-                                                    Overlap> ParallelScalarProduct;
-    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix,
-                                               OverlappingVector,
-                                               OverlappingVector> ParallelOperator;
+    typedef typename ParentType::ParallelOperator ParallelOperator;
+    typedef typename ParentType::OverlappingVector OverlappingVector;
+    typedef typename ParentType::ParallelPreconditioner ParallelPreconditioner;
+    typedef typename ParentType::ParallelScalarProduct ParallelScalarProduct;
 
-    enum { dimWorld = GridView::dimensionworld };
+    typedef typename LinearSolverWrapper::RawSolver RawLinearSolver;
+
+    typedef typename GET_PROP_TYPE(TypeTag, JacobianMatrix) Matrix;
+    typedef typename GET_PROP_TYPE(TypeTag, GlobalEqVector) Vector;
 
 public:
     ParallelIstlSolverBackend(const Simulator& simulator)
-        : simulator_(simulator)
-        , gridSequenceNumber_( -1 )
-    {
-        overlappingMatrix_ = nullptr;
-        overlappingb_ = nullptr;
-        overlappingx_ = nullptr;
-    }
-
-    ~ParallelIstlSolverBackend()
-    { cleanup_(); }
+        : ParentType(simulator)
+    { }
 
     /*!
      * \brief Register all run-time parameters for the linear solver.
      */
     static void registerParameters()
     {
-        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
-                             "The maximum allowed error between of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
-                             "The size of the algebraic overlap for the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,
-                             "The maximum number of iterations of the linear solver");
-        EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverVerbosity,
-                             "The verbosity level of the linear solver");
+        ParentType::registerParameters();
 
         LinearSolverWrapper::registerParameters();
-        PreconditionerWrapper::registerParameters();
     }
 
-    /*!
-     * \brief Causes the solve() method to discared the structure of the linear system of
-     *        equations the next time it is called.
-     */
-    void eraseMatrix()
-    { cleanup_(); }
+protected:
+    friend ParentType;
 
-    void prepareMatrix(const Matrix& M)
+    std::shared_ptr<RawLinearSolver> prepareSolver_(ParallelOperator& parOperator,
+                                                    ParallelScalarProduct& parScalarProduct,
+                                                    ParallelPreconditioner& parPreCond)
     {
-        // make sure that the overlapping matrix and block vectors
-        // have been created
-        prepare_(M);
-
-        // copy the values of the non-overlapping linear system of
-        // equations to the overlapping one. On ther border, we add up
-        // the values of all processes (using the assignAdd() methods)
-        overlappingMatrix_->assignAdd(M);
+        return solverWrapper_.get(parOperator,
+                                  parScalarProduct,
+                                  parPreCond);
     }
 
-    void prepareRhs(const Matrix& M, Vector& b)
+    bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
     {
-        // make sure that the overlapping matrix and block vectors
-        // have been created
-        prepare_(M);
-
-        overlappingb_->assignAddBorder(b);
-
-        // copy the result back to the non-overlapping vector. This is
-        // necessary here as assignAddBorder() might modify the
-        // residual vector for the border entities and we need the
-        // "globalized" residual in b...
-        overlappingb_->assignTo(b);
-    }
-
-    /*!
-     * \brief Actually solve the linear system of equations.
-     *
-     * \return true if the residual reduction could be achieved, else false.
-     */
-    bool solve(Vector& x)
-    {
-        Scalar oldSingularLimit = Dune::FMatrixPrecision<Scalar>::singular_limit();
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-50);
-
-        (*overlappingx_) = 0.0;
-
-        int preconditionerIsReady = 1;
-        try {
-            // update sequential preconditioner
-            precWrapper_.prepare(*overlappingMatrix_);
-        }
-        catch (const Dune::Exception& e) {
-            std::cout << "Preconditioner threw exception \"" << e.what()
-                      << " on rank " << overlappingMatrix_->overlap().myRank()
-                      << "\n"  << std::flush;
-            preconditionerIsReady = 0;
-        }
-
-        // make sure that the preconditioner is also ready on all peer
-        // ranks.
-        preconditionerIsReady = simulator_.gridView().comm().min(preconditionerIsReady);
-        if (!preconditionerIsReady) {
-            Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-            return false;
-        }
-
-        // create the parallel preconditioner
-        ParallelPreconditioner parPreCond(precWrapper_.get(),
-                                          overlappingMatrix_->overlap());
-
-        // create the parallel scalar product and the parallel operator
-        ParallelScalarProduct parScalarProduct(overlappingMatrix_->overlap());
-        ParallelOperator parOperator(*overlappingMatrix_);
-
-        // retrieve the linear solver
-        auto& solver = solverWrapper_.get(parOperator, parScalarProduct, parPreCond);
-
-        // run the linear solver and have some fun
         Dune::InverseOperatorResult result;
-        int solverSucceeded = 1;
-        try {
-            solver.apply(*overlappingx_, *overlappingb_, result);
-            solverSucceeded = simulator_.gridView().comm().min(solverSucceeded);
-        }
-        catch (const Dune::Exception& ) {
-            solverSucceeded = 0;
-            solverSucceeded = simulator_.gridView().comm().min(solverSucceeded);
-        }
-
-        // free the unneeded memory of the sequential preconditioner
-        // and the linear solver
-        solverWrapper_.cleanup();
-        precWrapper_.cleanup();
-
-        if (!solverSucceeded) {
-            Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-            return false;
-        }
-
-        // copy the result back to the non-overlapping vector
-        overlappingx_->assignTo(x);
-
-        // reset the singularity limit to the same value as before the
-        // linear solver was invoked.
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(oldSingularLimit);
-
-        // return the result of the solver
+        solver->apply(*this->overlappingx_, *this->overlappingb_, result);
         return result.converged;
     }
 
-private:
-    Implementation& asImp_()
-    { return *static_cast<Implementation *>(this); }
-
-    const Implementation& asImp_() const
-    { return *static_cast<const Implementation *>(this); }
-
-    void prepare_(const Matrix& M)
-    {
-        // if grid has changed the sequence number has changed too
-        int curSeqNum = simulator_.gridManager().gridSequenceNumber();
-        if( gridSequenceNumber_ == curSeqNum && overlappingMatrix_)
-            // the grid has not changed since the overlappingMatrix_has been created, so
-            // there's noting to do
-            return;
-
-        cleanup_();
-        gridSequenceNumber_ = curSeqNum;
-
-        BorderListCreator borderListCreator(simulator_.gridView(),
-                                            simulator_.model().dofMapper());
-
-        // create the overlapping Jacobian matrix
-        unsigned overlapSize = EWOMS_GET_PARAM(TypeTag, unsigned, LinearSolverOverlapSize);
-        overlappingMatrix_ = new OverlappingMatrix(M,
-                                                   borderListCreator.borderList(),
-                                                   borderListCreator.blackList(),
-                                                   overlapSize);
-
-        // create the overlapping vectors for the residual and the
-        // solution
-        overlappingb_ = new OverlappingVector(overlappingMatrix_->overlap());
-        overlappingx_ = new OverlappingVector(*overlappingb_);
-
-        // writeOverlapToVTK_();
-    }
-
-    void cleanup_()
-    {
-        // create the overlapping Jacobian matrix and vectors
-        delete overlappingMatrix_;
-        delete overlappingb_;
-        delete overlappingx_;
-
-        overlappingMatrix_ = 0;
-        overlappingb_ = 0;
-        overlappingx_ = 0;
-    }
-
-    void writeOverlapToVTK_()
-    {
-        for (int lookedAtRank = 0;
-             lookedAtRank < simulator_.gridView().comm().size(); ++lookedAtRank) {
-            std::cout << "writing overlap for rank " << lookedAtRank << "\n"  << std::flush;
-            typedef Dune::BlockVector<Dune::FieldVector<Scalar, 1> > VtkField;
-            int n = simulator_.gridView().size(/*codim=*/dimWorld);
-            VtkField isInOverlap(n);
-            VtkField rankField(n);
-            isInOverlap = 0.0;
-            rankField = 0.0;
-            assert(rankField.two_norm() == 0.0);
-            assert(isInOverlap.two_norm() == 0.0);
-            auto vIt = simulator_.gridView().template begin</*codim=*/dimWorld>();
-            const auto& vEndIt = simulator_.gridView().template end</*codim=*/dimWorld>();
-            const auto& overlap = overlappingMatrix_->overlap();
-            for (; vIt != vEndIt; ++vIt) {
-                int nativeIdx = simulator_.model().vertexMapper().map(*vIt);
-                int localIdx = overlap.foreignOverlap().nativeToLocal(nativeIdx);
-                if (localIdx < 0)
-                    continue;
-                rankField[nativeIdx] = simulator_.gridView().comm().rank();
-                if (overlap.peerHasIndex(lookedAtRank, localIdx))
-                    isInOverlap[nativeIdx] = 1.0;
-            }
-
-            typedef Dune::VTKWriter<GridView> VtkWriter;
-            VtkWriter writer(simulator_.gridView(), Dune::VTK::conforming);
-            writer.addVertexData(isInOverlap, "overlap");
-            writer.addVertexData(rankField, "rank");
-
-            std::ostringstream oss;
-            oss << "overlap_rank=" << lookedAtRank;
-            writer.write(oss.str().c_str(), Dune::VTK::ascii);
-        }
-    }
-
-    const Simulator& simulator_;
-    int gridSequenceNumber_;
-
-    OverlappingMatrix *overlappingMatrix_;
-    OverlappingVector *overlappingb_;
-    OverlappingVector *overlappingx_;
-
-    PreconditionerWrapper precWrapper_;
     LinearSolverWrapper solverWrapper_;
 };
 
-/*!
- * \brief Macro to create a wrapper around an ISTL solver
- */
-#define EWOMS_WRAP_ISTL_SOLVER(SOLVER_NAME, ISTL_SOLVER_NAME)                      \
-    template <class TypeTag>                                                       \
-    class SolverWrapper##SOLVER_NAME                                               \
-    {                                                                              \
-        typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;                    \
-        typedef typename GET_PROP_TYPE(TypeTag,                                    \
-                                       OverlappingMatrix) OverlappingMatrix;       \
-        typedef typename GET_PROP_TYPE(TypeTag,                                    \
-                                       OverlappingVector) OverlappingVector;       \
-                                                                                   \
-        typedef ISTL_SOLVER_NAME<OverlappingVector> ParallelSolver;                \
-                                                                                   \
-    public:                                                                        \
-        SolverWrapper##SOLVER_NAME()                                               \
-        {}                                                                         \
-                                                                                   \
-        static void registerParameters()                                           \
-        {}                                                                         \
-                                                                                   \
-        template <class LinearOperator, class ScalarProduct, class Preconditioner> \
-        ParallelSolver& get(LinearOperator& parOperator,                           \
-                            ScalarProduct& parScalarProduct,                       \
-                            Preconditioner& parPreCond)                            \
-        {                                                                          \
-            Scalar tolerance = EWOMS_GET_PARAM(TypeTag, Scalar,                    \
-                                               LinearSolverTolerance);             \
-            int maxIter = EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations);\
-                                                                                   \
-            int verbosity = 0;                                                     \
-            if (parOperator.overlap().myRank() == 0)                               \
-                verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);  \
-            solver_ = new ParallelSolver(parOperator, parScalarProduct,            \
-                                         parPreCond, tolerance, maxIter,           \
-                                         verbosity);                               \
-                                                                                   \
-            return *solver_;                                                       \
-        }                                                                          \
-                                                                                   \
-        void cleanup()                                                             \
-        { delete solver_; }                                                        \
-                                                                                   \
-    private:                                                                       \
-        ParallelSolver *solver_;                                                   \
-    };
-
-EWOMS_WRAP_ISTL_SOLVER(Richardson, Dune::LoopSolver)
-EWOMS_WRAP_ISTL_SOLVER(SteepestDescent, Dune::GradientSolver)
-EWOMS_WRAP_ISTL_SOLVER(ConjugatedGradients, Dune::CGSolver)
-EWOMS_WRAP_ISTL_SOLVER(BiCGStab, Dune::BiCGSTABSolver)
-EWOMS_WRAP_ISTL_SOLVER(MinRes, Dune::MINRESSolver)
-
-template <class TypeTag>
-class SolverWrapperRestartedGMRes
-{
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-
-    typedef Dune::RestartedGMResSolver<OverlappingVector> ParallelSolver;
-
-public:
-    SolverWrapperRestartedGMRes()
-    {}
-
-    static void registerParameters()
-    {
-        EWOMS_REGISTER_PARAM(TypeTag, int, GMResRestart,
-                             "Number of iterations after which the GMRES linear solver is restarted");
-    }
-
-    template <class LinearOperator, class ScalarProduct, class Preconditioner>
-    ParallelSolver& get(LinearOperator& parOperator,
-                        ScalarProduct& parScalarProduct,
-                        Preconditioner& parPreCond)
-    {
-        Scalar tolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        int maxIter = EWOMS_GET_PARAM(TypeTag, int, LinearSolverMaxIterations);
-
-        int verbosity = 0;
-        if (parOperator.overlap().myRank() == 0)
-            verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
-        int restartAfter = EWOMS_GET_PARAM(TypeTag, int, GMResRestart);
-        solver_ = new ParallelSolver(parOperator,
-                                     parScalarProduct,
-                                     parPreCond,
-                                     tolerance,
-                                     restartAfter,
-                                     maxIter,
-                                     verbosity);
-
-        return *solver_;
-    }
-
-    void cleanup()
-    { delete solver_; }
-
-private:
-    ParallelSolver *solver_;
-};
-
-#undef EWOMS_WRAP_ISTL_SOLVER
-#undef EWOMS_ISTL_SOLVER_TYPDEF
-} // namespace Linear
-} // namespace Ewoms
+}} // namespace Linear, Ewoms
 
 namespace Ewoms {
 namespace Properties {
-//! make the linear solver shut up by default
-SET_INT_PROP(ParallelIstlLinearSolver, LinearSolverVerbosity, 0);
-
-//! set the preconditioner relaxation parameter to 1.0 by default
-SET_SCALAR_PROP(ParallelIstlLinearSolver, PreconditionerRelaxation, 1.0);
-
-//! set the preconditioner order to 0 by default
-SET_INT_PROP(ParallelIstlLinearSolver, PreconditionerOrder, 0);
-
-//! set the GMRes restart parameter to 10 by default
-SET_INT_PROP(ParallelIstlLinearSolver, GMResRestart, 10);
-
-//! by default use the same kind of floating point values for the linearization and for
-//! the linear solve
-SET_TYPE_PROP(ParallelIstlLinearSolver,
-              LinearSolverScalar,
-              typename GET_PROP_TYPE(TypeTag, Scalar));
-
-SET_PROP(ParallelIstlLinearSolver, OverlappingMatrix)
-{
-    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef Dune::FieldMatrix<LinearSolverScalar, numEq, numEq> MatrixBlock;
-    typedef Dune::BCRSMatrix<MatrixBlock> NonOverlappingMatrix;
-    typedef Ewoms::Linear::OverlappingBCRSMatrix<NonOverlappingMatrix> type;
-};
-
-SET_TYPE_PROP(ParallelIstlLinearSolver,
-              Overlap,
-              typename GET_PROP_TYPE(TypeTag, OverlappingMatrix)::Overlap);
-
-SET_PROP(ParallelIstlLinearSolver, OverlappingVector)
-{
-    static constexpr int numEq = GET_PROP_VALUE(TypeTag, NumEq);
-    typedef typename GET_PROP_TYPE(TypeTag, LinearSolverScalar) LinearSolverScalar;
-    typedef Dune::FieldVector<LinearSolverScalar, numEq> VectorBlock;
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef Ewoms::Linear::OverlappingBlockVector<VectorBlock, Overlap> type;
-};
-
-SET_PROP(ParallelIstlLinearSolver, OverlappingScalarProduct)
-{
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef typename GET_PROP_TYPE(TypeTag, Overlap) Overlap;
-    typedef Ewoms::Linear::OverlappingScalarProduct<OverlappingVector, Overlap> type;
-};
-
-SET_PROP(ParallelIstlLinearSolver, OverlappingLinearOperator)
-{
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingMatrix) OverlappingMatrix;
-    typedef typename GET_PROP_TYPE(TypeTag, OverlappingVector) OverlappingVector;
-    typedef Ewoms::Linear::OverlappingOperator<OverlappingMatrix, OverlappingVector,
-                                               OverlappingVector> type;
-};
-
 SET_TYPE_PROP(ParallelIstlLinearSolver,
               LinearSolverBackend,
               Ewoms::Linear::ParallelIstlSolverBackend<TypeTag>);
@@ -602,12 +148,8 @@ SET_TYPE_PROP(ParallelIstlLinearSolver,
               PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
 
-//! set the default overlap size to 2
-SET_INT_PROP(ParallelIstlLinearSolver, LinearSolverOverlapSize, 2);
-
-//! set the default number of maximum iterations for the linear solver
-SET_INT_PROP(ParallelIstlLinearSolver, LinearSolverMaxIterations, 1000);
-} // namespace Properties
-} // namespace Ewoms
+//! set the GMRes restart parameter to 10 by default
+SET_INT_PROP(ParallelIstlLinearSolver, GMResRestart, 10);
+}} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/linear/parallelistlbackend.hh
+++ b/ewoms/linear/parallelistlbackend.hh
@@ -122,6 +122,11 @@ protected:
                                   parPreCond);
     }
 
+    void cleanupSolver_()
+    {
+        solverWrapper_.cleanup();
+    }
+
     bool runSolver_(std::shared_ptr<RawLinearSolver> solver)
     {
         Dune::InverseOperatorResult result;

--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -362,7 +362,7 @@ public:
                 // give it the chance to update the error and thus to terminate the
                 // Newton method without the need of solving the last linearization.
                 updateTimer_.start();
-                const auto& M = linearizer.matrix();
+                auto& M = linearizer.matrix();
                 auto& b = linearizer.residual();
                 linearSolver_.prepareRhs(M, b);
                 asImp_().preSolve_(currentSolution,  b);


### PR DESCRIPTION
this gets rid of quite a bit of copy-and-pasted code, replaces the "equation weight vector" for the  combinedCriterion class by rescaling the linear system of equations to be solved, improves the API and class names of the convergence criteria with an eye on performance and puts the preconditioner- and solver wrappers into separate files.

note that with this the prestine linear solvers from dune-istl now also respect the weight of equations (due to the rescaling the linear systems before solving them). Interestingly, the prestine dune-istl solvers do not seem to profit from this performance-wise while the home-brewn `BiCGStabSolver` seems to get 7 to 8% faster, probably because the `CombinedCriterion` performs better. This brings the performance advantage of `Ewoms::BiCGStabSolver` close to 50% for my testcase when compared to `Dune::BiCGSTABSolver`.