### PR TITLE
properly deal with exceptions thrown while switching the primary variables

### DIFF
--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -180,10 +180,26 @@ public:
             succeeded = 1;
             succeeded = gridView_().comm().min(succeeded);
         }
-        catch (Opm::NumericalProblem& e)
+        catch (const std::exception& e)
         {
             std::cout << "rank " << simulator_().gridView().comm().rank()
                       << " caught an exception while linearizing:" << e.what()
+                      << "\n"  << std::flush;
+            succeeded = 0;
+            succeeded = gridView_().comm().min(succeeded);
+        }
+        catch (const Dune::Exception& e)
+        {
+            std::cout << "rank " << simulator_().gridView().comm().rank()
+                      << " caught an exception while linearizing:" << e.what()
+                      << "\n"  << std::flush;
+            succeeded = 0;
+            succeeded = gridView_().comm().min(succeeded);
+        }
+        catch (...)
+        {
+            std::cout << "rank " << simulator_().gridView().comm().rank()
+                      << " caught an exception while linearizing"
                       << "\n"  << std::flush;
             succeeded = 0;
             succeeded = gridView_().comm().min(succeeded);

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -178,7 +178,6 @@ public:
         try {
             linearize_();
             succeeded = 1;
-            succeeded = gridView_().comm().min(succeeded);
         }
         catch (const std::exception& e)
         {
@@ -186,7 +185,6 @@ public:
                       << " caught an exception while linearizing:" << e.what()
                       << "\n"  << std::flush;
             succeeded = 0;
-            succeeded = gridView_().comm().min(succeeded);
         }
         catch (const Dune::Exception& e)
         {
@@ -194,7 +192,6 @@ public:
                       << " caught an exception while linearizing:" << e.what()
                       << "\n"  << std::flush;
             succeeded = 0;
-            succeeded = gridView_().comm().min(succeeded);
         }
         catch (...)
         {
@@ -202,8 +199,8 @@ public:
                       << " caught an exception while linearizing"
                       << "\n"  << std::flush;
             succeeded = 0;
-            succeeded = gridView_().comm().min(succeeded);
         }
+        succeeded = gridView_().comm().min(succeeded);
 
         if (!succeeded) {
             OPM_THROW(Opm::NumericalProblem,

--- a/ewoms/linear/parallelbicgstabbackend.hh
+++ b/ewoms/linear/parallelbicgstabbackend.hh
@@ -252,14 +252,21 @@ public:
 
         (*overlappingx_) = 0.0;
 
-        int preconditionerIsReady = 1;
+        int preconditionerIsReady;
         try {
             // update sequential preconditioner
             precWrapper_.prepare(*overlappingMatrix_);
+            preconditionerIsReady = 1;
         }
         catch (const Dune::Exception& e) {
             std::cout << "Preconditioner threw exception \"" << e.what()
                       << " on rank " << overlappingMatrix_->overlap().myRank()
+                      << "\n"  << std::flush;
+            preconditionerIsReady = 0;
+        }
+        catch (...) {
+            std::cout << "Preconditioner threw exception on rank "
+                      << overlappingMatrix_->overlap().myRank()
                       << "\n"  << std::flush;
             preconditionerIsReady = 0;
         }

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -120,38 +120,58 @@ protected:
                                  const EqVector& update,
                                  const EqVector& OPM_UNUSED currentResidual)
     {
-        for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
-            // calculate the update of the current primary variable. For the
-            // black-oil model we limit the pressure and saturation updates, but do
-            // we not clamp anything after the specified number of iterations was
-            // reached
-            Scalar delta = update[eqIdx];
+        int succeeded;
+        try {
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                // calculate the update of the current primary variable. For the
+                // black-oil model we limit the pressure and saturation updates, but do
+                // we not clamp anything after the specified number of iterations was
+                // reached
+                Scalar delta = update[eqIdx];
 
-            // limit changes in water saturation to 20%
-            if (eqIdx == Indices::waterSaturationIdx
-                && std::abs(delta) > 0.2)
-            {
-                delta = Ewoms::signum(delta)*0.2;
-            }
-            else if (eqIdx == Indices::compositionSwitchIdx) {
-                // the switching primary variable for composition is tricky because the
-                // "reasonable" value ranges it exhibits vary widely depending on its
-                // interpretation (it can represent Sg, Rs or Rv).  so far, we only limit
-                // changes in gas saturation to 20%
-                if (currentValue.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg
+                // limit changes in water saturation to 20%
+                if (eqIdx == Indices::waterSaturationIdx
                     && std::abs(delta) > 0.2)
                 {
                     delta = Ewoms::signum(delta)*0.2;
                 }
+                else if (eqIdx == Indices::compositionSwitchIdx) {
+                    // the switching primary variable for composition is tricky because the
+                    // "reasonable" value ranges it exhibits vary widely depending on its
+                    // interpretation (it can represent Sg, Rs or Rv).  so far, we only limit
+                    // changes in gas saturation to 20%
+                    if (currentValue.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg
+                        && std::abs(delta) > 0.2)
+                    {
+                        delta = Ewoms::signum(delta)*0.2;
+                    }
+                }
+
+                // do the actual update
+                nextValue[eqIdx] = currentValue[eqIdx] - delta;
             }
 
-            // do the actual update
-            nextValue[eqIdx] = currentValue[eqIdx] - delta;
+            // switch the new primary variables to something which is physically meaningful
+            if (nextValue.adaptPrimaryVariables(this->problem(), globalDofIdx))
+                ++ numPriVarsSwitched_;
+            succeeded = 1;
+            succeeded = this->simulator_.gridView().comm().min(succeeded);
+        }
+        catch (...)
+        {
+            std::cout << "rank " << this->simulator_.gridView().comm().rank()
+                      << " caught an exception while primary variable switching"
+                      << "\n"  << std::flush;
+            succeeded = 0;
+            succeeded = this->simulator_.gridView().comm().min(succeeded);
         }
 
-        // switch the new primary variables to something which is physically meaningful
-        if (nextValue.adaptPrimaryVariables(this->problem(), globalDofIdx))
-            ++ numPriVarsSwitched_;
+        if (!succeeded) {
+            OPM_THROW(Opm::NumericalProblem,
+                       "A process did not succeed in adapting the primary variables");
+        }
+
+        numPriVarsSwitched_ = this->simulator_.gridView().comm().sum(numPriVarsSwitched_);
     }
 
 private:

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -155,7 +155,6 @@ protected:
             if (nextValue.adaptPrimaryVariables(this->problem(), globalDofIdx))
                 ++ numPriVarsSwitched_;
             succeeded = 1;
-            succeeded = this->simulator_.gridView().comm().min(succeeded);
         }
         catch (...)
         {
@@ -163,8 +162,8 @@ protected:
                       << " caught an exception while primary variable switching"
                       << "\n"  << std::flush;
             succeeded = 0;
-            succeeded = this->simulator_.gridView().comm().min(succeeded);
         }
+        succeeded = this->simulator_.gridView().comm().min(succeeded);
 
         if (!succeeded) {
             OPM_THROW(Opm::NumericalProblem,

--- a/ewoms/models/pvs/pvsmodel.hh
+++ b/ewoms/models/pvs/pvsmodel.hh
@@ -472,47 +472,66 @@ public:
     {
         numSwitched_ = 0;
 
-        std::vector<bool> visited(this->numGridDof(), false);
-        ElementContext elemCtx(this->simulator_);
+        int succeeded;
+        try {
+            std::vector<bool> visited(this->numGridDof(), false);
+            ElementContext elemCtx(this->simulator_);
 
-        ElementIterator elemIt = this->gridView_.template begin<0>();
-        ElementIterator elemEndIt = this->gridView_.template end<0>();
-        for (; elemIt != elemEndIt; ++elemIt) {
-            const Element& elem = *elemIt;
-            if (elem.partitionType() != Dune::InteriorEntity)
-                continue;
-            elemCtx.updateStencil(elem);
-
-            size_t numLocalDof = elemCtx.stencil(/*timeIdx=*/0).numPrimaryDof();
-            for (unsigned dofIdx = 0; dofIdx < numLocalDof; ++dofIdx) {
-                unsigned globalIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
-
-                if (visited[globalIdx])
+            ElementIterator elemIt = this->gridView_.template begin<0>();
+            ElementIterator elemEndIt = this->gridView_.template end<0>();
+            for (; elemIt != elemEndIt; ++elemIt) {
+                const Element& elem = *elemIt;
+                if (elem.partitionType() != Dune::InteriorEntity)
                     continue;
-                visited[globalIdx] = true;
+                elemCtx.updateStencil(elem);
 
-                // compute the intensive quantities of the current degree of freedom
-                auto& priVars = this->solution(/*timeIdx=*/0)[globalIdx];
-                elemCtx.updateIntensiveQuantities(priVars, dofIdx, /*timeIdx=*/0);
-                const IntensiveQuantities& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
+                size_t numLocalDof = elemCtx.stencil(/*timeIdx=*/0).numPrimaryDof();
+                for (unsigned dofIdx = 0; dofIdx < numLocalDof; ++dofIdx) {
+                    unsigned globalIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
 
-                // evaluate primary variable switch
-                short oldPhasePresence = priVars.phasePresence();
+                    if (visited[globalIdx])
+                        continue;
+                    visited[globalIdx] = true;
 
-                // set the primary variables and the new phase state
-                // from the current fluid state
-                priVars.assignNaive(intQuants.fluidState());
+                    // compute the intensive quantities of the current degree of freedom
+                    auto& priVars = this->solution(/*timeIdx=*/0)[globalIdx];
+                    elemCtx.updateIntensiveQuantities(priVars, dofIdx, /*timeIdx=*/0);
+                    const IntensiveQuantities& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
 
-                if (oldPhasePresence != priVars.phasePresence()) {
-                    if (verbosity_ > 1)
-                        printSwitchedPhases_(elemCtx,
-                                             dofIdx,
-                                             intQuants.fluidState(),
-                                             oldPhasePresence,
-                                             priVars);
-                    ++numSwitched_;
+                    // evaluate primary variable switch
+                    short oldPhasePresence = priVars.phasePresence();
+
+                    // set the primary variables and the new phase state
+                    // from the current fluid state
+                    priVars.assignNaive(intQuants.fluidState());
+
+                    if (oldPhasePresence != priVars.phasePresence()) {
+                        if (verbosity_ > 1)
+                            printSwitchedPhases_(elemCtx,
+                                                 dofIdx,
+                                                 intQuants.fluidState(),
+                                                 oldPhasePresence,
+                                                 priVars);
+                        ++numSwitched_;
+                    }
                 }
             }
+
+            succeeded = 1;
+            succeeded = this->simulator_.gridView().comm().min(succeeded);
+        }
+        catch (...)
+        {
+            std::cout << "rank " << this->simulator_.gridView().comm().rank()
+                      << " caught an exception during primary variable switching"
+                      << "\n"  << std::flush;
+            succeeded = 0;
+            succeeded = this->simulator_.gridView().comm().min(succeeded);
+        }
+
+        if (!succeeded) {
+            OPM_THROW(Opm::NumericalProblem,
+                       "A process did not succeed in adapting the primary variables");
         }
 
         // make sure that if there was a variable switch in an

--- a/ewoms/models/pvs/pvsmodel.hh
+++ b/ewoms/models/pvs/pvsmodel.hh
@@ -518,7 +518,6 @@ public:
             }
 
             succeeded = 1;
-            succeeded = this->simulator_.gridView().comm().min(succeeded);
         }
         catch (...)
         {
@@ -526,8 +525,8 @@ public:
                       << " caught an exception during primary variable switching"
                       << "\n"  << std::flush;
             succeeded = 0;
-            succeeded = this->simulator_.gridView().comm().min(succeeded);
         }
+        succeeded = this->simulator_.gridView().comm().min(succeeded);
 
         if (!succeeded) {
             OPM_THROW(Opm::NumericalProblem,


### PR DESCRIPTION
this affects MPI-parallel runs of models that use primary variable switching, i.e. the PVS and the blackoil models. this was not noticed earlier because exceptions raised in this part of the code are quite rare. (but sometimes sh** hits the fan!)