### PR TITLE
newton: also call the endIteration_() callback if we do not need to solve the linearized system of equations

### DIFF
--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -368,8 +368,14 @@ public:
                 asImp_().preSolve_(currentSolution,  b);
                 updateTimer_.stop();
 
-                if (!asImp_().proceed_())
+                if (!asImp_().proceed_()) {
+                    // tell the implementation that we're done with this iteration
+                    prePostProcessTimer_.start();
+                    asImp_().endIteration_(nextSolution, currentSolution);
+                    prePostProcessTimer_.stop();
+
                     break;
+                }
 
                 // solve the resulting linear equation system
                 if (asImp_().verbose_()) {


### PR DESCRIPTION
the purpose of this is to print the error for the last iteration of a timestep to the terminal.