### PR TITLE
make the handbook compile on modern LaTeX distributions

### DIFF
--- a/doc/handbook/build-handbook.sh
+++ b/doc/handbook/build-handbook.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+# this script build the eWoms handbook from its LaTeX sources. The
+# result file is called "ewoms-handbook.pdf"
+
+latex ewoms-handbook
+bibtex ewoms-handbook
+latex ewoms-handbook
+latex ewoms-handbook
+dvipdf ewoms-handbook
+rm ewoms-handbook.dvi

--- a/doc/handbook/ewoms-handbook.tex
+++ b/doc/handbook/ewoms-handbook.tex
@@ -14,7 +14,7 @@
 
 \lstset{language=C++, basicstyle=\ttfamily, 
   keywordstyle=\color{black}\bfseries, tabsize=4, stringstyle=\ttfamily,
-  commentstyle=\it, extendedchars=true, escapeinside={/*@}{@*/}}
+  extendedchars=true, escapeinside={/*@}{@*/}}
 
 % for listings of bash code in install.tex
 \lstdefinestyle{Bash}

--- a/doc/handbook/fluidframework.tex
+++ b/doc/handbook/fluidframework.tex
@@ -17,14 +17,14 @@ The \eWoms fluid framework currently features the following concepts
 \item[Fluid state:] Fluid states are responsible for representing the
   complete thermodynamic configuration of a system at a given spatial
   and temporal position. A fluid state always provides access methods
-  to {\bf all} thermodynamic quantities, but the concept of a fluid state does not
+  to \textbf{all} thermodynamic quantities, but the concept of a fluid state does not
   mandate what assumptions are made to store these thermodynamic
-  quantities. What fluid states also do {\bf not} do is to make sure
+  quantities. What fluid states also do \textbf{not} do is to make sure
   that the thermodynamic state which they represent is physically
   possible.
-\item[Fluid system:] Fluid systems express the thermodynamic {\bf
-    relations}\footnote{Strictly speaking, these relations are
-    functions, mathematically.} between quantities. Since functions do
+\item[Fluid system:] Fluid systems express the thermodynamic \textbf{
+  relations}\footnote{Strictly speaking, these relations are
+  functions, mathematically.} between quantities. Since functions do
   not exhibit any internal state, fluid systems are stateless classes,
   i.e. all member functions are \texttt{static}. This is a conscious
   decision since the thermodynamic state of the system is expressed by
@@ -68,7 +68,7 @@ system at a given spatial and temporal position.
 
 \subsection{Exported Constants}
 
-{\bf All} fluid states {\bf must} export the following constants:
+\textbf{All} fluid states \textbf{must} export the following constants:
 \begin{description}
 \item[numPhases:] The number of fluid phases considered.
 \item[numComponents:] The number of considered chemical
@@ -77,7 +77,7 @@ system at a given spatial and temporal position.
 
 \subsection{Accessible Thermodynamic Quantities}
 
-Also, {\bf all} fluid states {\bf must} provide the following methods:
+Also, \textbf{all} fluid states \textbf{must} provide the following methods:
 \begin{description}
 \item[temperature():] The absolute temperature $T_\alpha$ of
   a fluid phase $\alpha$.

--- a/doc/handbook/models.tex
+++ b/doc/handbook/models.tex
@@ -16,7 +16,7 @@ systems is straightforward and can be found, e.\ g., in
 \subsection{Basic Definitions and Assumptions for the Compositional
   Model Concept}
 \textbf{Components:}
-The term {\it component} stands for constituents of the phases which
+The term \textit{component} stands for constituents of the phases which
 can be associated with a unique chemical species, or, more generally, with 
 a group of species exploiting similar physical behavior. In this work, we
 assume a water-gas-NAPL system composed of the phases water (subscript

--- a/doc/handbook/newton-in-a-nutshell.tex
+++ b/doc/handbook/newton-in-a-nutshell.tex
@@ -7,7 +7,7 @@ conservation equation needs to be solved:
   \frac{\partial \phi \varrho_\alpha S_\alpha}{\partial t}
  -
  \text{div} \left\{
- \varrho_\alpha \frac{k_{r\alpha}}{\mu_\alpha} \mbox{\bf K} \left(\text{grad}\, p_\alpha - \varrho_{\alpha} \mbox{\bf g} \right)
+ \varrho_\alpha \frac{k_{r\alpha}}{\mu_\alpha} \mbox{\textbf{K}} \left(\text{grad}\, p_\alpha - \varrho_{\alpha} \mbox{\textbf{g}} \right)
  \right\} - q_\alpha} _
 {\textbf{f}(\textbf{u})}
 = 0 \; .


### PR DESCRIPTION
TeXLive 2016 complains about \it and \bf.

Also, this patch adds a simple bash script to create the handbook from its LaTeX sources. Note that this script does *not* attempt to detect if all prerequisites (in terms of binaries and LaTeX packages) are properly available.