### PR TITLE
handbook: use more sensible options for the hyperref package

### DIFF
--- a/doc/handbook/build-handbook.sh
+++ b/doc/handbook/build-handbook.sh
@@ -1,11 +1,11 @@
 #! /bin/sh
 
-# this script build the eWoms handbook from its LaTeX sources. The
+# this script builds the eWoms handbook from its LaTeX sources. The
 # result file is called "ewoms-handbook.pdf"
 
-latex ewoms-handbook
-bibtex ewoms-handbook
-latex ewoms-handbook
-latex ewoms-handbook
-dvipdf ewoms-handbook
+latex ewoms-handbook || exit $?
+bibtex ewoms-handbook || exit $?
+latex ewoms-handbook || exit $?
+latex ewoms-handbook || exit $?
+dvipdf ewoms-handbook || exit $?
 rm ewoms-handbook.dvi

--- a/doc/handbook/ewoms-handbook.tex
+++ b/doc/handbook/ewoms-handbook.tex
@@ -47,7 +47,26 @@
 \lstset{showstringspaces=false,
  breaklines=true}
 
-\usepackage{hyperref}
+\usepackage[
+            pdfpagelabels=true,
+            %draft,
+            final,
+            bookmarks=true,
+            bookmarksnumbered=true,
+            bookmarksopen=true,
+            bookmarksopenlevel=1,
+            breaklinks=true,
+            colorlinks=true,
+            hyperindex=true,
+            linkcolor=black,
+            citecolor=black,
+            urlcolor=black,
+            pdfpagelayout=SinglePage,
+            %ps2pdf
+            %dvips
+            %dvipdf
+            %pdftex
+            ]{hyperref}
 \usepackage{psfrag}
 \usepackage{makeidx}
 \usepackage{graphicx}


### PR DESCRIPTION
this gets rid of the ugly red and green boxes around references. Note that for some reason, hyperlinks do not seem to work anyway and that using pdflatex directly does not work either :/