### PR TITLE
Fixes pushing to resized array distributedCartesianIndex.

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -247,7 +247,7 @@ namespace Ewoms
 #else
                     int elemIdx = elemMapper.map( element );
 #endif
-                    distributedCartesianIndex.push_back( gridManager.cartesianIndex( elemIdx ) );
+                    distributedCartesianIndex[elemIdx] = gridManager.cartesianIndex( elemIdx );
 
                     // only store interior element for collection
                     if( element.partitionType() == Dune :: InteriorEntity )


### PR DESCRIPTION
Previously distributedCartesianIndex was resized and afterwards all
entries were added with push_back. Therefore the array was twice as
big as expected and contained wrong values in the front.

With this commit we insert the values using random access. Thus the
size is as expeceted and the index of the entries do not depend on the
order of the grid traversal.

This is yet untested.