### PR TITLE
Fix extra warnings

### DIFF
--- a/ewoms/disc/common/fvbaseintensivequantities.hh
+++ b/ewoms/disc/common/fvbaseintensivequantities.hh
@@ -51,12 +51,11 @@ class FvBaseIntensiveQuantities
 public:
     // default constructor
     FvBaseIntensiveQuantities()
-    { evalPoint_ = 0; }
+    { }
 
     // copy constructor
     FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities& v)
     {
-        evalPoint_ = 0;
         extrusionFactor_ = v.extrusionFactor_;
     }
 
@@ -65,7 +64,6 @@ public:
      */
     FvBaseIntensiveQuantities& operator=(const FvBaseIntensiveQuantities& v)
     {
-        evalPoint_ = 0;
         extrusionFactor_ = v.extrusionFactor_;
 
         return *this;
@@ -76,27 +74,6 @@ public:
      */
     static void registerParameters()
     { }
-
-    /*!
-     * \brief Sets the evaluation point used by the local jacobian.
-     *
-     * The evaluation point is only used by semi-smooth models.
-     *
-     * \param ep A pointer to the IntensiveQuantities object of the evaluation point
-     */
-    void setEvalPoint(const Implementation *ep)
-    {
-        evalPoint_ = ep;
-        Valgrind::CheckDefined(evalPoint_);
-    }
-
-    /*!
-     * \brief Returns the evaluation point used by the local jacobian.
-     *
-     * The evaluation point is only used by semi-smooth models.
-     */
-    const Implementation& evalPoint() const
-    { return (evalPoint_ == 0)?asImp_():*evalPoint_; }
 
     /*!
      * \brief Update all quantities for a given control volume.
@@ -137,22 +114,13 @@ public:
      *        quantities in the intensive quantities are defined.
      */
     void checkDefined() const
-    {
-#if !defined NDEBUG && HAVE_VALGRIND
-        Valgrind::CheckDefined(evalPoint_);
-        if (evalPoint_ && evalPoint_ != this)
-            evalPoint_->checkDefined();
-#endif
-    }
+    { }
 
 private:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
-
-    // the evaluation point of the local jacobian
-    const Implementation *evalPoint_;
 
     Scalar extrusionFactor_;
 };

--- a/ewoms/linear/domesticoverlapfrombcrsmatrix.hh
+++ b/ewoms/linear/domesticoverlapfrombcrsmatrix.hh
@@ -523,7 +523,7 @@ protected:
             domesticOverlapByIndex_[static_cast<unsigned>(domesticIdx)][static_cast<unsigned>(peerRank)] = borderDistance;
             domesticOverlapWithPeer_[static_cast<unsigned>(peerRank)].push_back(domesticIdx);
 
-            assert(borderDistance >= 0);
+            //assert(borderDistance >= 0);
             assert(globalIdx >= 0);
             assert(domesticIdx >= 0);
             assert(!(borderDistance == 0 && !foreignOverlap_.isLocal(domesticIdx)));

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -87,6 +87,7 @@ public:
     }
 
     BlackOilIntensiveQuantities(const BlackOilIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other)

--- a/ewoms/models/discretefracture/discretefractureintensivequantities.hh
+++ b/ewoms/models/discretefracture/discretefractureintensivequantities.hh
@@ -74,6 +74,7 @@ public:
     { }
 
     DiscreteFractureIntensiveQuantities(const DiscreteFractureIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     DiscreteFractureIntensiveQuantities& operator=(const DiscreteFractureIntensiveQuantities& other)

--- a/ewoms/models/flash/flashintensivequantities.hh
+++ b/ewoms/models/flash/flashintensivequantities.hh
@@ -93,6 +93,7 @@ public:
     { }
 
     FlashIntensiveQuantities(const FlashIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     FlashIntensiveQuantities& operator=(const FlashIntensiveQuantities& other)

--- a/ewoms/models/immiscible/immiscibleintensivequantities.hh
+++ b/ewoms/models/immiscible/immiscibleintensivequantities.hh
@@ -84,6 +84,7 @@ public:
     { }
 
     ImmiscibleIntensiveQuantities(const ImmiscibleIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     ImmiscibleIntensiveQuantities& operator=(const ImmiscibleIntensiveQuantities& other)

--- a/ewoms/models/ncp/ncpintensivequantities.hh
+++ b/ewoms/models/ncp/ncpintensivequantities.hh
@@ -93,6 +93,7 @@ public:
     {}
 
     NcpIntensiveQuantities(const NcpIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     NcpIntensiveQuantities& operator=(const NcpIntensiveQuantities& other)

--- a/ewoms/models/pvs/pvsintensivequantities.hh
+++ b/ewoms/models/pvs/pvsintensivequantities.hh
@@ -99,6 +99,7 @@ public:
     { }
 
     PvsIntensiveQuantities(const PvsIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     PvsIntensiveQuantities& operator=(const PvsIntensiveQuantities& other)

--- a/ewoms/models/richards/richardsintensivequantities.hh
+++ b/ewoms/models/richards/richardsintensivequantities.hh
@@ -78,6 +78,7 @@ public:
     {}
 
     RichardsIntensiveQuantities(const RichardsIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     RichardsIntensiveQuantities& operator=(const RichardsIntensiveQuantities& other)

--- a/ewoms/models/stokes/stokesintensivequantities.hh
+++ b/ewoms/models/stokes/stokesintensivequantities.hh
@@ -80,6 +80,7 @@ public:
     {}
 
     StokesIntensiveQuantities(const StokesIntensiveQuantities& other)
+        : ParentType()
     { std::memcpy(this, &other, sizeof(other)); }
 
     StokesIntensiveQuantities& operator=(const StokesIntensiveQuantities& other)


### PR DESCRIPTION
this PR fixes a few warnings that are produced by GCC if it is passed `-Wextra` and removes the "evaluation point" concept from the intensive quantities. the latter potentially makes things a tiny bit faster because eight bytes are shoved of the intensive quantities object.