### PR TITLE
localIndexMaps in CollectToIORank need to be lists of interior element indices.

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -229,7 +229,7 @@ namespace Ewoms
 
                 localIndexMap_.clear();
                 const size_t gridSize = gridManager.grid().size( 0 );
-                localIndexMap_.resize( gridSize, -1 );
+                localIndexMap_.reserve( gridSize );
 
                 // store the local Cartesian index
                 IndexMapType distributedCartesianIndex;

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -250,7 +250,7 @@ namespace Ewoms
                     // only store interior element for collection
                     if( element.partitionType() == Dune :: InteriorEntity )
                     {
-                        localIndexMap_[elemIdx] = elemIdx;
+                        localIndexMap_.push_back( elemIdx );
                     }
                 }
 

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -120,7 +120,6 @@ namespace Ewoms
                     indexMap.resize( localSize );
                     for( size_t i=0; i<localSize; ++i )
                     {
-                        assert( localIndexMap_[ i ] != -1 );
                         const int id = distributedGlobalIndex_[ localIndexMap_[ i ] ];
                         indexMap[ i ] = globalPosition_[ id ] ;
 #ifndef NDEBUG
@@ -234,7 +233,6 @@ namespace Ewoms
 
                 // store the local Cartesian index
                 IndexMapType distributedCartesianIndex;
-                int interiorElementIdx = 0;
                 distributedCartesianIndex.resize(gridSize, -1);
 
                 auto localView = gridManager.grid().leafGridView();
@@ -252,7 +250,7 @@ namespace Ewoms
                     // only store interior element for collection
                     if( element.partitionType() == Dune :: InteriorEntity )
                     {
-                        localIndexMap_[elemIdx] = interiorElementIdx++;
+                        localIndexMap_[elemIdx] = elemIdx;
                     }
                 }
 


### PR DESCRIPTION
Correct version of #137 that gets reverted with this PR,

When comparing the code with `ParallelDebugOutput.hh` (the source for copy and paste) I realized that #137 must be wrong as these arrays get passed to `P2PCommunicator` and therefore should look the same in both cases.

I conclude that reserving memory instead of resizing the vector was correct, but we have to use `push_back` to populate the vector to get a list of interior element indices. That is the input P2PCommunicator seems to need.

@dr-robertk should probably have a look at this, too.

Patch is tested together with #140 that I will open again as it is needed, too.