### PR TITLE
update the dune.module file

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -10,4 +10,4 @@ Url: http://opm-project.org/ewoms
 MaintainerName: Andreas Lauser
 Maintainer: and@poware.org
 Depends: dune-grid (>= 2.3) dune-istl  (>= 2.3) opm-common opm-material
-Suggests: dune-localfunctions (>= 2.3) dune-fem dune-alugrid opm-parser opm-grid opm-core
+Suggests: dune-localfunctions (>= 2.3) dune-fem  (>= 2.4) dune-alugrid (>= 2.4) opm-parser opm-grid opm-core


### PR DESCRIPTION
this explicitly sets the minimum version of dune-fem and dune-alugrid to 2.4 in the `dune.module` file: Although version 2.3 of these modules *may* work, I haven't tested this and I don't have the intention of doing so. 