### PR TITLE
Fix istl solverwrapper build

### DIFF
--- a/ewoms/linear/istlsolverwrappers.hh
+++ b/ewoms/linear/istlsolverwrappers.hh
@@ -101,7 +101,7 @@ namespace Linear {
         }                                                                          \
                                                                                    \
         void cleanup()                                                             \
-        { delete solver_; }                                                        \
+        { solver_.reset(); }                                                       \
                                                                                    \
     private:                                                                       \
         std::shared_ptr<RawSolver> solver_;                                        \

--- a/tests/problems/groundwaterproblem.hh
+++ b/tests/problems/groundwaterproblem.hh
@@ -29,6 +29,7 @@
 #define EWOMS_GROUND_WATER_PROBLEM_HH
 
 #include <ewoms/models/immiscible/immiscibleproperties.hh>
+#include <ewoms/linear/parallelistlbackend.hh>
 
 #include <opm/material/components/SimpleH2O.hpp>
 #include <opm/material/fluidstates/ImmiscibleFluidState.hpp>
@@ -99,8 +100,13 @@ SET_SCALAR_PROP(GroundWaterBaseProblem, InitialTimeStepSize, 1);
 
 // The default DGF file to load
 SET_STRING_PROP(GroundWaterBaseProblem, GridFile, "./data/groundwater_2d.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+// Use the conjugated gradient linear solver with the default preconditioner (i.e.,
+// ILU-0) from dune-istl
+SET_TAG_PROP(GroundWaterBaseProblem, LinearSolverSplice, ParallelIstlLinearSolver);
+SET_TYPE_PROP(GroundWaterBaseProblem, LinearSolverWrapper,
+              Ewoms::Linear::SolverWrapperConjugatedGradients<TypeTag>);
+}} // namespace Properties, Ewoms
 
 namespace Ewoms {
 /*!


### PR DESCRIPTION
this fixes a small build issue in the wrappers of the solvers which are generated by the `EWOMS_WRAP_ISTL_SOLVER()` macro. it also changes the test for the groundwater problem to use such a solver. 