### PR TITLE
ebos: no longer fail if the EQLDIMS keyword is not explicitly mentioned in the deck

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -75,6 +75,7 @@
 #include <opm/common/Valgrind.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
@@ -827,8 +828,7 @@ public:
         // SWATINIT.
         const auto& deck = this->simulator().gridManager().deck();
         const auto& eclState = this->simulator().gridManager().eclState();
-        int numEquilRegions =
-            deck.getKeyword("EQLDIMS").getRecord(0).getItem("NTEQUL").template get<int>(0);
+        int numEquilRegions = eclState.getTableManager().getEqldims().getNumEquilRegions();
         bool useThpres = deck.hasKeyword("THPRES") && numEquilRegions > 1;
         bool useSwatinit =
             GET_PROP_VALUE(TypeTag, EnableSwatinit) &&
@@ -1101,9 +1101,7 @@ private:
     {
         const auto& deck = this->simulator().gridManager().deck();
         const auto& eclState = this->simulator().gridManager().eclState();
-        int numEquilRegions =
-            deck.getKeyword("EQLDIMS").getRecord(0).getItem("NTEQUL").template get<int>(0);
-
+        int numEquilRegions = eclState.getTableManager().getEqldims().getNumEquilRegions();
         bool useThpres = deck.hasKeyword("THPRES") && numEquilRegions > 1;
         bool useSwatinit =
             GET_PROP_VALUE(TypeTag, EnableSwatinit) &&

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -36,6 +36,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/common/ErrorMacros.hpp>
@@ -91,7 +92,6 @@ public:
     void finishInit()
     {
         const auto& gridView = simulator_.gridView();
-        const auto& deck = simulator_.gridManager().deck();
 
         unsigned numElements = gridView.size(/*codim=*/0);
 
@@ -109,8 +109,7 @@ public:
         if (!enableThresholdPressure_)
             return;
 
-        numEquilRegions_ =
-            deck.getKeyword("EQLDIMS").getRecord(0).getItem("NTEQUL").template get<int>(0);
+        numEquilRegions_ = eclState.getTableManager().getEqldims().getNumEquilRegions();
         if (numEquilRegions_ > 0xff) {
             // make sure that the index of an equilibration region can be stored in a
             // single byte


### PR DESCRIPTION
the deck object currently does not provide a way to auto-generate an all-defaulted keyword if it has not been mentioned in the deck, so only access the keyword object if it is present.

possibly, this information is also exposed by EclipseState, but I have not found anything suitable.

@atgeirr: please merge if this fixes/improves the issues you've recently had.