### PR TITLE
ebos: sychronize the parse context with the one used by flow_legacy

### DIFF
--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -138,7 +138,8 @@ public:
         typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
         typedef std::vector<ParseModePair> ParseModePairs;
         ParseModePairs tmp;
-        tmp.push_back(ParseModePair(Opm::ParseContext::PARSE_RANDOM_SLASH , Opm::InputError::IGNORE));
+        tmp.push_back(ParseModePair(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE));
+        tmp.push_back(ParseModePair(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN));
         Opm::ParseContext parseContext(tmp);
 
         deck_ = parser.parseFile(fileName , parseContext);


### PR DESCRIPTION
i.e., add the PARSE_MISSING_DIMS_KEYWORD option. this was a recent change in flow_legacy.