### PR TITLE
Only search for test file under tests.

### DIFF
--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -36,9 +36,10 @@
 
 # originally generated with the command:
 # find tests -name '*.xml' -a ! -wholename '*/not-unit/*' -printf '\t%p\n' | sort
-file(GLOB_RECURSE TMP_GRIDS RELATIVE "${CMAKE_SOURCE_DIR}" "*.dgf")
-file(GLOB_RECURSE TMP_VTUS RELATIVE "${CMAKE_SOURCE_DIR}" "*.vtu")
-file(GLOB_RECURSE TMP_VTPS RELATIVE "${CMAKE_SOURCE_DIR}" "*.vtp")
+file(GLOB_RECURSE TMP_GRIDS RELATIVE "${CMAKE_SOURCE_DIR}" "tests/*.dgf")
+file(GLOB_RECURSE TMP_VTUS RELATIVE "${CMAKE_SOURCE_DIR}" "*tests/*.vtu")
+file(GLOB_RECURSE TMP_VTPS RELATIVE "${CMAKE_SOURCE_DIR}" "tests/*.vtp")
+
 list(APPEND TEST_DATA_FILES
 	${TMP_GRIDS}
 	${TMP_VTPS}


### PR DESCRIPTION
Without this we will also find generated test files in build directories
located below the source directory. This happens each time cmake run and
thus the list will increase due to recursiveness.

With this commit we only search for file below tests.

Closes #148 
