### PR TITLE
Add include of opm/common/Unused.hpp

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -32,6 +32,7 @@
 #ifndef EWOMS_PARAMETERS_HH
 #define EWOMS_PARAMETERS_HH
 
+#include <opm/common/Unused.hpp>
 #include <ewoms/common/propertysystem.hh>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>


### PR DESCRIPTION
It is used here but not included. The problem surfaced when I
had to change inclusion order in opm-simulators for debugging.