### PR TITLE
make explicit initialization for twophase cases work

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1134,8 +1134,9 @@ private:
         const auto& eclState = gridManager.eclState();
 
         // since the values specified in the deck do not need to be consistent, we use an
-        // initial condition that conserves the total mass specified by these values.
-        useMassConservativeInitialCondition_ = true;
+        // initial condition that conserves the total mass specified by these values, but
+        // for this to work all three phases must be active.
+        useMassConservativeInitialCondition_ = (FluidSystem::numActivePhases() == 3);
 
         // make sure all required quantities are enables
         if (FluidSystem::phaseIsActive(waterPhaseIdx) && !deck.hasKeyword("SWAT"))

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -195,6 +195,9 @@ public:
 
         paramCache.updateAll(fsFlash);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            if (!FluidSystem::phaseIsActive(phaseIdx))
+                continue;
+
             Scalar rho = FluidSystem::template density<FlashFluidState, Scalar>(fsFlash, paramCache, phaseIdx);
             fsFlash.setDensity(phaseIdx, rho);
         }
@@ -203,6 +206,9 @@ public:
         ComponentVector globalMolarities(0.0);
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (!FluidSystem::phaseIsActive(phaseIdx))
+                    continue;
+
                 globalMolarities[compIdx] +=
                     fsFlash.saturation(phaseIdx) * fsFlash.molarity(phaseIdx, compIdx);
             }


### PR DESCRIPTION
if the initial solution is explicitly given by the deck using the PRESSURE, SWAT, etc. keywords, the specified state can be thermodynamically impossible. To avoid inconsistencies, we use a flash calculation to find a state that is in thermodynamic equilibrium and exhibits the same masses as the explicitly specified solution. Since the flash solver needs to compute quantities for all fluid phases, but two-phase blackoil simulations usually do not specify the properties of one phase, the flash solver crashed. This patch works around that
issue by simply not using the flash solver in the twophase case, i.e., the explicit initial condition must be thermodynamically consistent in order to produce the stable results for a different choice of primary variables.

@akva2: If Jenkins is happy and you don't object, I'll also cherry-pick this into the release branch.