### PR TITLE
EclCpGridManager: do not delete unintialized pointers

### DIFF
--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -248,6 +248,8 @@ protected:
         // equilGrid_being a shallow copy only the global view.
         equilGrid_ = new Dune::CpGrid(*grid_);
         equilCartesianIndexMapper_ = new CartesianIndexMapper(*equilGrid_);
+
+        globalTrans_ = nullptr;
     }
 
     Grid* grid_;


### PR DESCRIPTION
this was found using GCC-7's address sanitizer. I suspect that this did not surface earlier (i.e., with valgrind), because newly allocated memory gets initialized to zero by the operating system, so the value
of the pointer was zero and the delete operator did what was right by coincidence. the new asan seems to initialize memory randomly, though.

i also tried to fix this using `std::unique_ptr`, but this seems to suffer from the same problem. maybe it is a bug in GCC-7's unique_ptr implementation.

lacking objections I'll cherry-pick this patch into the release branch.