### PR TITLE
fix some mild memory leaks found by ASAN

### DIFF
--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -611,7 +611,7 @@ public:
         { return PropertyInfo<typename GetProperty<TypeTag, PropTag>::template GetEffectiveTypeTag_<TypeTag>::type, PropTag>::propertyName; }
     };
 
-    typedef std::list<SpliceRegistryEntryBase*> SpliceList;
+    typedef std::list<std::unique_ptr<SpliceRegistryEntryBase> > SpliceList;
     typedef std::map<std::string, SpliceList> SpliceListMap;
 
     typedef std::list<std::string> ChildrenList;
@@ -646,9 +646,7 @@ public:
     {
         std::string typeTagName = Dune::className<TypeTag>();
 
-        SpliceRegistryEntry<TypeTag, Splice1> *tmp = new SpliceRegistryEntry<TypeTag, Splice1>;
-
-        splices_[typeTagName].push_front(tmp);
+        splices_[typeTagName].emplace_front(new SpliceRegistryEntry<TypeTag, Splice1>);
         addSplices<TypeTag, RemainingSplices...>();
     }
 

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -136,6 +136,9 @@ public:
             defaultVtkWriter_ = new VtkMultiWriter(gridView_, asImp_().name());
     }
 
+    ~FvBaseProblem()
+    { delete defaultVtkWriter_; }
+
     /*!
      * \brief Registers all available parameters for the problem and
      *        the model.


### PR DESCRIPTION
these leaks are not very important because these objects are de-facto singletons, i.e., they usually get allocated only once per invocation of the program.