### PR TITLE
VtkMultiphaseModule: fix incorrect loop variables

### DIFF
--- a/ewoms/io/vtkmultiphasemodule.hh
+++ b/ewoms/io/vtkmultiphasemodule.hh
@@ -260,8 +260,8 @@ public:
 
                     const auto& inputPGrad = extQuants.potentialGrad(phaseIdx);
                     DimVector pGrad;
-                    for (unsigned j = 0; j < numPhases; ++j)
-                        pGrad[j] = Toolbox::value(inputPGrad[j])*weight;
+                    for (unsigned dimIdx = 0; dimIdx < dimWorld; ++dimIdx)
+                        pGrad[dimIdx] = Toolbox::value(inputPGrad[dimIdx])*weight;
                     potentialGradient_[phaseIdx][I] += pGrad;
                 } // end for all phases
             } // end for all faces


### PR DESCRIPTION
this is supposed to be a loop over all spatial axis, not over the fluid phases. the latest GCC from SVN rightfully complains about this. the error has not been discovered earlier because VTK velocity output is disabled by default and also, it worked "by coincidence" if the number of fluid phases was equal to the number of spatial dimensions.