### PR TITLE
Write extrusion factor

### DIFF
--- a/ewoms/disc/common/fvbaseintensivequantities.hh
+++ b/ewoms/disc/common/fvbaseintensivequantities.hh
@@ -54,20 +54,7 @@ public:
     { }
 
     // copy constructor
-    FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities& v)
-    {
-        extrusionFactor_ = v.extrusionFactor_;
-    }
-
-    /*!
-     * \brief Assignment operator
-     */
-    FvBaseIntensiveQuantities& operator=(const FvBaseIntensiveQuantities& v)
-    {
-        extrusionFactor_ = v.extrusionFactor_;
-
-        return *this;
-    }
+    FvBaseIntensiveQuantities(const FvBaseIntensiveQuantities& v) = default;
 
     /*!
      * \brief Register all run-time parameters for the intensive quantities.

--- a/ewoms/io/vtkprimaryvarsmodule.hh
+++ b/ewoms/io/vtkprimaryvarsmodule.hh
@@ -84,11 +84,11 @@ public:
     static void registerParameters()
     {
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePrimaryVars,
-                             "Include the primary variables in the VTK output files");
+                             "Include the primary variables into the VTK output files");
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteProcessRank,
-                             "Include the MPI process rank in the VTK output files");
+                             "Include the MPI process rank into the VTK output files");
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteDofIndex,
-                             "Include the index of the degrees of freedom in the VTK output files");
+                             "Include the index of the degrees of freedom into the VTK output files");
     }
 
     /*!


### PR DESCRIPTION
this PR contains a minor cleanup of the FV base intensive quantities to reduce of manual fiddling if changing the attributes and -- more importantly -- it enables to write the extrusion factor of DOFs to the VTK files so that they can be inspected visually.