### PR TITLE
Add polymer module in ebos

### DIFF
--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -209,6 +209,9 @@ protected:
     void updateSolvent(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
     { asImp_().updateVolumeFluxTrans(elemCtx, scvfIdx, timeIdx); }
 
+    void updatePolymer(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
+    { asImp_().updateShearMultipliers(elemCtx, scvfIdx, timeIdx); }
+
     /*!
      * \brief Update the required gradients for interior faces
      */

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1521,7 +1521,7 @@ private:
             unsigned compressedDofIdx = elemCtx.globalSpaceIndex(/*spaceIdx=*/0, /*timeIdx=*/0);
             const auto& intQuants = elemCtx.intensiveQuantities(/*spaceIdx=*/0, /*timeIdx=*/0);
 
-            maxPolymerAdsorption_[compressedDofIdx] = std::max(maxPolymerAdsorption_[compressedDofIdx] , intQuants.polymerAdsorption().value());
+            maxPolymerAdsorption_[compressedDofIdx] = std::max(maxPolymerAdsorption_[compressedDofIdx] , Opm::scalarValue(intQuants.polymerAdsorption()));
         }
     }
 

--- a/ewoms/io/vtkblackoilpolymermodule.hh
+++ b/ewoms/io/vtkblackoilpolymermodule.hh
@@ -1,0 +1,253 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Ewoms::VtkBlackOilPolymerModule
+ */
+#ifndef EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
+#define EWOMS_VTK_BLACK_OIL_POLYMER_MODULE_HH
+
+#include <opm/material/densead/Math.hpp>
+
+#include "vtkmultiwriter.hh"
+#include "baseoutputmodule.hh"
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+#include <ewoms/models/blackoil/blackoilproperties.hh>
+
+#include <dune/common/fvector.hh>
+
+#include <cstdio>
+
+namespace Ewoms {
+namespace Properties {
+// create new type tag for the VTK multi-phase output
+NEW_TYPE_TAG(VtkBlackOilPolymer);
+
+// create the property tags needed for the polymer output module
+NEW_PROP_TAG(EnablePolymer);
+NEW_PROP_TAG(EnableVtkOutput);
+NEW_PROP_TAG(VtkWritePolymerConcentration);
+NEW_PROP_TAG(VtkWritePolymerAlivePoreSpace);
+NEW_PROP_TAG(VtkWritePolymerAdsorption);
+NEW_PROP_TAG(VtkWritePolymerRockDensity);
+NEW_PROP_TAG(VtkWritePolymerViscosityCorrection);
+NEW_PROP_TAG(VtkWriteWaterViscosityCorrection);
+
+// set default values for what quantities to output
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerConcentration, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAlivePoreSpace, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerViscosityCorrection, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWriteWaterViscosityCorrection, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerRockDensity, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAdsorption, true);
+} // namespace Properties
+} // namespace Ewoms
+
+namespace Ewoms {
+/*!
+ * \ingroup Vtk
+ *
+ * \brief VTK output module for the black oil model's polymer related quantities.
+ */
+template <class TypeTag>
+class VtkBlackOilPolymerModule : public BaseOutputModule<TypeTag>
+{
+    typedef BaseOutputModule<TypeTag> ParentType;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    static const int vtkFormat = GET_PROP_VALUE(TypeTag, VtkOutputFormat);
+    typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
+
+    enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+
+    typedef typename ParentType::ScalarBuffer ScalarBuffer;
+
+public:
+    VtkBlackOilPolymerModule(const Simulator& simulator)
+        : ParentType(simulator)
+    { }
+
+    /*!
+     * \brief Register all run-time parameters for the multi-phase VTK output
+     * module.
+     */
+    static void registerParameters()
+    {
+        if (!enablePolymer)
+            return;
+
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerConcentration,
+                             "Include the concentration of the polymer component in the water phase "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace,
+                             "Include the fraction of the \"alive\" pore space "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerRockDensity,
+                             "Include the amount of already adsorbed polymer component"
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAdsorption,
+                             "Include the adsorption rate of the polymer component"
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection,
+                             "Include the viscosity correction of the polymer component "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteWaterViscosityCorrection,
+                             "Include the viscosity correction of the water component "
+                             "due to polymers in the VTK output files");
+    }
+
+    /*!
+     * \brief Allocate memory for the scalar fields we would like to
+     *        write to the VTK file.
+     */
+    void allocBuffers()
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        if (polymerConcentrationOutput_())
+            this->resizeScalarBuffer_(polymerConcentration_);
+        if (polymerAlivePoreSpaceOutput_())
+            this->resizeScalarBuffer_(polymerAlivePoreSpace_);
+        if (polymerRockDensityOutput_())
+            this->resizeScalarBuffer_(polymerRockDensity_);
+        if (polymerAdsorptionOutput_())
+            this->resizeScalarBuffer_(polymerAdsorption_);
+        if (polymerViscosityCorrectionOutput_())
+            this->resizeScalarBuffer_(polymerViscosityCorrection_);
+        if (waterViscosityCorrectionOutput_())
+            this->resizeScalarBuffer_(waterViscosityCorrection_);
+    }
+
+    /*!
+     * \brief Modify the internal buffers according to the intensive quantities relevant for
+     *        an element
+     */
+    void processElement(const ElementContext& elemCtx)
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
+            const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
+            unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+
+            if (polymerConcentrationOutput_())
+                polymerConcentration_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerConcentration());
+
+            if (polymerAlivePoreSpaceOutput_())
+                polymerAlivePoreSpace_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerAlivePoreSpace());
+
+            if (polymerRockDensityOutput_())
+                polymerRockDensity_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerRockDensity());
+
+            if (polymerAdsorptionOutput_())
+                polymerAdsorption_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerAdsorption());
+
+            if (polymerViscosityCorrectionOutput_())
+                polymerViscosityCorrection_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerViscosityCorrection());
+
+            if (waterViscosityCorrectionOutput_())
+                waterViscosityCorrection_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.waterViscosityCorrection());
+        }
+    }
+
+    /*!
+     * \brief Add all buffers to the VTK output writer.
+     */
+    void commitBuffers(BaseOutputWriter& baseWriter)
+    {
+        VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
+        if (!vtkWriter)
+            return;
+
+        if (!enablePolymer)
+            return;
+
+        if (polymerConcentrationOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer concentration", polymerConcentration_);
+
+        if (polymerAlivePoreSpaceOutput_())
+            this->commitScalarBuffer_(baseWriter, "alive pore volume fraction", polymerAlivePoreSpace_);
+
+        if (polymerRockDensityOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer rock density", polymerRockDensity_);
+
+        if (polymerAdsorptionOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer adsorption", polymerAdsorption_);
+
+        if (polymerViscosityCorrectionOutput_())
+            this->commitScalarBuffer_(baseWriter, "polymer viscosity correction", polymerViscosityCorrection_);
+
+        if (waterViscosityCorrectionOutput_())
+            this->commitScalarBuffer_(baseWriter, "water viscosity correction", waterViscosityCorrection_);
+    }
+
+private:
+    static bool polymerConcentrationOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerConcentration); }
+
+    static bool polymerAlivePoreSpaceOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace); }
+
+    static bool polymerRockDensityOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerRockDensity); }
+
+    static bool polymerAdsorptionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerAdsorption); }
+
+    static bool polymerViscosityCorrectionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection); }
+
+    static bool waterViscosityCorrectionOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection); }
+
+    ScalarBuffer polymerConcentration_;
+    ScalarBuffer polymerAlivePoreSpace_;
+    ScalarBuffer polymerRockDensity_;
+    ScalarBuffer polymerAdsorption_;
+    ScalarBuffer polymerViscosityCorrection_;
+    ScalarBuffer waterViscosityCorrection_;
+};
+} // namespace Ewoms
+
+#endif

--- a/ewoms/io/vtkblackoilpolymermodule.hh
+++ b/ewoms/io/vtkblackoilpolymermodule.hh
@@ -49,7 +49,7 @@ NEW_TYPE_TAG(VtkBlackOilPolymer);
 NEW_PROP_TAG(EnablePolymer);
 NEW_PROP_TAG(EnableVtkOutput);
 NEW_PROP_TAG(VtkWritePolymerConcentration);
-NEW_PROP_TAG(VtkWritePolymerAlivePoreSpace);
+NEW_PROP_TAG(VtkWritePolymerDeadPoreVolume);
 NEW_PROP_TAG(VtkWritePolymerAdsorption);
 NEW_PROP_TAG(VtkWritePolymerRockDensity);
 NEW_PROP_TAG(VtkWritePolymerViscosityCorrection);
@@ -57,7 +57,7 @@ NEW_PROP_TAG(VtkWriteWaterViscosityCorrection);
 
 // set default values for what quantities to output
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerConcentration, true);
-SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAlivePoreSpace, true);
+SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerDeadPoreVolume, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerViscosityCorrection, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWriteWaterViscosityCorrection, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerRockDensity, true);
@@ -106,8 +106,8 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerConcentration,
                              "Include the concentration of the polymer component in the water phase "
                              "in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace,
-                             "Include the fraction of the \"alive\" pore space "
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerDeadPoreVolume,
+                             "Include the fraction of the \"dead\" pore volume "
                              "in the VTK output files");
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWritePolymerRockDensity,
                              "Include the amount of already adsorbed polymer component"
@@ -137,8 +137,8 @@ public:
 
         if (polymerConcentrationOutput_())
             this->resizeScalarBuffer_(polymerConcentration_);
-        if (polymerAlivePoreSpaceOutput_())
-            this->resizeScalarBuffer_(polymerAlivePoreSpace_);
+        if (polymerDeadPoreVolumeOutput_())
+            this->resizeScalarBuffer_(polymerDeadPoreVolume_);
         if (polymerRockDensityOutput_())
             this->resizeScalarBuffer_(polymerRockDensity_);
         if (polymerAdsorptionOutput_())
@@ -169,9 +169,9 @@ public:
                 polymerConcentration_[globalDofIdx] =
                     Opm::scalarValue(intQuants.polymerConcentration());
 
-            if (polymerAlivePoreSpaceOutput_())
-                polymerAlivePoreSpace_[globalDofIdx] =
-                    Opm::scalarValue(intQuants.polymerAlivePoreSpace());
+            if (polymerDeadPoreVolumeOutput_())
+                polymerDeadPoreVolume_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.polymerDeadPoreVolume());
 
             if (polymerRockDensityOutput_())
                 polymerRockDensity_[globalDofIdx] =
@@ -206,8 +206,8 @@ public:
         if (polymerConcentrationOutput_())
             this->commitScalarBuffer_(baseWriter, "polymer concentration", polymerConcentration_);
 
-        if (polymerAlivePoreSpaceOutput_())
-            this->commitScalarBuffer_(baseWriter, "alive pore volume fraction", polymerAlivePoreSpace_);
+        if (polymerDeadPoreVolumeOutput_())
+            this->commitScalarBuffer_(baseWriter, "dead pore volume fraction", polymerDeadPoreVolume_);
 
         if (polymerRockDensityOutput_())
             this->commitScalarBuffer_(baseWriter, "polymer rock density", polymerRockDensity_);
@@ -226,8 +226,8 @@ private:
     static bool polymerConcentrationOutput_()
     { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerConcentration); }
 
-    static bool polymerAlivePoreSpaceOutput_()
-    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerAlivePoreSpace); }
+    static bool polymerDeadPoreVolumeOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerDeadPoreVolume); }
 
     static bool polymerRockDensityOutput_()
     { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerRockDensity); }
@@ -242,7 +242,7 @@ private:
     { return EWOMS_GET_PARAM(TypeTag, bool, VtkWritePolymerViscosityCorrection); }
 
     ScalarBuffer polymerConcentration_;
-    ScalarBuffer polymerAlivePoreSpace_;
+    ScalarBuffer polymerDeadPoreVolume_;
     ScalarBuffer polymerRockDensity_;
     ScalarBuffer polymerAdsorption_;
     ScalarBuffer polymerViscosityCorrection_;

--- a/ewoms/models/blackoil/blackoildarcyfluxmodule.hh
+++ b/ewoms/models/blackoil/blackoildarcyfluxmodule.hh
@@ -87,6 +87,9 @@ public:
 
     }
 
+    void updatePolymer(const ElementContext& elemCtx, unsigned scvfIdx, unsigned timeIdx)
+    { asImp_().updateShearMultipliersPerm(elemCtx, scvfIdx, timeIdx); }
+
 protected:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }

--- a/ewoms/models/blackoil/blackoilextensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilextensivequantities.hh
@@ -30,6 +30,8 @@
 
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
+#include "blackoilpolymermodules.hh"
+
 
 #include <ewoms/models/common/multiphasebaseextensivequantities.hh>
 
@@ -50,9 +52,13 @@ template <class TypeTag>
 class BlackOilExtensiveQuantities
     : public MultiPhaseBaseExtensiveQuantities<TypeTag>
     , public BlackOilSolventExtensiveQuantities<TypeTag>
+    , public BlackOilPolymerExtensiveQuantities<TypeTag>
+
 {
     typedef MultiPhaseBaseExtensiveQuantities<TypeTag> MultiPhaseParent;
     typedef BlackOilSolventExtensiveQuantities<TypeTag> SolventParent;
+    typedef BlackOilPolymerExtensiveQuantities<TypeTag> PolymerParent;
+
 
     typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
@@ -71,6 +77,7 @@ public:
         MultiPhaseParent::update(elemCtx, scvfIdx, timeIdx);
 
         asImp_().updateSolvent(elemCtx, scvfIdx, timeIdx);
+        asImp_().updatePolymer(elemCtx, scvfIdx, timeIdx);
     }
 
 protected:

--- a/ewoms/models/blackoil/blackoilextensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilextensivequantities.hh
@@ -53,7 +53,6 @@ class BlackOilExtensiveQuantities
     : public MultiPhaseBaseExtensiveQuantities<TypeTag>
     , public BlackOilSolventExtensiveQuantities<TypeTag>
     , public BlackOilPolymerExtensiveQuantities<TypeTag>
-
 {
     typedef MultiPhaseBaseExtensiveQuantities<TypeTag> MultiPhaseParent;
     typedef BlackOilSolventExtensiveQuantities<TypeTag> SolventParent;

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -35,14 +35,17 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned PVOffset>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset>
 struct BlackOilIndices
 {
     //! Number of solvent components considered
     static const int numSolvents = numSolventsV;
 
+    //! Number of polymer components considered
+    static const int numPolymers = numPolymersV;
+
     //! The number of equations
-    static const int numEq = 3 + numSolvents;
+    static const int numEq = 3 + numSolvents + numPolymers;
 
     ////////
     // Primary variable indices
@@ -65,7 +68,11 @@ struct BlackOilIndices
     static const int compositionSwitchIdx = PVOffset + 2;
 
     //! Index of the primary variable for the first solvent
-    static const int solventSaturationIdx  = PVOffset + 3;
+    static const int solventSaturationIdx  = compositionSwitchIdx + numSolvents;
+
+    //! Index of the primary variable for the first polymer
+    static const int polymerConcentrationIdx  = solventSaturationIdx + numPolymers;
+
     // numSolvents-1 primary variables follow
 
     ////////
@@ -77,7 +84,10 @@ struct BlackOilIndices
     // two continuity equations follow
 
     //! Index of the continuity equation for the first solvent component
-    static const int contiSolventEqIdx = PVOffset + 3;
+    static const int contiSolventEqIdx = PVOffset + 2 + numSolvents;
+
+    //! Index of the continuity equation for the first polymer component
+    static const int contiPolymerEqIdx = contiSolventEqIdx + numPolymers;
     // numSolvents-1 continuity equations follow
 };
 

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -152,8 +152,6 @@ public:
         fluidState_.setSaturation(oilPhaseIdx, So);
 
         asImp_().solventPreSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
-        asImp_().polymerPreSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
-
 
         // now we compute all phase pressures
         Evaluation pC[numPhases];
@@ -178,8 +176,9 @@ public:
         MaterialLaw::relativePermeabilities(mobility_, materialParams, fluidState_);
         Opm::Valgrind::CheckDefined(mobility_);
 
+        // update the Saturation functions for the blackoil extensions.
         asImp_().solventPostSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
-        asImp_().polymerPostSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
+        asImp_().polymerSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
 
 
         Scalar SoMax = elemCtx.model().maxOilSaturation(globalSpaceIdx);

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -176,10 +176,8 @@ public:
         MaterialLaw::relativePermeabilities(mobility_, materialParams, fluidState_);
         Opm::Valgrind::CheckDefined(mobility_);
 
-        // update the Saturation functions for the blackoil extensions.
+        // update the Saturation functions for the blackoil solvent module.
         asImp_().solventPostSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
-        asImp_().polymerSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
-
 
         Scalar SoMax = elemCtx.model().maxOilSaturation(globalSpaceIdx);
 

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -30,6 +30,8 @@
 
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
+#include "blackoilpolymermodules.hh"
+
 
 namespace Ewoms {
 /*!
@@ -65,6 +67,8 @@ class BlackOilLocalResidual : public GET_PROP_TYPE(TypeTag, DiscLocalResidual)
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef BlackOilSolventModule<TypeTag> SolventModule;
+    typedef BlackOilPolymerModule<TypeTag> PolymerModule;
+
 
 public:
     /*!
@@ -109,9 +113,6 @@ public:
             }
         }
 
-        // deal with solvents (if present)
-        SolventModule::addStorage(storage, intQuants);
-
         // convert surface volumes to component masses
         unsigned pvtRegionIdx = intQuants.pvtRegionIndex();
         storage[conti0EqIdx + waterCompIdx] *=
@@ -120,6 +121,12 @@ public:
             FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
         storage[conti0EqIdx + oilCompIdx] *=
             FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+
+        // deal with solvents (if present)
+        SolventModule::addStorage(storage, intQuants);
+
+        // deal with polymer (if present)
+        PolymerModule::addStorage(storage, intQuants);
 
         // deal with the two-phase cases
         if (FluidSystem::numActivePhases() != 3) {
@@ -175,6 +182,9 @@ public:
 
         // deal with solvents (if present)
         SolventModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
+
+        // deal with polymer (if present)
+        PolymerModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
     }
 
     /*!

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -70,6 +70,7 @@ namespace Properties {
 NEW_TYPE_TAG(BlackOilModel, INHERITS_FROM(MultiPhaseBaseModel,
                                           VtkBlackOil,
                                           VtkBlackOilSolvent,
+                                          VtkBlackOilPolymer,
                                           VtkComposition));
 
 //! Set the local residual function

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -29,7 +29,7 @@
 #define EWOMS_BLACK_OIL_POLYMER_MODULE_HH
 
 #include "blackoilproperties.hh"
- // #include <ewoms/io/vtkblackoilpolymermodule.hh>
+#include <ewoms/io/vtkblackoilpolymermodule.hh>
 #include <ewoms/models/common/quantitycallbacks.hh>
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
@@ -365,10 +365,10 @@ public:
     static void registerParameters()
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return;
 
-        //Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
+        Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
     }
 
     /*!
@@ -378,16 +378,16 @@ public:
                                       Simulator& simulator)
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return;
 
-        //model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
+        model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
     }
 
     static bool primaryVarApplies(unsigned pvIdx)
     {
         if (!enablePolymer)
-            // polymers have disabled at compile time
+            // polymers have been disabled at compile time
             return false;
 
         return pvIdx == polymerConcentrationIdx;

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -1,0 +1,1148 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Contains the classes required to extend the black-oil model by polymer.
+ */
+#ifndef EWOMS_BLACK_OIL_POLYMER_MODULE_HH
+#define EWOMS_BLACK_OIL_POLYMER_MODULE_HH
+
+#include "blackoilproperties.hh"
+ // #include <ewoms/io/vtkblackoilpolymermodule.hh>
+#include <ewoms/models/common/quantitycallbacks.hh>
+
+#include <opm/material/common/Tabulated1DFunction.hpp>
+
+#if HAVE_OPM_PARSER
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
+#endif
+
+#include <opm/common/Valgrind.hpp>
+#include <opm/common/Unused.hpp>
+#include <opm/common/ErrorMacros.hpp>
+#include <opm/common/Exceptions.hpp>
+
+#include <dune/common/fvector.hh>
+
+#include <string>
+
+namespace Ewoms {
+/*!
+ * \ingroup BlackOil
+ * \brief Contains the high level supplements required to extend the black oil
+ *        model by polymer.
+ */
+template <class TypeTag, bool enablePolymerV = GET_PROP_VALUE(TypeTag, EnablePolymer)>
+class BlackOilPolymerModule
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, EqVector) EqVector;
+    typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+
+    typedef Opm::MathToolbox<Evaluation> Toolbox;
+
+    typedef typename Opm::Tabulated1DFunction<Scalar> TabulatedFunction;
+
+    static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
+    static constexpr unsigned contiPolymerEqIdx = Indices::contiPolymerEqIdx;
+    static constexpr unsigned contiWaterEqIdx = Indices::conti0EqIdx + FluidSystem::waterCompIdx ;
+    static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
+
+
+    static constexpr unsigned enablePolymer = enablePolymerV;
+    static constexpr unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    static constexpr unsigned numPhases = FluidSystem::numPhases;
+
+public:
+    enum AdsorptionBehaviour { Desorption = 1, NoDesorption = 2 };
+
+#if HAVE_OPM_PARSER
+    /*!
+     * \brief Initialize all internal data structures needed by the polymer module
+     */
+    static void initFromDeck(const Opm::Deck& deck, const Opm::EclipseState& eclState)
+    {
+        // some sanity checks: if polymers are enabled, the POLYMER keyword must be
+        // present, if polymers are disabled the keyword must not be present.
+        if (enablePolymer && !deck.hasKeyword("POLYMER")) {
+            OPM_THROW(std::runtime_error,
+                      "Non-trivial polymer treatment requested at compile time, but "
+                      "the deck does not contain the POLYMER keyword");
+        }
+        else if (!enablePolymer && deck.hasKeyword("POLYMER")) {
+            OPM_THROW(std::runtime_error,
+                      "Polymer treatment disabled at compile time, but the deck "
+                      "contains the POLYMER keyword");
+        }
+
+        if (!deck.hasKeyword("POLYMER"))
+            return; // polymer treatment is supposed to be disabled
+
+        const auto& tableManager = eclState.getTableManager();
+
+        unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+        setNumSatRegions(numSatRegions);
+
+        // initialize the objects which deal with the PLYROCK keyword
+        const auto& plyrockTables = tableManager.getPlyrockTables();
+        if (!plyrockTables.empty()) {
+            assert(numSatRegions == plyrockTables.size());
+            for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++ satRegionIdx) {
+                const auto& plyrockTable = plyrockTables.template getTable<Opm::PlyrockTable>(satRegionIdx);
+                setPlyrock(satRegionIdx,
+                           plyrockTable.getDeadPoreVolumeColumn()[satRegionIdx],
+                           plyrockTable.getResidualResistanceFactorColumn()[satRegionIdx],
+                           plyrockTable.getRockDensityFactorColumn()[satRegionIdx],
+                           static_cast<AdsorptionBehaviour>(plyrockTable.getAdsorbtionIndexColumn()[satRegionIdx]),
+                           plyrockTable.getMaxAdsorbtionColumn()[satRegionIdx]);
+            }
+        } else {
+            OPM_THROW(std::runtime_error, "PLYROCK must be specified in POLYMER runs\n");
+        }
+
+        // initialize the objects which deal with the PLYADS keyword
+        const auto& plyadsTables = tableManager.getPlyadsTables();
+        if (!plyadsTables.empty()) {
+            assert(numSatRegions == plyadsTables.size());
+            for (unsigned satRegionIdx = 0; satRegionIdx < numSatRegions; ++ satRegionIdx) {
+                const auto& plyadsTable = plyadsTables.template getTable<Opm::PlyadsTable>(satRegionIdx);
+                // Copy data
+                const auto& c = plyadsTable.getPolymerConcentrationColumn();
+                const auto& ads = plyadsTable.getAdsorbedPolymerColumn();
+                plyadsAdsorbedPolymer_[satRegionIdx].setXYContainers(c, ads);
+            }
+        } else {
+            OPM_THROW(std::runtime_error, "PLYADS must be specified in POLYMER runs\n");
+        }
+
+
+        unsigned numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+        setNumPvtRegions(numPvtRegions);
+
+        // initialize the objects which deal with the PLYVISC keyword
+        const auto& plyviscTables = tableManager.getPlyviscTables();
+        if (!plyviscTables.empty()) {
+
+            assert(numPvtRegions == plyviscTables.size());
+            for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++ pvtRegionIdx) {
+                const auto& plyadsTable = plyviscTables.template getTable<Opm::PlyviscTable>(pvtRegionIdx);
+                // Copy data
+                const auto& c = plyadsTable.getPolymerConcentrationColumn();
+                const auto& visc = plyadsTable.getViscosityMultiplierColumn();
+                plyviscViscosityMultiplier_[pvtRegionIdx].setXYContainers(c, visc);
+            }
+        } else {
+            OPM_THROW(std::runtime_error, "PLYVISC must be specified in POLYMER runs\n");
+        }
+
+        // initialize the objects which deal with the PLYMAX keyword
+        const auto& plymaxTables = tableManager.getPlymaxTables();
+        unsigned numMixRegions = plymaxTables.size();
+        assert(numMixRegions == 1);// TODO: supports PLMIXNUM
+        setNumMixRegions(numMixRegions);
+        if (!plymaxTables.empty()) {
+            for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++ mixRegionIdx) {
+                const auto& plymaxTable = plymaxTables.template getTable<Opm::PlymaxTable>(mixRegionIdx);
+                setPlymax(mixRegionIdx, plymaxTable.getPolymerConcentrationColumn()[mixRegionIdx]);
+            }
+        } else {
+            OPM_THROW(std::runtime_error, "PLYMAX must be specified in POLYMER runs\n");
+        }
+
+        if (deck.hasKeyword("PLMIXPAR")) {
+            // initialize the objects which deal with the PLMIXPAR keyword
+            for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++ mixRegionIdx) {
+                const auto& plmixparRecord = deck.getKeyword("PLMIXPAR").getRecord(mixRegionIdx);
+                setPlmixpar(mixRegionIdx, plmixparRecord.getItem("TODD_LONGSTAFF").getSIDouble(0));
+            }
+        } else {
+            OPM_THROW(std::runtime_error, "PLMIXPAR must be specified in POLYMER runs\n");
+        }
+
+        hasPlyshlog_ = deck.hasKeyword("PLYSHLOG");
+        hasShrate_ = deck.hasKeyword("SHRATE");
+
+        if (hasPlyshlog_) {
+            const auto& plyshlogTables = tableManager.getPlyshlogTables();
+            assert(numPvtRegions == plyshlogTables.size());
+            plyshlogShearEffectRefMultiplier_.resize(numPvtRegions);
+            plyshlogShearEffectRefLogVelocity_.resize(numPvtRegions);
+            for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++ pvtRegionIdx) {
+                const auto& plyshlogTable = plyshlogTables.template getTable<Opm::PlyshlogTable>(pvtRegionIdx);
+
+                Scalar plyshlogRefPolymerConcentration = plyshlogTable.getRefPolymerConcentration();
+                std::vector<double> waterVelocity = plyshlogTable.getWaterVelocityColumn().vectorCopy();
+                std::vector<double> shearMultiplier = plyshlogTable.getShearMultiplierColumn().vectorCopy();
+
+                // do the unit version here for the waterVelocity
+                Opm::UnitSystem unitSystem = deck.getActiveUnitSystem();
+                double siFactor = hasShrate_? unitSystem.parse("1/Time").getSIScaling() : unitSystem.parse("Length/Time").getSIScaling();
+                for (size_t i = 0; i < waterVelocity.size(); ++i ) {
+                    waterVelocity[i] *= siFactor;
+                    waterVelocity[i] = std::log(waterVelocity[i]);
+                }
+
+                Scalar refViscMult = plyviscViscosityMultiplier_[pvtRegionIdx].eval(plyshlogRefPolymerConcentration, /*extrapolate=*/true);
+                // convert the table using referece conditions
+                for (size_t i = 0; i < waterVelocity.size(); ++i ) {
+                    shearMultiplier[i] *= refViscMult;
+                    shearMultiplier[i] -= 1;
+                    shearMultiplier[i] /= (refViscMult - 1);
+                    shearMultiplier[i] = shearMultiplier[i];
+                }
+                plyshlogShearEffectRefMultiplier_[pvtRegionIdx].resize(waterVelocity.size());
+                plyshlogShearEffectRefLogVelocity_[pvtRegionIdx].resize(waterVelocity.size());
+
+                for (size_t i = 0; i < waterVelocity.size(); ++i ) {
+                    plyshlogShearEffectRefMultiplier_[pvtRegionIdx][i] = shearMultiplier[i];
+                    plyshlogShearEffectRefLogVelocity_[pvtRegionIdx][i] = waterVelocity[i];
+                }
+            }
+        }
+
+        if (hasShrate_) {
+            if(!hasPlyshlog_) {
+                OPM_THROW(std::runtime_error, "PLYSHLOG must be specified if SHRATE is used in POLYMER runs\n");
+            }
+            const auto& shrateKeyword = deck.getKeyword("SHRATE");
+            std::vector<double> shrateFromDeck = shrateKeyword.getSIDoubleData();
+            shrate_.resize(numPvtRegions);
+            for (unsigned pvtRegionIdx = 0; pvtRegionIdx < numPvtRegions; ++ pvtRegionIdx) {
+                if (shrateFromDeck.size() == 0) {
+                    shrate_[pvtRegionIdx] = 4.8; //default;
+                } else if (shrateFromDeck.size() == numPvtRegions) {
+                    shrate_[pvtRegionIdx] = shrateKeyword.getSIDoubleData()[pvtRegionIdx];
+                } else {
+                    OPM_THROW(std::runtime_error, "SHRATE must either have 0 or number of NUMPVT entries\n");
+                }
+            }
+        }
+
+    }
+#endif
+
+    /*!
+     * \brief Specify the number of satuation regions.
+     *
+     * This must be called before setting the PLYROCK and PLYADS of any region.
+     */
+    static void setNumSatRegions(unsigned numRegions)
+    {
+        plyrockDeadPoreVolume_.resize(numRegions);
+        plyrockResidualResistanceFactor_.resize(numRegions);
+        plyrockRockDensityFactor_.resize(numRegions);
+        plyrockAdsorbtionIndex_.resize(numRegions);
+        plyrockMaxAdsorbtion_.resize(numRegions);
+        plyadsAdsorbedPolymer_.resize(numRegions);
+    }
+
+    /*!
+     * \brief Specify the polymer rock properties a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    static void setPlyrock(unsigned satRegionIdx,
+                           const Scalar& plyrockDeadPoreVolume,
+                           const Scalar& plyrockResidualResistanceFactor,
+                           const Scalar& plyrockRockDensityFactor,
+                           const Scalar& plyrockAdsorbtionIndex,
+                           const Scalar& plyrockMaxAdsorbtion)
+    {
+        plyrockDeadPoreVolume_[satRegionIdx] = plyrockDeadPoreVolume;
+        plyrockResidualResistanceFactor_[satRegionIdx] = plyrockResidualResistanceFactor;
+        plyrockRockDensityFactor_[satRegionIdx] = plyrockRockDensityFactor;
+        plyrockAdsorbtionIndex_[satRegionIdx] = plyrockAdsorbtionIndex;
+        plyrockMaxAdsorbtion_[satRegionIdx] = plyrockMaxAdsorbtion;
+    }
+
+    /*!
+     * \brief Specify the polymer rock properties a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    static void setAdsrock(unsigned satRegionIdx,
+                           const TabulatedFunction& plyadsAdsorbedPolymer)
+    {
+        plyadsAdsorbedPolymer_[satRegionIdx] = plyadsAdsorbedPolymer;
+    }
+
+    /*!
+     * \brief Specify the number of pvt regions.
+     *
+     * This must be called before setting the PLYVISC of any region.
+     */
+    static void setNumPvtRegions(unsigned numRegions)
+    {
+        plyviscViscosityMultiplier_.resize(numRegions);
+    }
+
+    /*!
+     * \brief Specify the polymer viscosity a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    static void setPlyvisc(unsigned satRegionIdx,
+                           const TabulatedFunction& plyviscViscosityMultiplier)
+    {
+        plyviscViscosityMultiplier_[satRegionIdx] = plyviscViscosityMultiplier;
+    }
+
+    /*!
+     * \brief Specify the number of mix regions.
+     *
+     * This must be called before setting the PLYMAC and PLMIXPAR of any region.
+     */
+    static void setNumMixRegions(unsigned numRegions)
+    {
+        plymaxCmax_.resize(numRegions);
+        plymixparTL_.resize(numRegions);
+    }
+
+    /*!
+     * \brief Specify the maximum polymer concentration a single region.
+     *
+     * The index of specified here must be in range [0, numMixRegionIdx)
+     */
+    static void setPlymax(unsigned mixRegionIdx,
+                           const Scalar& plymaxCmax)
+    {
+        plymaxCmax_[mixRegionIdx] = plymaxCmax;
+    }
+
+    /*!
+     * \brief Specify the maximum polymer concentration a single region.
+     *
+     * The index of specified here must be in range [0, numMixRegionIdx)
+     */
+    static void setPlmixpar(unsigned mixRegionIdx,
+                           const Scalar& plymixparTL)
+    {
+        plymixparTL_[mixRegionIdx] = plymixparTL;
+    }
+
+
+
+    /*!
+     * \brief Register all run-time parameters for the black-oil polymer module.
+     */
+    static void registerParameters()
+    {
+        if (!enablePolymer)
+            // polymers have disabled at compile time
+            return;
+
+        //Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
+    }
+
+    /*!
+     * \brief Register all polymer specific VTK and ECL output modules.
+     */
+    static void registerOutputModules(Model& model,
+                                      Simulator& simulator)
+    {
+        if (!enablePolymer)
+            // polymers have disabled at compile time
+            return;
+
+        //model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
+    }
+
+    static bool primaryVarApplies(unsigned pvIdx)
+    {
+        if (!enablePolymer)
+            // polymers have disabled at compile time
+            return false;
+
+        return pvIdx == polymerConcentrationIdx;
+    }
+
+    static std::string primaryVarName(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+        assert(primaryVarApplies(pvIdx));
+
+        return "saturation_polymer";
+    }
+
+    static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+        assert(primaryVarApplies(pvIdx));
+
+        // TODO: it may be beneficial to chose this differently.
+        return static_cast<Scalar>(1.0);
+    }
+
+    static bool eqApplies(unsigned eqIdx)
+    {
+        if (!enablePolymer)
+            return false;
+
+        return eqIdx == contiPolymerEqIdx;
+    }
+
+    static std::string eqName(unsigned eqIdx OPM_OPTIM_UNUSED)
+    {
+        assert(eqApplies(eqIdx));
+
+        return "conti^polymer";
+    }
+
+    static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
+    {
+        assert(eqApplies(eqIdx));
+
+        // TODO: it may be beneficial to chose this differently.
+        return static_cast<Scalar>(1.0);
+    }
+
+    // must be called after water storage is computed
+    template <class LhsEval>
+    static void addStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                           const IntensiveQuantities& intQuants)
+    {
+        if (!enablePolymer)
+            return;
+
+        const auto& fs = intQuants.fluidState();
+
+        LhsEval surfaceVolumeWater =
+            Toolbox::template decay<LhsEval>(fs.saturation(waterPhaseIdx))
+            * Toolbox::template decay<LhsEval>(fs.invB(waterPhaseIdx))
+            * Toolbox::template decay<LhsEval>(intQuants.porosity());
+
+        // avoid singular matrix if no water is present.
+        surfaceVolumeWater = Opm::max(surfaceVolumeWater, 1e-10);
+
+        // polymer in water phase
+        storage[contiPolymerEqIdx] += surfaceVolumeWater
+                * Toolbox::template decay<LhsEval>(intQuants.polymerConcentration())
+                * Toolbox::template decay<LhsEval>(intQuants.polymerAlivePoreSpace());
+
+        // polymer in solid phase
+        storage[contiPolymerEqIdx] +=
+                Toolbox::template decay<LhsEval>(1.0 - intQuants.porosity())
+                * Toolbox::template decay<LhsEval>(intQuants.polymerRockDensity())
+                * Toolbox::template decay<LhsEval>(intQuants.polymerAdsorption());
+
+    }
+
+    static void computeFlux(RateVector& flux,
+                            const ElementContext& elemCtx,
+                            unsigned scvfIdx,
+                            unsigned timeIdx)
+
+    {
+        if (!enablePolymer)
+            return;
+
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+
+        unsigned upIdx = extQuants.upstreamIndex(FluidSystem::waterPhaseIdx);
+        unsigned inIdx = extQuants.interiorIndex();
+        const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+
+        if (upIdx == inIdx) {
+            flux[contiPolymerEqIdx] =
+                    extQuants.volumeFlux(waterPhaseIdx)
+                    *up.fluidState().invB(waterPhaseIdx)
+                    *up.polymerViscosityCorrection()
+                    /extQuants.polymerShearFactor()
+                    *up.polymerConcentration();
+
+            // modify water
+            flux[contiWaterEqIdx] /=
+                    extQuants.waterShearFactor();
+        } else {
+            flux[contiPolymerEqIdx] =
+                    extQuants.volumeFlux(waterPhaseIdx)
+                    *Opm::decay<Scalar>(up.fluidState().invB(waterPhaseIdx))
+                    *Opm::decay<Scalar>(up.polymerViscosityCorrection())
+                    /Opm::decay<Scalar>(extQuants.polymerShearFactor())
+                    *Opm::decay<Scalar>(up.polymerConcentration());
+
+            // modify water
+            flux[contiWaterEqIdx] /=
+                    Opm::decay<Scalar>(extQuants.waterShearFactor());
+        }
+
+    }
+
+    /*!
+     * \brief Assign the polymer specific primary variables to a PrimaryVariables object
+     */
+    static void assignPrimaryVars(PrimaryVariables& priVars,
+                                  Scalar polymerSaturation)
+    {
+        if (!enablePolymer)
+            return;
+
+        priVars[polymerConcentrationIdx] = polymerSaturation;
+    }
+
+    /*!
+     * \brief Do a Newton-Raphson update the primary variables of the polymers.
+     */
+    static void updatePrimaryVars(PrimaryVariables& newPv,
+                                  const PrimaryVariables& oldPv,
+                                  const EqVector& delta)
+    {
+        if (!enablePolymer)
+            return;
+
+        // do a plain unchopped Newton update
+        newPv[polymerConcentrationIdx] = oldPv[polymerConcentrationIdx] - delta[polymerConcentrationIdx];
+    }
+
+    /*!
+     * \brief Return how much a Newton-Raphson update is considered an error
+     */
+    static Scalar computeUpdateError(const PrimaryVariables& oldPv OPM_UNUSED,
+                                     const EqVector& delta OPM_UNUSED)
+    {
+        // do not consider consider the cange of polymer primary variables for
+        // convergence
+        // TODO: maybe this should be changed
+        return static_cast<Scalar>(0.0);
+    }
+
+    /*!
+     * \brief Return how much a residual is considered an error
+     */
+    static Scalar computeResidualError(const EqVector& resid)
+    {
+        // do not weight the residual of polymers when it comes to convergence
+        return std::abs(Toolbox::scalarValue(resid[contiPolymerEqIdx]));
+    }
+
+    template <class DofEntity>
+    static void serializeEntity(const Model& model, std::ostream& outstream, const DofEntity& dof)
+    {
+        if (!enablePolymer)
+            return;
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+        unsigned dofIdx = model.dofMapper().index(dof);
+#else
+        unsigned dofIdx = model.dofMapper().map(dof);
+#endif
+
+        const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
+        outstream << priVars[polymerConcentrationIdx];
+    }
+
+    template <class DofEntity>
+    static void deserializeEntity(Model& model, std::istream& instream, const DofEntity& dof)
+    {
+        if (!enablePolymer)
+            return;
+
+#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
+        unsigned dofIdx = model.dofMapper().index(dof);
+#else
+        unsigned dofIdx = model.dofMapper().map(dof);
+#endif
+
+        PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
+        PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
+
+        instream >> priVars0[polymerConcentrationIdx];
+
+        // set the primary variables for the beginning of the current time step.
+        priVars1 = priVars0[polymerConcentrationIdx];
+    }
+
+    static const Scalar& plyrockDeadPoreVolume(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyrockDeadPoreVolume_[satnumRegionIdx];
+    }
+
+    static const Scalar& plyrockResidualResistanceFactor(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyrockResidualResistanceFactor_[satnumRegionIdx];
+    }
+
+    static const Scalar& plyrockRockDensityFactor(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyrockRockDensityFactor_[satnumRegionIdx];
+    }
+
+    static const Scalar& plyrockAdsorbtionIndex(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyrockAdsorbtionIndex_[satnumRegionIdx];
+    }
+
+    static const Scalar& plyrockMaxAdsorbtion(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyrockMaxAdsorbtion_[satnumRegionIdx];
+    }
+
+    static const TabulatedFunction& plyadsAdsorbedPolymer(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyadsAdsorbedPolymer_[satnumRegionIdx];
+    }
+
+    static const TabulatedFunction& plyviscViscosityMultiplier(const ElementContext& elemCtx,
+                                            unsigned scvIdx,
+                                            unsigned timeIdx)
+    {
+        unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plyviscViscosityMultiplier_[pvtnumRegionIdx];
+    }
+
+    static const Scalar& plymaxCmax(const ElementContext& elemCtx,
+                                    unsigned scvIdx,
+                                    unsigned timeIdx)
+    {
+        unsigned polymerMixRegionIdx = 0; //elemCtx.problem().polymerMixRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plymaxCmax_[polymerMixRegionIdx];
+    }
+
+    static const Scalar& plymixparTL(const ElementContext& elemCtx,
+                                    unsigned scvIdx,
+                                    unsigned timeIdx)
+    {
+        unsigned polymerMixRegionIdx = 0; //elemCtx.problem().polymerMixRegionIndex(elemCtx, scvIdx, timeIdx);
+        return plymixparTL_[polymerMixRegionIdx];
+    }
+
+    static bool hasPlyshlog()
+    {
+        return hasPlyshlog_;
+    }
+
+    static bool hasShrate()
+    {
+        return hasShrate_;
+    }
+
+    static const Scalar& shrate(unsigned pvtnumRegionIdx)
+    {
+        return shrate_[pvtnumRegionIdx];
+    }
+
+    /*!
+     * \brief Computes the shear factor
+     *
+     * Input is polymer concentration and either the water velocity or the shrate if has_shrate_ is true.
+     * The pvtnumRegionIdx is needed to make sure the right table is used.
+     */
+    template <class Evaluation>
+    static Evaluation computeShearFactor(const Evaluation& polymerConcentration,
+                                   unsigned pvtnumRegionIdx,
+                                   const Evaluation& v0) {
+
+        const auto& viscosityMultiplierTable = plyviscViscosityMultiplier_[pvtnumRegionIdx];
+        Scalar viscosityMultiplier =  Opm::scalarValue( viscosityMultiplierTable.eval(polymerConcentration, /*extrapolate=*/true) );
+
+        const Scalar eps = 1e-14;
+        // return 1.0 if the polymer has no effect on the water.
+        if ( std::abs( (viscosityMultiplier - 1.0) ) < eps){
+            return Evaluation(1.0);
+        }
+
+        const std::vector<Scalar>& shearEffectRefLogVelocity = plyshlogShearEffectRefLogVelocity_[pvtnumRegionIdx];
+        auto v0AbsLog = Opm::log(Opm::abs(v0));
+        // return 1.0 if the velocity /sharte is smaller than the first velocity entry.
+        if (v0AbsLog.value() < shearEffectRefLogVelocity[0])
+            return  Evaluation(1.0);
+
+        // compute shear factor from input
+        // Z = (1 + (P - 1) * M(v) ) / P
+        // where M(v) is computed from user input
+        // and P = viscosityMultiplier
+        const std::vector<Scalar>& shearEffectRefMultiplier = plyshlogShearEffectRefMultiplier_[pvtnumRegionIdx];
+        int numTableEntries = shearEffectRefLogVelocity.size();
+        assert (shearEffectRefMultiplier.size() == numTableEntries);
+
+        std::vector<Scalar> shearEffectMultiplier(numTableEntries, 1.0);
+        for (int i = 0; i < numTableEntries; ++i) {
+            shearEffectMultiplier[i] = (1.0 + (viscosityMultiplier - 1.0)*shearEffectRefMultiplier[i]) / viscosityMultiplier;
+            shearEffectMultiplier[i] = Opm::log(shearEffectMultiplier[i]);
+        }
+        // store the log velocity and log multipliers in a table for easy look up and
+        // linear interpolation in the log space.
+        TabulatedFunction logShearEffectMultiplier = TabulatedFunction(numTableEntries, shearEffectRefLogVelocity, shearEffectMultiplier );
+
+        // Find sheared velocity (v) that satisfies
+        // F = log(v) + log (Z) - log(v0) = 0;
+
+        // Set up the function
+        // u = log(v)
+        auto F = [&logShearEffectMultiplier, &v0AbsLog](const auto& u) {
+            return u + logShearEffectMultiplier.eval(u, true) - v0AbsLog;
+        };
+        // and its derivative
+        auto dF = [&logShearEffectMultiplier](const auto& u) {
+            return 1 + logShearEffectMultiplier.evalDerivative(u, true);
+        };
+
+        // Solve F = 0 using Newton
+        // Use log(v0) as inital value for u
+        auto u = v0AbsLog;
+        bool converged = false;
+        for (int i = 0; i < 20; ++i ) {
+            auto f = F(u);
+            auto df = dF(u);
+            u -= f/df;
+            if (std::abs(Opm::scalarValue(f)) < 1e-12) {
+                converged = true;
+                break;
+            }
+        }
+        if (!converged) {
+             OPM_THROW(std::runtime_error, "Not able to compute shear velocity. \n");
+        }
+
+        // return the shear factor
+        return Opm::exp( logShearEffectMultiplier.eval(u, /*extrapolate=*/true) );
+
+    }
+
+
+
+
+private:
+    static std::vector<Scalar> plyrockDeadPoreVolume_;
+    static std::vector<Scalar> plyrockResidualResistanceFactor_;
+    static std::vector<Scalar> plyrockRockDensityFactor_;
+    static std::vector<Scalar> plyrockAdsorbtionIndex_;
+    static std::vector<Scalar> plyrockMaxAdsorbtion_;
+    static std::vector<TabulatedFunction> plyadsAdsorbedPolymer_;
+    static std::vector<TabulatedFunction> plyviscViscosityMultiplier_;
+    static std::vector<Scalar> plymaxCmax_;
+    static std::vector<Scalar> plymixparTL_;
+    static std::vector<std::vector<Scalar>> plyshlogShearEffectRefMultiplier_;
+    static std::vector<std::vector<Scalar>> plyshlogShearEffectRefLogVelocity_;
+    static std::vector<Scalar> shrate_;
+    static bool hasShrate_;
+    static bool hasPlyshlog_;
+
+};
+
+
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockDeadPoreVolume_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockResidualResistanceFactor_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockRockDensityFactor_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockAdsorbtionIndex_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockMaxAdsorbtion_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyadsAdsorbedPolymer_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyviscViscosityMultiplier_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plymaxCmax_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plymixparTL_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefMultiplier_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefLogVelocity_;
+
+template <class TypeTag, bool enablePolymerV>
+std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+BlackOilPolymerModule<TypeTag, enablePolymerV>::shrate_;
+
+template <class TypeTag, bool enablePolymerV>
+bool
+BlackOilPolymerModule<TypeTag, enablePolymerV>::hasShrate_;
+
+template <class TypeTag, bool enablePolymerV>
+bool
+BlackOilPolymerModule<TypeTag, enablePolymerV>::hasPlyshlog_;
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilPolymerIntensiveQuantities
+ *
+ * \brief Provides the volumetric quantities required for the equations needed by the
+ *        polymers extension of the black-oil model.
+ */
+template <class TypeTag, bool enablePolymerV = GET_PROP_VALUE(TypeTag, EnablePolymer)>
+class BlackOilPolymerIntensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    typedef BlackOilPolymerModule<TypeTag> PolymerModule;
+
+    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+    static constexpr int polymerConcentrationIdx = Indices::polymerConcentrationIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+
+
+public:
+    /*!
+     * \brief Called before the saturation functions are doing their magic
+     *
+     */
+    void polymerPreSatFuncUpdate_(const ElementContext& elemCtx OPM_UNUSED,
+                                  unsigned scvIdx OPM_UNUSED,
+                                  unsigned timeIdx OPM_UNUSED)
+    { }
+
+    /*!
+     * \brief Called after the saturation functions have been doing their magic
+     *
+     * After this function, all saturations, pressures
+     * and relative permeabilities must be final. (i.e., the "hydrocarbon
+     * saturations".)
+     */
+    void polymerPostSatFuncUpdate_(const ElementContext& elemCtx,
+                                   unsigned dofIdx,
+                                   unsigned timeIdx)
+    {
+        const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        polymerConcentration_ = priVars.makeEvaluation(polymerConcentrationIdx, timeIdx);
+        const Scalar cmax = PolymerModule::plymaxCmax(elemCtx, dofIdx, timeIdx);
+
+        // permeability reduction due to polymer
+        const Scalar& maxAdsorbtion = PolymerModule::plyrockMaxAdsorbtion(elemCtx, dofIdx, timeIdx);
+        const auto& plyadsAdsorbedPolymer = PolymerModule::plyadsAdsorbedPolymer(elemCtx, dofIdx, timeIdx);
+        polymerAdsorption_ = plyadsAdsorbedPolymer.eval(polymerConcentration_, /*extrapolate=*/true);
+        if (PolymerModule::plyrockAdsorbtionIndex(elemCtx, dofIdx, timeIdx) == PolymerModule::NoDesorption ) {
+                const Scalar& maxPolymerAdsorption = elemCtx.problem().maxPolymerAdsorption(elemCtx, dofIdx, timeIdx);
+                polymerAdsorption_ = std::max(Evaluation(maxPolymerAdsorption) , polymerAdsorption_);
+        }
+
+        // compute resitanceFactor
+        const Scalar& residualResistanceFactor = PolymerModule::plyrockResidualResistanceFactor(elemCtx, dofIdx, timeIdx);
+        const Evaluation resistanceFactor = 1.0 + (residualResistanceFactor - 1.0) * polymerAdsorption_ / maxAdsorbtion;
+
+        // compute effective viscosities
+        auto& fs = asImp_().fluidState_;
+        const Evaluation& muWater = fs.viscosity(waterPhaseIdx);
+        const auto& viscosityMultiplier = PolymerModule::plyviscViscosityMultiplier(elemCtx, dofIdx, timeIdx);
+        Evaluation viscosityMixture = viscosityMultiplier.eval(polymerConcentration_, /*extrapolate=*/true) * muWater;
+
+        // Do the Todd-Longstaff mixing
+        const Scalar plymixparTL = PolymerModule::plymixparTL(elemCtx, dofIdx, timeIdx);
+        Evaluation viscosityPolymer = viscosityMultiplier.eval(cmax, /*extrapolate=*/true) * muWater;
+        Evaluation viscosityPolymerEffective = pow(viscosityMixture, plymixparTL) * pow(viscosityPolymer, 1.0 - plymixparTL);
+        Evaluation viscosityWaterEffective = pow(viscosityMixture, plymixparTL) * pow(muWater, 1.0 - plymixparTL);
+
+        Evaluation cbar = polymerConcentration_ / cmax;
+        // waterViscosity / effectiveWaterViscosity
+        waterViscosityCorrection_ = muWater * ( (1.0 - cbar) / viscosityWaterEffective + cbar / viscosityPolymerEffective );
+
+        // adjust water mobility
+        Evaluation& mobWater = asImp_().mobility_[waterPhaseIdx];
+        mobWater *= waterViscosityCorrection_ / resistanceFactor;
+
+        // effectiveWaterViscosity / effectivePolymerViscosity
+        polymerViscosityCorrection_ =  (muWater / waterViscosityCorrection_) / viscosityPolymerEffective;
+
+    }
+
+    /*!
+     * \brief Update the intensive properties needed to handle polymers from the
+     *        primary variables
+     *
+     */
+    void polymerPropertiesUpdate_(const ElementContext& elemCtx,
+                                  unsigned scvIdx,
+                                  unsigned timeIdx)
+    {
+        // update rock properties
+        polymerAlivePoreSpace_ = 1.0 - PolymerModule::plyrockDeadPoreVolume(elemCtx, scvIdx, timeIdx);
+        polymerRockDensity_ = PolymerModule::plyrockRockDensityFactor(elemCtx, scvIdx, timeIdx);
+    }
+
+    const Evaluation& polymerConcentration() const
+    { return polymerConcentration_; }
+
+    const Scalar& polymerAlivePoreSpace() const
+    { return polymerAlivePoreSpace_; }
+
+    const Evaluation& polymerAdsorption() const
+    { return polymerAdsorption_; }
+
+    const Scalar& polymerRockDensity() const
+    { return polymerRockDensity_; }
+
+    // effectiveWaterViscosity / effectivePolymerViscosity
+    const Evaluation& polymerViscosityCorrection() const
+    { return polymerViscosityCorrection_; }
+
+    // waterViscosity / effectiveWaterViscosity
+    const Evaluation& waterViscosityCorrection() const
+    { return waterViscosityCorrection_; }
+
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation polymerConcentration_;
+    Scalar polymerAlivePoreSpace_;
+    Scalar polymerRockDensity_;
+    Evaluation polymerAdsorption_;
+    Evaluation polymerViscosityCorrection_;
+    Evaluation waterViscosityCorrection_;
+
+
+};
+
+template <class TypeTag>
+class BlackOilPolymerIntensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+
+public:
+    void polymerPreSatFuncUpdate_(const ElementContext& elemCtx OPM_UNUSED,
+                                  unsigned scvIdx OPM_UNUSED,
+                                  unsigned timeIdx OPM_UNUSED)
+    { }
+
+    void polymerPostSatFuncUpdate_(const ElementContext& elemCtx OPM_UNUSED,
+                                   unsigned scvIdx OPM_UNUSED,
+                                   unsigned timeIdx OPM_UNUSED)
+    { }
+
+    void polymerPropertiesUpdate_(const ElementContext& elemCtx OPM_UNUSED,
+                                  unsigned scvIdx OPM_UNUSED,
+                                  unsigned timeIdx OPM_UNUSED)
+    { }
+
+    const Evaluation& polymerConcentration() const
+    { OPM_THROW(std::runtime_error, "polymerConcentration() called but polymers are disabled"); }
+
+    const Evaluation& polymerAlivePoreSpace() const
+    { OPM_THROW(std::runtime_error, "polymerAlivePoreSpace() called but polymers are disabled"); }
+
+    const Evaluation& polymerAdsorption() const
+    { OPM_THROW(std::runtime_error, "polymerAdsorption() called but polymers are disabled"); }
+
+    const Evaluation& polymerRockDensity() const
+    { OPM_THROW(std::runtime_error, "polymerRockDensity() called but polymers are disabled"); }
+
+    const Evaluation& polymerViscosityCorrection() const
+    { OPM_THROW(std::runtime_error, "polymerViscosityCorrection() called but polymers are disabled"); }
+
+    const Evaluation& waterViscosityCorrection() const
+    { OPM_THROW(std::runtime_error, "waterViscosityCorrection() called but polymers are disabled"); }
+
+
+};
+
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilPolymerExtensiveQuantities
+ *
+ * \brief Provides the polymer specific extensive quantities to the generic black-oil
+ *        module's extensive quantities.
+ */
+template <class TypeTag, bool enablePolymerV = GET_PROP_VALUE(TypeTag, EnablePolymer)>
+class BlackOilPolymerExtensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+
+    typedef Opm::MathToolbox<Evaluation> Toolbox;
+
+    typedef BlackOilPolymerModule<TypeTag> PolymerModule;
+
+
+    static constexpr unsigned gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int dimWorld = GridView::dimensionworld;
+    static constexpr unsigned waterPhaseIdx =  FluidSystem::waterPhaseIdx;
+
+    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
+    typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
+
+public:
+
+    /*!
+     * \brief Method which calculates the shear factor based on flow velocity
+     */
+    template <class Dummy = bool> // we need to make this method a template to avoid
+                                  // compiler errors if it is not instantiated!
+    void updateShearMultipliers(const ElementContext& elemCtx,
+                               unsigned scvfIdx,
+                               unsigned timeIdx)
+    {
+
+        waterShearFactor_ = 1.0;
+        polymerShearFactor_ = 1.0;
+
+        if (!PolymerModule::hasPlyshlog())
+            return;
+
+        const ExtensiveQuantities& extQuants = asImp_();
+        unsigned upIdx = extQuants.upstreamIndex(waterPhaseIdx);
+        unsigned interiorDofIdx = extQuants.interiorIndex();
+        unsigned exteriorDofIdx = extQuants.exteriorIndex();
+        const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+        const auto& intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx, timeIdx);
+        const auto& intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx, timeIdx);
+
+        // compute water velocity from flux
+        Evaluation poroAvg = intQuantsIn.porosity()*0.5 + intQuantsEx.porosity()*0.5;
+        unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvfIdx, timeIdx);
+        const Evaluation& Sw = up.fluidState().saturation(waterPhaseIdx);
+        unsigned cellIdx = elemCtx.globalSpaceIndex(scvfIdx, timeIdx);
+        const auto& materialLawManager = elemCtx.problem().materialLawManager();
+        const auto& scaledDrainageInfo =
+                materialLawManager->oilWaterScaledEpsInfoDrainage(cellIdx);
+        const Scalar& Swcr = scaledDrainageInfo.Swcr;
+
+        // guard against zero porosity and no mobile water
+        Evaluation denom = Opm::max(poroAvg * (Sw - Swcr), 1e-12);
+        Evaluation waterVolumeVelocity = extQuants.volumeFlux(waterPhaseIdx) / denom;
+
+        // if shrate is specified. Compute shrate based on the water velocity
+        if (PolymerModule::hasShrate()) {
+            const Evaluation& relWater = up.relativePermeability(waterPhaseIdx);
+            Scalar trans = elemCtx.problem().transmissibility(elemCtx, interiorDofIdx, exteriorDofIdx);
+            if (trans > 0.0) {
+                Scalar faceArea = elemCtx.stencil(timeIdx).interiorFace(scvfIdx).area();
+                auto dist = elemCtx.pos(interiorDofIdx, timeIdx ) -  elemCtx.pos(exteriorDofIdx, timeIdx );
+                // compute permeability from transmissibility.
+                Scalar absPerm = trans / faceArea * dist.two_norm();
+                waterVolumeVelocity *= PolymerModule::shrate(pvtnumRegionIdx) * Opm::sqrt( poroAvg * Sw / (relWater * absPerm )    ) ;
+                assert(Opm::isfinite(waterVolumeVelocity));
+            }
+        }
+
+        // compute share factors for water and polymer
+        waterShearFactor_ = PolymerModule::computeShearFactor(up.polymerConcentration(), pvtnumRegionIdx, waterVolumeVelocity);
+        polymerShearFactor_ = PolymerModule::computeShearFactor(up.polymerConcentration(), pvtnumRegionIdx, waterVolumeVelocity * up.polymerViscosityCorrection());
+
+    }
+
+    const Evaluation& polymerShearFactor() const
+    { return polymerShearFactor_; }
+
+    const Evaluation& waterShearFactor() const
+    { return waterShearFactor_; }
+
+
+private:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation polymerShearFactor_;
+    Evaluation waterShearFactor_;
+
+};
+
+template <class TypeTag>
+class BlackOilPolymerExtensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+
+public:
+    void updateShearMultipliers(const ElementContext& elemCtx OPM_UNUSED,
+                              unsigned scvfIdx OPM_UNUSED,
+                              unsigned timeIdx OPM_UNUSED)
+    { }
+
+    const Evaluation& polymerShearFactor() const
+    { OPM_THROW(std::runtime_error, "polymerShearFactor() called but polymers are disabled"); }
+
+    const Evaluation& waterShearFactor() const
+    { OPM_THROW(std::runtime_error, "waterShearFactor() called but polymers are disabled"); }
+};
+
+
+} // namespace Ewoms
+
+#endif

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -1048,9 +1048,28 @@ class BlackOilPolymerExtensiveQuantities
     typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
 
 public:
+    /*!
+     * \brief Method which calculates the shear factor based on flow velocity
+     *
+     * This is the variant of the method which assumes that the problem is specified
+     * using permeabilities, i.e., *not* via transmissibilities.
+     */
+    template <class Dummy = bool> // we need to make this method a template to avoid
+                                  // compiler errors if it is not instantiated!
+    void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+                                    unsigned scvfIdx OPM_UNUSED,
+                                    unsigned timeIdx OPM_UNUSED)
+    {
+        OPM_THROW(std::runtime_error,
+                  "The extension of the blackoil model for polymers is not yet "
+                  "implemented for problems specified using permeabilities.");
+    }
 
     /*!
      * \brief Method which calculates the shear factor based on flow velocity
+     *
+     * This is the variant of the method which assumes that the problem is specified
+     * using transmissibilities, i.e., *not* via permeabilities.
      */
     template <class Dummy = bool> // we need to make this method a template to avoid
                                   // compiler errors if it is not instantiated!
@@ -1133,6 +1152,11 @@ public:
     void updateShearMultipliers(const ElementContext& elemCtx OPM_UNUSED,
                               unsigned scvfIdx OPM_UNUSED,
                               unsigned timeIdx OPM_UNUSED)
+    { }
+
+    void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+                                    unsigned scvfIdx OPM_UNUSED,
+                                    unsigned timeIdx OPM_UNUSED)
     { }
 
     const Evaluation& polymerShearFactor() const

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -175,7 +175,6 @@ public:
         // initialize the objects which deal with the PLYMAX keyword
         const auto& plymaxTables = tableManager.getPlymaxTables();
         unsigned numMixRegions = plymaxTables.size();
-        assert(numMixRegions == 1);// TODO: supports PLMIXNUM
         setNumMixRegions(numMixRegions);
         if (!plymaxTables.empty()) {
             for (unsigned mixRegionIdx = 0; mixRegionIdx < numMixRegions; ++ mixRegionIdx) {
@@ -903,8 +902,7 @@ public:
         waterViscosityCorrection_ = muWater * ( (1.0 - cbar) / viscosityWaterEffective + cbar / viscosityPolymerEffective );
 
         // adjust water mobility
-        Evaluation& mobWater = asImp_().mobility_[waterPhaseIdx];
-        mobWater *= waterViscosityCorrection_ / resistanceFactor;
+        asImp_().mobility_[waterPhaseIdx] *= waterViscosityCorrection_ / resistanceFactor;
 
         // effectiveWaterViscosity / effectivePolymerViscosity
         polymerViscosityCorrection_ =  (muWater / waterViscosityCorrection_) / viscosityPolymerEffective;

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -716,7 +716,7 @@ public:
         }
         // store the logarithmic velocity and logarithmic multipliers in a table for easy look up and
         // linear interpolation in the logarithmic space.
-        TabulatedFunction logShearEffectMultiplier = TabulatedFunction(numTableEntries, shearEffectRefLogVelocity, shearEffectMultiplier );
+        TabulatedFunction logShearEffectMultiplier = TabulatedFunction(numTableEntries, shearEffectRefLogVelocity, shearEffectMultiplier, /*bool sortInputs =*/ false );
 
         // Find sheared velocity (v) that satisfies
         // F = log(v) + log (Z) - log(v0) = 0;

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -644,6 +644,11 @@ public:
         return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
     }
 
+    static const TabulatedFunction& plyviscViscosityMultiplierTable(unsigned pvtnumRegionIdx)
+    {
+        return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
+    }
+
     static const Scalar plymaxMaxConcentration(const ElementContext& elemCtx,
                                                unsigned scvIdx,
                                                unsigned timeIdx)

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -370,7 +370,7 @@ public:
             // polymers have disabled at compile time
             return;
 
-        //Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
+        Ewoms::VtkBlackOilPolymerModule<TypeTag>::registerParameters();
     }
 
     /*!
@@ -383,7 +383,7 @@ public:
             // polymers have disabled at compile time
             return;
 
-        //model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
+        model.addOutputModule(new Ewoms::VtkBlackOilPolymerModule<TypeTag>(simulator));
     }
 
     static bool primaryVarApplies(unsigned pvIdx)

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -30,6 +30,7 @@
 
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
+#include "blackoilpolymermodules.hh"
 
 #include <ewoms/disc/common/fvbaseprimaryvariables.hh>
 
@@ -44,6 +45,9 @@
 namespace Ewoms {
 template <class TypeTag, bool enableSolvent>
 class BlackOilSolventModule;
+
+template <class TypeTag, bool enablePolymer>
+class BlackOilPolymerModule;
 
 /*!
  * \ingroup BlackOilModel
@@ -81,6 +85,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     // component indices from the fluid system
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
+    enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
     enum { oilCompIdx = FluidSystem::oilCompIdx };
@@ -88,6 +93,8 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     typedef typename Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldVector<Scalar, numComponents> ComponentVector;
     typedef BlackOilSolventModule<TypeTag, enableSolvent> SolventModule;
+    typedef BlackOilPolymerModule<TypeTag, enablePolymer> PolymerModule;
+
 
     static_assert(numPhases == 3, "The black-oil model assumes three phases!");
     static_assert(numComponents == 3, "The black-oil model assumes three components!");
@@ -240,6 +247,9 @@ public:
 
         // set the primary variables of the solvent module
         SolventModule::assignPrimaryVars(*this, solSat);
+
+        // set the primary variables of the polymer module
+        PolymerModule::assignPrimaryVars(*this, solSat);
     }
 
     /*!
@@ -499,6 +509,14 @@ private:
             return 0.0;
 
         return (*this)[Indices::solventSaturationIdx];
+    }
+
+    Scalar polymerConcentration() const
+    {
+        if (!enablePolymer)
+            return 0.0;
+
+        return (*this)[Indices::polymerConcentrationIdx];
     }
 
     template <class Container>

--- a/ewoms/models/blackoil/blackoilproblem.hh
+++ b/ewoms/models/blackoil/blackoilproblem.hh
@@ -78,6 +78,15 @@ public:
     { return 0; }
 
     /*!
+     * \brief Returns the index of the relevant region for polymer mixing functions
+     */
+    template <class Context>
+    unsigned plmixnumRegionIndex(const Context& context OPM_UNUSED,
+                                 unsigned spaceIdx OPM_UNUSED,
+                                 unsigned timeIdx OPM_UNUSED) const
+    { return 0; }
+
+    /*!
      * \brief Returns the compressibility of the porous medium of a cell
      */
     template <class Context>

--- a/ewoms/models/blackoil/blackoilproblem.hh
+++ b/ewoms/models/blackoil/blackoilproblem.hh
@@ -78,6 +78,15 @@ public:
     { return 0; }
 
     /*!
+     * \brief Returns the index of the relevant region for solvent mixing functions
+     */
+    template <class Context>
+    unsigned miscnumRegionIndex(const Context& context OPM_UNUSED,
+                                unsigned spaceIdx OPM_UNUSED,
+                                unsigned timeIdx OPM_UNUSED) const
+    { return 0; }
+
+    /*!
      * \brief Returns the index of the relevant region for polymer mixing functions
      */
     template <class Context>

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -42,6 +42,8 @@ NEW_PROP_TAG(HeatConductionLaw);
 NEW_PROP_TAG(HeatConductionLawParams);
 //! Enable the ECL-blackoil extension for solvents. ("Second gas")
 NEW_PROP_TAG(EnableSolvent);
+//! Enable the ECL-blackoil extension for polymer.
+NEW_PROP_TAG(EnablePolymer);
 }} // namespace Properties, Ewoms
 
 #endif


### PR DESCRIPTION
Adds a conservation equation for polymer.
Polymer concentration in the water phase is used as primary variable
The polymer influences the viscosity of the water, and leaves gas and oil
unaffected. 

Shear effects can be modeled using the PLYSHLOG and SHRATE keywords. 

