### PR TITLE
add ROCKOPTS support

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -760,6 +760,9 @@ public:
         return pvtnum_[elemIdx];
     }
 
+    const std::vector<int>& pvtRegionArray() const
+    { return pvtnum_; }
+
     /*!
      * \brief Returns the index of the relevant region for thermodynmic properties
      */
@@ -1507,7 +1510,7 @@ private:
 
     EclThresholdPressure<TypeTag> thresholdPressures_;
 
-    std::vector<unsigned short> pvtnum_;
+    std::vector<int> pvtnum_;
     std::vector<unsigned short> satnum_;
     std::vector<unsigned short> miscnum_;
     std::vector<unsigned short> rockTableIdx_;


### PR DESCRIPTION
this adds support for the ROCKOPTS keyword to ebos and it exports the array of PVT region numbers for the compressed grid.

note that the ROCKOPTS stuff accesses the deck object directly because -- as far as I can see -- this keyword is not internalized by EclipseState yet.

I've tested this on norne and it did not seem to change anything.