### PR TITLE
fix some field names of the VTK output module for the solvent blackoil model extension

### DIFF
--- a/ewoms/io/vtkblackoilsolventmodule.hh
+++ b/ewoms/io/vtkblackoilsolventmodule.hh
@@ -189,10 +189,10 @@ public:
             this->commitScalarBuffer_(baseWriter, "density_solvent", solventDensity_);
 
         if (solventViscosityOutput_())
-            this->commitScalarBuffer_(baseWriter, "density_solvent", solventViscosity_);
+            this->commitScalarBuffer_(baseWriter, "viscosity_solvent", solventViscosity_);
 
         if (solventMobilityOutput_())
-            this->commitScalarBuffer_(baseWriter, "density_solvent", solventMobility_);
+            this->commitScalarBuffer_(baseWriter, "mobility_solvent", solventMobility_);
     }
 
 private:


### PR DESCRIPTION
this is kind of trivial, but if you want paraview not to be confused about the files produced with this it is critical.