### PR TITLE
Make BlackoilModel work for two-phases with hardcoded numPhases.

### DIFF
--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -133,7 +133,8 @@ public:
         PolymerModule::addStorage(storage, intQuants);
 
         // deal with the two-phase cases for three-phase model
-        if ( ! compositionSwitchEnabled ) {
+        if ( compositionSwitchEnabled && FluidSystem::numActivePhases() < 3 )
+        {
             assert(FluidSystem::numActivePhases() == 2);
             const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
             if (!FluidSystem::phaseIsActive(oilPhaseIdx)) {

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -64,6 +64,10 @@ class BlackOilLocalResidual : public GET_PROP_TYPE(TypeTag, DiscLocalResidual)
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { oilCompIdx = FluidSystem::oilCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
+    enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
+
+    // if compositionSwitchIdx is negative then this feature is disabled in Indices
+    static const bool compositionSwitchEnabled = (compositionSwitchIdx >= 0 );
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef BlackOilSolventModule<TypeTag> SolventModule;
@@ -128,8 +132,8 @@ public:
         // deal with polymer (if present)
         PolymerModule::addStorage(storage, intQuants);
 
-        // deal with the two-phase cases
-        if (FluidSystem::numActivePhases() != 3) {
+        // deal with the two-phase cases for three-phase model
+        if ( ! compositionSwitchEnabled ) {
             assert(FluidSystem::numActivePhases() == 2);
             const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
             if (!FluidSystem::phaseIsActive(oilPhaseIdx)) {

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -32,6 +32,7 @@
 
 #include "blackoilproblem.hh"
 #include "blackoilindices.hh"
+#include "blackoiltwophaseindices.hh"
 #include "blackoilextensivequantities.hh"
 #include "blackoilprimaryvariables.hh"
 #include "blackoilintensivequantities.hh"
@@ -206,6 +207,9 @@ class BlackOilModel
     enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
     enum { numComponents = FluidSystem::numComponents };
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
+
+    // if compositionSwitchIdx is negative then this feature is disabled in Indices
+    static const bool compositionSwitchEnabled = (Indices::compositionSwitchIdx >= 0);
 
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
@@ -507,7 +511,9 @@ public:
                 Scalar So = 0.0;
                 switch (priVars.primaryVarsMeaning()) {
                 case PrimaryVariables::Sw_po_Sg:
-                    So = 1.0 - priVars[Indices::waterSaturationIdx] - priVars[Indices::compositionSwitchIdx];
+                    So = 1.0 - priVars[Indices::waterSaturationIdx];
+                    if( compositionSwitchEnabled )
+                        So -= priVars[Indices::compositionSwitchIdx];
                     break;
                 case PrimaryVariables::Sw_pg_Rv:
                     So = 0.0;

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -23,10 +23,10 @@
 /*!
  * \file
  *
- * \copydoc Ewoms::BlackOilIndices
+ * \copydoc Ewoms::BlackOilTwoPhaseIndices
  */
-#ifndef EWOMS_BLACK_OIL_INDICES_HH
-#define EWOMS_BLACK_OIL_INDICES_HH
+#ifndef EWOMS_BLACK_OIL_TWO_PHASE_INDICES_HH
+#define EWOMS_BLACK_OIL_TWO_PHASE_INDICES_HH
 
 namespace Ewoms {
 
@@ -36,10 +36,10 @@ namespace Ewoms {
  * \brief The primary variable and equation indices for the black-oil model.
  */
 template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset>
-struct BlackOilIndices
+struct BlackOilTwoPhaseIndices
 {
     //! Number of phases active at all times
-    static const int numPhases = 3;
+    static const int numPhases = 2;
 
     //! Number of solvent components considered
     static const int numSolvents = numSolventsV;
@@ -50,9 +50,9 @@ struct BlackOilIndices
     //! The number of equations
     static const int numEq = numPhases + numSolvents + numPolymers;
 
-    ////////
+    //////////////////////////////
     // Primary variable indices
-    ////////
+    //////////////////////////////
 
     //! The index of the water saturation
     static const int waterSaturationIdx  = PVOffset + 0;
@@ -64,23 +64,21 @@ struct BlackOilIndices
      * \brief Index of the switching variable which determines the composition of the
      *        hydrocarbon phases.
      *
-     * Depending on the phases present, this variable is either interpreted as the
-     * saturation of the gas phase, as the mole fraction of the gas component in the oil
-     * phase or as the mole fraction of the oil component in the gas phase.
+     * \note For Two-Phase models this is disabled.
      */
-    static const int compositionSwitchIdx = PVOffset + 2;
+    static const int compositionSwitchIdx = -1000000;
 
     //! Index of the primary variable for the first solvent
-    static const int solventSaturationIdx  = compositionSwitchIdx + numSolvents;
+    static const int solventSaturationIdx  = PVOffset + numPhases;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx  = solventSaturationIdx + numPolymers;
 
     // numSolvents-1 primary variables follow
 
-    ////////
+    //////////////////////
     // Equation indices
-    ////////
+    //////////////////////
 
     //! Index of the continuity equation of the first phase
     static const int conti0EqIdx = PVOffset + 0;


### PR DESCRIPTION
This PR fixes several issues with the BlackoilModel when the number of phases is hardcoded to 2 for efficiency of two-phase cases. 
