### PR TITLE
Make it possible to formulate the blackoil eq in terms of surfacevolumes

### DIFF
--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -250,6 +250,10 @@ SET_INT_PROP(FvBaseDiscretization, TimeDiscHistorySize, 2);
 //! Most models use extensive quantities for their storage term (so far, only the Stokes
 //! model does), so we disable this by default.
 SET_BOOL_PROP(FvBaseDiscretization, ExtensiveStorageTerm, false);
+
+// use volumetric residuals is default
+SET_BOOL_PROP(FvBaseDiscretization, UseVolumetricResidual, true);
+
 } // namespace Properties
 
 /*!

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -289,6 +289,9 @@ NEW_PROP_TAG(TimeDiscHistorySize);
  */
 NEW_PROP_TAG(ExtensiveStorageTerm);
 
+//! \brief Specify whether to use volumetric residuals or not
+NEW_PROP_TAG(UseVolumetricResidual);
+
 }} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -124,7 +124,8 @@ public:
 // by default, the ECL solvent module is disabled
 SET_BOOL_PROP(BlackOilModel, EnableSolvent, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
-
+// by default, ebos formulates the conservation equations in terms of mass not surface volumes
+SET_BOOL_PROP(BlackOilModel, BlackoilConserveSurfaceVolume, false);
 } // namespace Properties
 
 /*!

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -44,6 +44,8 @@ NEW_PROP_TAG(HeatConductionLawParams);
 NEW_PROP_TAG(EnableSolvent);
 //! Enable the ECL-blackoil extension for polymer.
 NEW_PROP_TAG(EnablePolymer);
+//! Enable surface volume scaling
+NEW_PROP_TAG(BlackoilConserveSurfaceVolume);
 }} // namespace Properties, Ewoms
 
 #endif


### PR DESCRIPTION
A Tag that enables surface volume scaling is added to the property
system.
NEW_PROP_TAG(EnableSurfaceVolumeScaling);
If enabled the blackoil equations will be formulated in terms of surface
volumes instead of mass/volume. 