### PR TITLE
remove support for dune < 2.4

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -9,5 +9,5 @@ Description: The eWoms simulation framework for flow  and transport in porous me
 Url: http://opm-project.org
 MaintainerName: The Open Porous Media Project
 Maintainer: opm@opm-project.org
-Depends: dune-grid (>= 2.3) dune-istl  (>= 2.3) opm-common opm-material
-Suggests: dune-localfunctions (>= 2.3) dune-fem  (>= 2.4) dune-alugrid (>= 2.4) opm-parser opm-grid opm-core
+Depends: dune-grid (>= 2.4) dune-istl  (>= 2.4) opm-common opm-material
+Suggests: dune-localfunctions (>= 2.4) dune-fem  (>= 2.4) dune-alugrid (>= 2.4) opm-parser opm-grid opm-core

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -213,11 +213,7 @@ namespace Ewoms
                     auto elemIt = gridManager.equilGrid().leafGridView().template begin<0>();
                     const auto& elemEndIt = gridManager.equilGrid().leafGridView().template end<0>();
                     for (; elemIt != elemEndIt; ++elemIt) {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                         int elemIdx = equilElemMapper.index(*elemIt );
-#else
-                        int elemIdx = equilElemMapper.map(*elemIt );
-#endif
                         int cartElemIdx = gridManager.equilCartesianIndexMapper().cartesianIndex(elemIdx);
                         globalCartesianIndex_[elemIdx] = cartElemIdx;
                     }
@@ -255,11 +251,7 @@ namespace Ewoms
                      end = localGridView.template end< 0, Dune::Interior_Partition >(); it != end; ++it )
                 {
                     const auto element = *it ;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                     int elemIdx = elemMapper.index( element );
-#else
-                    int elemIdx = elemMapper.map( element );
-#endif
                     distributedCartesianIndex[elemIdx] = gridManager.cartesianIndex( elemIdx );
 
                     // only store interior element for collection

--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -170,13 +170,8 @@ public:
                     if (!is.neighbor())
                         continue;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                     unsigned I = elemMapper.index(is.inside());
                     unsigned J = elemMapper.index(is.outside());
-#else
-                    unsigned I = elemMapper.map(is.inside());
-                    unsigned J = elemMapper.map(is.outside());
-#endif
 
                     // FIXME (?): this is not portable!
                     unsigned faceIdx = is.id();

--- a/ebos/eclpeacemanwell.hh
+++ b/ebos/eclpeacemanwell.hh
@@ -94,11 +94,7 @@ class EclPeacemanWell : public BaseAuxiliaryModule<TypeTag>
     typedef Opm::MathToolbox<Evaluation> Toolbox;
 
     typedef typename GridView::template Codim<0>::Entity        Element;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 4)
     typedef Element  ElementStorage;
-#else
-    typedef typename GridView::template Codim<0>::EntityPointer ElementStorage;
-#endif
 
     // the dimension of the simulator's world
     static const int dimWorld = GridView::dimensionworld;
@@ -373,11 +369,7 @@ public:
             // influence of grid on well
             auto& curBlock = matrix[wellGlobalDofIdx][gridDofIdx];
 
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 4)
             elemCtx.updateStencil( dofVars.element );
-#else
-            elemCtx.updateStencil( *dofVars.element );
-#endif
             curBlock = 0.0;
             for (unsigned priVarIdx = 0; priVarIdx < numModelEq; ++priVarIdx) {
                 // calculate the derivative of the well equation w.r.t. the current
@@ -609,11 +601,7 @@ public:
         DofVariables& dofVars = *dofVariables_[globalDofIdx];
         wellTotalVolume_ += context.model().dofTotalVolume(globalDofIdx);
 
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 4)
         dofVars.element = context.element();
-#else
-        dofVars.element = ElementStorage( context.element() );
-#endif
 
         dofVars.localDofIdx = dofIdx;
         dofVars.pvtRegionIdx = context.problem().pvtRegionIndex(context, dofIdx, /*timeIdx=*/0);
@@ -622,13 +610,8 @@ public:
         // determine the size of the element
         dofVars.effectiveSize.fill(0.0);
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         // we assume all elements to be hexahedrons!
         assert(context.element().subEntities(/*codim=*/dimWorld) == 8);
-#else
-        // we assume all elements to be hexahedrons!
-        assert(context.element().template count</*codim=*/dimWorld>() == 8);
-#endif
 
         const auto& refElem = Dune::ReferenceElements<Scalar, /*dim=*/3>::cube();
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1083,11 +1083,7 @@ private:
         const auto& elemEndIt = gridView.template end</*codim=*/0>();
         for (; elemIt != elemEndIt; ++elemIt) {
             const Element& element = *elemIt;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
             const unsigned int elemIdx = elemMapper.index(element);
-#else
-            const unsigned int elemIdx = elemMapper.map(element);
-#endif
 
             elementCenterDepth_[elemIdx] = cellCenterDepth( element );
         }
@@ -1643,18 +1639,9 @@ private:
         {
             const auto& elementMapper = this->model().elementMapper();
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
             unsigned globalElemIdx = elementMapper.index(stencil.entity(localDofIdx));
-#else
-            unsigned globalElemIdx = elementMapper.map(stencil.entity(localDofIdx));
-#endif
-
             if (localDofIdx != 0) {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                 unsigned globalCenterElemIdx = elementMapper.index(stencil.entity(/*dofIdx=*/0));
-#else
-                unsigned globalCenterElemIdx = elementMapper.map(stencil.entity(/*dofIdx=*/0));
-#endif
                 dofData.transmissibility = transmissibilities_.transmissibility(globalCenterElemIdx, globalElemIdx);
             }
         };

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -263,13 +263,8 @@ private:
                 const auto& inside = intersection.inside();
                 const auto& outside = intersection.outside();
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                 unsigned insideElemIdx = elementMapper.index(inside);
                 unsigned outsideElemIdx = elementMapper.index(outside);
-#else
-                unsigned insideElemIdx = elementMapper.map(*inside);
-                unsigned outsideElemIdx = elementMapper.map(*outside);
-#endif
 
                 unsigned equilRegionInside = elemEquilRegion_[insideElemIdx];
                 unsigned equilRegionOutside = elemEquilRegion_[outsideElemIdx];

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -128,11 +128,7 @@ public:
         const auto& elemEndIt = gridView.template end</*codim=*/ 0>();
         for (; elemIt != elemEndIt; ++elemIt) {
             const auto& elem = *elemIt;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
             unsigned elemIdx = elemMapper.index(elem);
-#else
-            unsigned elemIdx = elemMapper.map(elem);
-#endif
 
             // compute the axis specific "centroids" used for the transmissibilities. for
             // consistency with the flow simulator, we use the element centers as
@@ -169,13 +165,8 @@ public:
 
                 const auto& inside = intersection.inside();
                 const auto& outside = intersection.outside();
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
                 unsigned insideElemIdx = elemMapper.index(inside);
                 unsigned outsideElemIdx = elemMapper.index(outside);
-#else
-                unsigned insideElemIdx = elemMapper.map(*inside);
-                unsigned outsideElemIdx = elemMapper.map(*outside);
-#endif
 
                 // we only need to calculate a face's transmissibility
                 // once...

--- a/ebos/ertwrappers.hh
+++ b/ebos/ertwrappers.hh
@@ -242,12 +242,7 @@ public:
         auto elemIt = grid.leafGridView().template begin<0>();
         const auto& elemEndIt = grid.leafGridView().template end<0>();
         for (; elemIt != elemEndIt; ++elemIt) {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
             int elemIdx = elemMapper.index(*elemIt );
-#else
-            int elemIdx = elemMapper.map(*elemIt );
-#endif
-
             int cartElemIdx = cartesianMapper.cartesianIndex(elemIdx);
             actnumData[cartElemIdx] = 1;
         }

--- a/ewoms/common/pffgridvector.hh
+++ b/ewoms/common/pffgridvector.hh
@@ -75,11 +75,7 @@ public:
         for (; elemIt != elemEndIt; ++elemIt) {
             // set the DOF data pointer for the current element
             const auto& elem = *elemIt;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
             unsigned elemIdx = elementMapper_.index(elem);
-#else
-            unsigned elemIdx = elementMapper_.map(elem);
-#endif
             elemData_[elemIdx] = curElemDataPtr;
 
             stencil.update(elem);
@@ -95,11 +91,7 @@ public:
 
     void prefetch(const Element& elem) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned elemIdx = elementMapper_.index(elem);
-#else
-        unsigned elemIdx = elementMapper_.map(elem);
-#endif
 
         // we use 0 as the temporal locality, because it is reasonable to assume that an
         // entry will only be accessed once.
@@ -108,12 +100,7 @@ public:
 
     const Data& get(const Element& elem, unsigned localDofIdx) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned elemIdx = elementMapper_.index(elem);
-#else
-        unsigned elemIdx = elementMapper_.map(elem);
-#endif
-
         return elemData_[elemIdx][localDofIdx];
     }
 

--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -308,7 +308,7 @@ static inline int start(int argc, char **argv)
             std::cout << e.what() << ". Abort!\n" << std::flush;
         return 1;
     }
-#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2, 5)
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
     catch (Dune::Exception& e)
     {
         if (myRank == 0)

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -1356,11 +1356,7 @@ public:
     void serializeEntity(std::ostream& outstream,
                          const DofEntity& dof)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().index(dof));
-#else
-        unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().map(dof));
-#endif
 
         // write phase state
         if (!outstream.good()) {
@@ -1384,11 +1380,7 @@ public:
     void deserializeEntity(std::istream& instream,
                            const DofEntity& dof)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().index(dof));
-#else
-        unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().map(dof));
-#endif
 
         for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             if (!instream.good())

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -187,7 +187,7 @@ public:
                       << "\n"  << std::flush;
             succeeded = 0;
         }
-#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2, 5)
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
         catch (const Dune::Exception& e)
         {
             std::cout << "rank " << simulator_().gridView().comm().rank()

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -57,9 +57,6 @@ class EcfvStencil
     typedef typename GridView::ctype CoordScalar;
     typedef typename GridView::Intersection Intersection;
     typedef typename GridView::template Codim<0>::Entity Element;
-#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
-    typedef typename GridView::template Codim<0>::EntityPointer ElementPointer;
-#endif
 
     typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView,
                                                       Dune::MCMGElementLayout> ElementMapper;
@@ -90,30 +87,16 @@ public:
         SubControlVolume()
         {}
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         SubControlVolume(const Element& element)
             : element_(element)
-#else
-        SubControlVolume(const ElementPointer& elementPtr)
-            : elementPtr_(elementPtr)
-#endif
         { update(); }
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         void update(const Element& element)
         { element_ = element; }
-#else
-        void update(const ElementPointer& elementPtr)
-        { elementPtr_ = elementPtr; }
-#endif
 
         void update()
         {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             const auto& geometry = element_.geometry();
-#else
-            const auto& geometry = elementPtr_->geometry();
-#endif
             centerPos_ = geometry.center();
             volume_ = geometry.volume();
         }
@@ -139,23 +122,13 @@ public:
         /*!
          * \brief The geometry of the sub-control volume.
          */
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         const LocalGeometry geometry() const
         { return element_.geometry(); }
-#else
-        const LocalGeometry geometry() const
-        { return elementPtr_->geometry(); }
-#endif
 
     private:
         GlobalPosition centerPos_;
         Scalar volume_;
-
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         Element element_;
-#else
-        ElementPointer elementPtr_;
-#endif
     };
 
     /*!
@@ -238,20 +211,11 @@ public:
         auto isIt = gridView_.ibegin(element);
         const auto& endIsIt = gridView_.iend(element);
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         // add the "center" element of the stencil
         subControlVolumes_.clear();
         subControlVolumes_.emplace_back(/*SubControlVolume(*/element/*)*/);
         elements_.clear();
         elements_.emplace_back(element);
-#else
-        // add the "center" element of the stencil
-        ElementPointer ePtr(element);
-        subControlVolumes_.clear();
-        subControlVolumes_.emplace_back(/*SubControlVolume(*/ePtr/*)*/);
-        elements_.clear();
-        elements_.emplace_back(ePtr);
-#endif
 
         interiorFaces_.clear();
         boundaryFaces_.clear();
@@ -274,20 +238,11 @@ public:
 
     void updatePrimaryTopology(const Element& element)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         // add the "center" element of the stencil
         subControlVolumes_.clear();
         subControlVolumes_.emplace_back(/*SubControlVolume(*/element/*)*/);
         elements_.clear();
         elements_.emplace_back(element);
-#else
-        // add the "center" element of the stencil
-        ElementPointer ePtr(element);
-        subControlVolumes_.clear();
-        subControlVolumes_.emplace_back(/*SubControlVolume(*/ePtr/*)*/);
-        elements_.clear();
-        elements_.emplace_back(ePtr);
-#endif
     }
 
     void update(const Element& element)
@@ -340,11 +295,7 @@ public:
     {
         assert(0 <= dofIdx && dofIdx < numDof());
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         return static_cast<unsigned>(elementMapper_.index(element(dofIdx)));
-#else
-        return static_cast<unsigned>(elementMapper_.map(element(dofIdx)));
-#endif
     }
 
     /*!
@@ -364,11 +315,7 @@ public:
     {
         assert(0 <= dofIdx && dofIdx < numDof());
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         return elements_[dofIdx];
-#else
-        return *elements_[dofIdx];
-#endif
     }
 
     /*!
@@ -417,12 +364,7 @@ protected:
     const GridView&       gridView_;
     const ElementMapper&  elementMapper_;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
     std::vector<Element> elements_;
-#else
-    std::vector<ElementPointer> elements_;
-#endif
-
     std::vector<SubControlVolume>      subControlVolumes_;
     std::vector<SubControlVolumeFace>  interiorFaces_;
     std::vector<SubControlVolumeFace>  boundaryFaces_;

--- a/ewoms/io/dgfgridmanager.hh
+++ b/ewoms/io/dgfgridmanager.hh
@@ -171,23 +171,15 @@ protected:
                     // get local vertex number from edge
                     const int localVx = refElem.subEntity(edge, edgeCodim, vx, Grid::dimension);
 
-#if DUNE_VERSION_NEWER(DUNE_GRID,2,4)
                     // get vertex
                     const auto vertex = element.template subEntity<Grid::dimension>(localVx);
-#else
-                    // get vertex
-                    const auto vertexPtr = element.template subEntity<Grid::dimension>(localVx);
-                    const auto& vertex = *vertexPtr ;
-#endif
 
                     // if vertex has parameter 1 insert as a fracture vertex
-                    if (dgfPointer.parameters( vertex )[ 0 ] > 0) {
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2,4)
-                        vertexIndices.push_back(static_cast<unsigned>(elementMapper.subIndex(element, static_cast<int>(localVx), Grid::dimension)));
-#else
-                        vertexIndices.push_back(static_cast<unsigned>(elementMapper.map(element, static_cast<int>(localVx), Grid::dimension)));
-#endif
-                    }
+                    if (dgfPointer.parameters( vertex )[ 0 ] > 0)
+                        vertexIndices.push_back(
+                            static_cast<unsigned>(elementMapper.subIndex(element,
+                                                                         static_cast<int>(localVx),
+                                                                         Grid::dimension)));
                 }
                 // if 2 vertices have been found with flag 1 insert a fracture edge
                 if (static_cast<int>(vertexIndices.size()) == Grid::dimension)

--- a/ewoms/io/vtkmultiwriter.hh
+++ b/ewoms/io/vtkmultiwriter.hh
@@ -76,7 +76,7 @@ public:
     typedef BaseOutputWriter::TensorBuffer TensorBuffer;
 
     typedef Dune::VTKWriter<GridView> VtkWriter;
-#if DUNE_VERSION_NEWER(DUNE_GRID, 2, 5)
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2,5)
     typedef std::shared_ptr< Dune::VTKFunction< GridView > > FunctionPtr;
 #else
     typedef typename VtkWriter::VTKFunctionPtr FunctionPtr;

--- a/ewoms/io/vtkprimaryvarsmodule.hh
+++ b/ewoms/io/vtkprimaryvarsmodule.hh
@@ -116,11 +116,7 @@ public:
             return;
 
         const auto& elementMapper = elemCtx.model().elementMapper();
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned elemIdx = static_cast<unsigned>(elementMapper.index(elemCtx.element()));
-#else
-        unsigned elemIdx = static_cast<unsigned>(elementMapper .map(elemCtx.element()));
-#endif
         if (processRankOutput_() && !processRank_.empty())
             processRank_[elemIdx] = static_cast<unsigned>(this->simulator_.gridView().comm().rank());
 

--- a/ewoms/io/vtkscalarfunction.hh
+++ b/ewoms/io/vtkscalarfunction.hh
@@ -84,11 +84,7 @@ public:
         unsigned idx;
         if (codim_ == 0) {
             // cells. map element to the index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<unsigned>(mapper_.index(e));
-#else
-            idx = static_cast<unsigned>(mapper_.map(e));
-#endif
         }
         else if (codim_ == dim) {
             // find vertex which is closest to xi in local
@@ -96,11 +92,7 @@ public:
             double min = 1e100;
             int imin = -1;
             Dune::GeometryType gt = e.type();
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             int n = static_cast<int>(e.subEntities(dim));
-#else
-            int n = e.template count<dim>();
-#endif
             for (int i = 0; i < n; ++i) {
                 Dune::FieldVector<ctype, dim> local =
                     Dune::ReferenceElements<ctype, dim>::general(gt).position(i, dim);
@@ -113,11 +105,7 @@ public:
             }
 
             // map vertex to an index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<unsigned>(mapper_.subIndex(e, imin, codim_));
-#else
-            idx = static_cast<unsigned>(mapper_.map(e, imin, codim_));
-#endif
         }
         else
             OPM_THROW(std::logic_error, "Only element and vertex based vector "

--- a/ewoms/io/vtktensorfunction.hh
+++ b/ewoms/io/vtktensorfunction.hh
@@ -82,11 +82,7 @@ public:
         size_t idx;
         if (codim_ == 0) {
             // cells. map element to the index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<size_t>(mapper_.index(e));
-#else
-            idx = static_cast<size_t>(mapper_.map(e));
-#endif
         }
         else if (codim_ == dim) {
             // find vertex which is closest to xi in local
@@ -94,11 +90,7 @@ public:
             double min = 1e100;
             int imin = -1;
             Dune::GeometryType gt = e.type();
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             int n = static_cast<int>(e.subEntities(dim));
-#else
-            int n = static_cast<int>(e.template count<dim>());
-#endif
             for (int i = 0; i < n; ++i) {
                 Dune::FieldVector<ctype, dim> local =
                     Dune::ReferenceElements<ctype, dim>::general(gt).position(i, dim);
@@ -111,11 +103,7 @@ public:
             }
 
             // map vertex to an index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<size_t>(mapper_.subIndex(e, imin, codim_));
-#else
-            idx = static_cast<size_t>(mapper_.map(e, imin, codim_));
-#endif
         }
         else
             OPM_THROW(std::logic_error,

--- a/ewoms/io/vtkvectorfunction.hh
+++ b/ewoms/io/vtkvectorfunction.hh
@@ -82,11 +82,7 @@ public:
         unsigned idx;
         if (codim_ == 0) {
             // cells. map element to the index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<unsigned>(mapper_.index(e));
-#else
-            idx = static_cast<unsigned>(mapper_.map(e));
-#endif
         }
         else if (codim_ == dim) {
             // find vertex which is closest to xi in local
@@ -94,11 +90,7 @@ public:
             double min = 1e100;
             int imin = -1;
             Dune::GeometryType gt = e.type();
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             int n = static_cast<int>(e.subEntities(dim));
-#else
-            int n = static_cast<int>(e.template count<dim>());
-#endif
             for (int i = 0; i < n; ++i) {
                 Dune::FieldVector<ctype, dim> local =
                     Dune::ReferenceElements<ctype, dim>::general(gt).position(i, dim);
@@ -111,11 +103,7 @@ public:
             }
 
             // map vertex to an index
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             idx = static_cast<unsigned>(mapper_.subIndex(e, imin, codim_));
-#else
-            idx = static_cast<unsigned>(mapper_.map(e, imin, codim_));
-#endif
         }
         else
             OPM_THROW(std::logic_error, "Only element and vertex based vector "

--- a/ewoms/linear/convergencecriterion.hh
+++ b/ewoms/linear/convergencecriterion.hh
@@ -56,12 +56,8 @@ namespace Linear {
 template <class Vector>
 class ConvergenceCriterion
 {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
     //! \brief The real type of the field type (is the same if using real numbers, but differs for std::complex)
     typedef typename Dune::FieldTraits<typename Vector::field_type>::real_type real_type;
-#else
-    typedef typename Vector::field_type real_type;
-#endif
 
     typedef real_type Scalar;
 

--- a/ewoms/linear/elementborderlistfromgrid.hh
+++ b/ewoms/linear/elementborderlistfromgrid.hh
@@ -74,11 +74,7 @@ class ElementBorderListFromGrid
             const auto& elemEndIt = gridView_.template end<0>();
             for (; elemIt != elemEndIt; ++elemIt) {
                 if (elemIt->partitionType() != Dune::InteriorEntity) {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
                     Index elemIdx = static_cast<Index>(map_.index(*elemIt));
-#else
-                    Index elemIdx = static_cast<Index>(map_.map(*elemIt));
-#endif
                     blackList_.addIndex(elemIdx);
                 }
             }
@@ -98,11 +94,7 @@ class ElementBorderListFromGrid
         template <class MessageBufferImp, class EntityType>
         void gather(MessageBufferImp& buff, const EntityType& e) const
         {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             unsigned myIdx = static_cast<unsigned>(map_.index(e));
-#else
-            unsigned myIdx = static_cast<unsigned>(map_.map(e));
-#endif
             buff.write(static_cast<unsigned>(gridView_.comm().rank()));
             buff.write(myIdx);
         }
@@ -119,11 +111,7 @@ class ElementBorderListFromGrid
             for (; isIt != isEndIt; ++isIt) {
                 if (!isIt->neighbor())
                     continue;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
                 else if (isIt->outside().partitionType() == Dune::InteriorEntity) {
-#else
-                else if (isIt->outside()->partitionType() == Dune::InteriorEntity) {
-#endif
                     isInteriorNeighbor = true;
                     break;
                 }
@@ -133,11 +121,7 @@ class ElementBorderListFromGrid
 
             BorderIndex bIdx;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             bIdx.localIdx = static_cast<Index>(map_.index(e));
-#else
-            bIdx.localIdx = static_cast<Index>(map_.map(e));
-#endif
             {
                 ProcessRank tmp;
                 buff.read(tmp);
@@ -201,11 +185,7 @@ class ElementBorderListFromGrid
         void gather(MessageBufferImp& buff, const EntityType& e) const
         {
             buff.write(static_cast<int>(gridView_.comm().rank()));
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             buff.write(static_cast<int>(map_.index(e)));
-#else
-            buff.write(static_cast<int>(map_.map(e)));
-#endif
         }
 
         template <class MessageBufferImp, class EntityType>
@@ -217,11 +197,7 @@ class ElementBorderListFromGrid
 
             buff.read(peerRank);
             buff.read(peerIdx);
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
             localIdx = static_cast<Index>(map_.index(e));
-#else
-            localIdx = static_cast<Index>(map_.map(e));
-#endif
 
             PeerBlackListedEntry pIdx;
             pIdx.nativeIndexOfPeer = static_cast<Index>(peerIdx);

--- a/ewoms/linear/superlubackend.hh
+++ b/ewoms/linear/superlubackend.hh
@@ -137,7 +137,7 @@ public:
 // quadruple precision math on Dune 2.4. this is because the most which SuperLU can
 // handle is double precision (i.e., the linear systems of equations are always solved
 // with at most double precision if chosing SuperLU as the linear solver...)
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4) && HAVE_QUAD
+#if HAVE_QUAD
 template <class TypeTag, class Matrix, class Vector>
 class SuperLUSolve_<__float128, TypeTag, Matrix, Vector>
 {

--- a/ewoms/linear/vertexborderlistfromgrid.hh
+++ b/ewoms/linear/vertexborderlistfromgrid.hh
@@ -73,11 +73,7 @@ public:
             if (vIt->partitionType() != Dune::InteriorEntity
                 && vIt->partitionType() != Dune::BorderEntity)
             {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
                 Index vIdx = static_cast<Index>(map_.index(*vIt));
-#else
-                Index vIdx = static_cast<Index>(map_.map(*vIt));
-#endif
                 blackList_.addIndex(vIdx);
             }
         }
@@ -98,11 +94,7 @@ public:
     void gather(MessageBufferImp& buff, const EntityType& e) const
     {
         buff.write(static_cast<int>(gridView_.comm().rank()));
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         buff.write(static_cast<int>(map_.index(e)));
-#else
-        buff.write(static_cast<int>(map_.map(e)));
-#endif
     }
 
     template <class MessageBufferImp, class EntityType>
@@ -110,11 +102,7 @@ public:
     {
         BorderIndex bIdx;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         bIdx.localIdx = static_cast<Index>(map_.index(e));
-#else
-        bIdx.localIdx = static_cast<Index>(map_.map(e));
-#endif
         {
             int tmp;
             buff.read(tmp);

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -367,11 +367,7 @@ public:
     template <class DofEntity>
     void serializeEntity(std::ostream& outstream, const DofEntity& dof)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().index(dof));
-#else
-        unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().map(dof));
-#endif
 
         // write phase state
         if (!outstream.good()) {
@@ -407,11 +403,7 @@ public:
     void deserializeEntity(std::istream& instream,
                            const DofEntity& dof)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().index(dof));
-#else
-        unsigned dofIdx = static_cast<unsigned>(asImp_().dofMapper().map(dof));
-#endif
 
         // read in the "real" primary variables of the DOF
         auto& priVars = this->solution(/*timeIdx=*/0)[dofIdx];

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -557,12 +557,7 @@ public:
         if (!enablePolymer)
             return;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned dofIdx = model.dofMapper().index(dof);
-#else
-        unsigned dofIdx = model.dofMapper().map(dof);
-#endif
-
         const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
         outstream << priVars[polymerConcentrationIdx];
     }
@@ -573,12 +568,7 @@ public:
         if (!enablePolymer)
             return;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned dofIdx = model.dofMapper().index(dof);
-#else
-        unsigned dofIdx = model.dofMapper().map(dof);
-#endif
-
         PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
         PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
 

--- a/ewoms/models/blackoil/blackoilsolventmodules.hh
+++ b/ewoms/models/blackoil/blackoilsolventmodules.hh
@@ -643,11 +643,7 @@ public:
         if (!enableSolvent)
             return;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned dofIdx = model.dofMapper().index(dof);
-#else
-        unsigned dofIdx = model.dofMapper().map(dof);
-#endif
 
         const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
         outstream << priVars[solventSaturationIdx];
@@ -659,11 +655,7 @@ public:
         if (!enableSolvent)
             return;
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2,4)
         unsigned dofIdx = model.dofMapper().index(dof);
-#else
-        unsigned dofIdx = model.dofMapper().map(dof);
-#endif
 
         PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
         PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];

--- a/ewoms/models/pvs/pvsmodel.hh
+++ b/ewoms/models/pvs/pvsmodel.hh
@@ -425,11 +425,7 @@ public:
         // write primary variables
         ParentType::serializeEntity(outstream, dofEntity);
 
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(this->dofMapper().index(dofEntity));
-#else
-        unsigned dofIdx = static_cast<unsigned>(this->dofMapper().map(dofEntity));
-#endif
         if (!outstream.good())
             OPM_THROW(std::runtime_error, "Could not serialize DOF " << dofIdx);
 
@@ -446,11 +442,7 @@ public:
         ParentType::deserializeEntity(instream, dofEntity);
 
         // read phase presence
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(this->dofMapper().index(dofEntity));
-#else
-        unsigned dofIdx = static_cast<unsigned>(this->dofMapper().map(dofEntity));
-#endif
         if (!instream.good())
             OPM_THROW(std::runtime_error,
                        "Could not deserialize DOF " << dofIdx);

--- a/ewoms/parallel/gridcommhandles.hh
+++ b/ewoms/parallel/gridcommhandles.hh
@@ -75,22 +75,14 @@ public:
     template <class MessageBufferImp, class EntityType>
     void gather(MessageBufferImp& buff, const EntityType& e) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
     void scatter(MessageBufferImp& buff, const EntityType& e, size_t n OPM_UNUSED)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
 
         FieldType tmp;
         buff.read(tmp);
@@ -143,22 +135,14 @@ public:
     template <class MessageBufferImp, class EntityType>
     void gather(MessageBufferImp& buff, const EntityType& e) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
     void scatter(MessageBufferImp& buff, const EntityType& e, size_t n OPM_UNUSED)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         buff.read(container_[dofIdx]);
     }
 
@@ -206,22 +190,14 @@ public:
     template <class MessageBufferImp, class EntityType>
     void gather(MessageBufferImp& buff, const EntityType& e) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
     void scatter(MessageBufferImp& buff, const EntityType& e, size_t n OPM_UNUSED)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         FieldType tmp;
         buff.read(tmp);
         container_[dofIdx] = std::max(container_[dofIdx], tmp);
@@ -271,22 +247,14 @@ public:
     template <class MessageBufferImp, class EntityType>
     void gather(MessageBufferImp& buff, const EntityType& e) const
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         buff.write(container_[dofIdx]);
     }
 
     template <class MessageBufferImp, class EntityType>
     void scatter(MessageBufferImp& buff, const EntityType& e, size_t n OPM_UNUSED)
     {
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
         unsigned dofIdx = static_cast<unsigned>(mapper_.index(e));
-#else
-        unsigned dofIdx = static_cast<unsigned>(mapper_.map(e));
-#endif
         FieldType tmp;
         buff.read(tmp);
         container_[dofIdx] = std::min(container_[dofIdx], tmp);

--- a/ewoms/parallel/threadmanager.hh
+++ b/ewoms/parallel/threadmanager.hh
@@ -82,16 +82,7 @@ public:
                       "OpenMP is not available. The only valid values for "
                       "threads-per-process is 1 and -1 but it is " << numThreads_ << "!");
         numThreads_ = 1;
-#elif !DUNE_VERSION_NEWER(DUNE_COMMON, 2,4) && !defined NDEBUG
-        if (numThreads_ != 1)
-            OPM_THROW(std::invalid_argument,
-                      "You seem to be using Dune "
-                      <<DUNE_COMMON_VERSION_MAJOR<<"."<<DUNE_COMMON_VERSION_MINOR
-                      << " in debug mode and with the number of OpenMP threads larger than 1. "
-                      "This Dune version does not support thread parallelism in debug mode!");
-        numThreads_ = 1;
-
-#elif DUNE_VERSION_NEWER(DUNE_COMMON, 2,4) && !defined NDEBUG && defined DUNE_INTERFACECHECK
+#elif !defined NDEBUG && defined DUNE_INTERFACECHECK
         if (numThreads_ != 1)
             OPM_THROW(std::invalid_argument,
                       "You explicitly enabled Barton-Nackman interface checking in Dune. "
@@ -99,6 +90,7 @@ public:
                       "thread parallelism!");
         numThreads_ = 1;
 #else
+
         if (numThreads_ == 0)
             OPM_THROW(std::invalid_argument,
                       "Zero threads per process are not possible: It must be at least 1, "

--- a/tests/test_quadrature.cc
+++ b/tests/test_quadrature.cc
@@ -293,17 +293,7 @@ void testQuadrature()
 
     typedef Dune::YaspGrid<dim> Grid;
     typedef Grid::LeafGridView GridView;
-#if DUNE_VERSION_NEWER(DUNE_COMMON, 2, 4)
     Grid grid(upperRight, cellRes);
-#else
-    Grid grid(
-#ifdef HAVE_MPI
-        Dune::MPIHelper::getCommunicator(),
-#endif
-        upperRight,     // upper right
-        cellRes,        // number of cells
-        isPeriodic, 0); // overlap
-#endif
 
     // compute approximate integral
     auto gridView = grid.leafGridView();


### PR DESCRIPTION
this allows quite a substantial amount of code decluttering, mainly because Dune 2.4 renamed mapper.map() to mapper.index().