### PR TITLE
remove the specialized copy constructors and copy operators from all IQ classes

### DIFF
--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -99,12 +99,9 @@ public:
         fluidState_.setRv(0.0);
     }
 
-    BlackOilIntensiveQuantities(const BlackOilIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    BlackOilIntensiveQuantities(const BlackOilIntensiveQuantities& other) = default;
 
-    BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    BlackOilIntensiveQuantities& operator=(const BlackOilIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc IntensiveQuantities::update

--- a/ewoms/models/discretefracture/discretefractureintensivequantities.hh
+++ b/ewoms/models/discretefracture/discretefractureintensivequantities.hh
@@ -73,12 +73,9 @@ public:
     DiscreteFractureIntensiveQuantities()
     { }
 
-    DiscreteFractureIntensiveQuantities(const DiscreteFractureIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    DiscreteFractureIntensiveQuantities(const DiscreteFractureIntensiveQuantities& other) = default;
 
-    DiscreteFractureIntensiveQuantities& operator=(const DiscreteFractureIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    DiscreteFractureIntensiveQuantities& operator=(const DiscreteFractureIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc IntensiveQuantities::update

--- a/ewoms/models/flash/flashintensivequantities.hh
+++ b/ewoms/models/flash/flashintensivequantities.hh
@@ -92,12 +92,9 @@ public:
     FlashIntensiveQuantities()
     { }
 
-    FlashIntensiveQuantities(const FlashIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    FlashIntensiveQuantities(const FlashIntensiveQuantities& other) = default;
 
-    FlashIntensiveQuantities& operator=(const FlashIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    FlashIntensiveQuantities& operator=(const FlashIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc IntensiveQuantities::update

--- a/ewoms/models/immiscible/immiscibleintensivequantities.hh
+++ b/ewoms/models/immiscible/immiscibleintensivequantities.hh
@@ -83,12 +83,9 @@ public:
     ImmiscibleIntensiveQuantities()
     { }
 
-    ImmiscibleIntensiveQuantities(const ImmiscibleIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    ImmiscibleIntensiveQuantities(const ImmiscibleIntensiveQuantities& other) = default;
 
-    ImmiscibleIntensiveQuantities& operator=(const ImmiscibleIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    ImmiscibleIntensiveQuantities& operator=(const ImmiscibleIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc IntensiveQuantities::update

--- a/ewoms/models/ncp/ncpintensivequantities.hh
+++ b/ewoms/models/ncp/ncpintensivequantities.hh
@@ -92,12 +92,9 @@ public:
     NcpIntensiveQuantities()
     {}
 
-    NcpIntensiveQuantities(const NcpIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    NcpIntensiveQuantities(const NcpIntensiveQuantities& other) = default;
 
-    NcpIntensiveQuantities& operator=(const NcpIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    NcpIntensiveQuantities& operator=(const NcpIntensiveQuantities& other)  = default;
 
     /*!
      * \brief IntensiveQuantities::update

--- a/ewoms/models/pvs/pvsintensivequantities.hh
+++ b/ewoms/models/pvs/pvsintensivequantities.hh
@@ -98,12 +98,9 @@ public:
     PvsIntensiveQuantities()
     { }
 
-    PvsIntensiveQuantities(const PvsIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    PvsIntensiveQuantities(const PvsIntensiveQuantities& other) = default;
 
-    PvsIntensiveQuantities& operator=(const PvsIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    PvsIntensiveQuantities& operator=(const PvsIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc ImmiscibleIntensiveQuantities::update

--- a/ewoms/models/richards/richardsintensivequantities.hh
+++ b/ewoms/models/richards/richardsintensivequantities.hh
@@ -77,12 +77,9 @@ public:
     RichardsIntensiveQuantities()
     {}
 
-    RichardsIntensiveQuantities(const RichardsIntensiveQuantities& other)
-        : ParentType()
-    { std::memcpy(this, &other, sizeof(other)); }
+    RichardsIntensiveQuantities(const RichardsIntensiveQuantities& other) = default;
 
-    RichardsIntensiveQuantities& operator=(const RichardsIntensiveQuantities& other)
-    { std::memcpy(this, &other, sizeof(other)); return *this; }
+    RichardsIntensiveQuantities& operator=(const RichardsIntensiveQuantities& other) = default;
 
     /*!
      * \copydoc IntensiveQuantities::update


### PR DESCRIPTION
after OPM/opm-material#242, using memcpy() for this does not yield any performance benefit anymore but it may cause trouble in the future if some models do not use trivially copyable intensive quantities. (this
should probably be avoided for performance reasons, but the proper way to do this is to do this explicitly, i.e., using std::is_trivially_copyable)