### PR TITLE
Improve the adaptPrimaryVariables code

### DIFF
--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -123,14 +123,14 @@ public:
         Evaluation Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
 
         Evaluation Sg = 0.0;
-        if( compositionSwitchEnabled )
+        if (compositionSwitchEnabled)
         {
             if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Sg)
                 // -> threephase case
                 Sg = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
             else if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_pg_Rv) {
                 // -> gas-water case
-                Sg = 1 - Sw;
+                Sg = 1.0 - Sw;
 
                 // deal with solvent
                 if (enableSolvent)


### PR DESCRIPTION
Changes
- water only case is treated separately
- an epsilon can be added to restrict the switching. Useful to avoid
oscillating between primary variable meaning
- call the method recursively since a variable switch may occur more than
once at a time

Testing 
Pass all tests in ewoms 
Runs SPE9 fine with ebos. 
Tested in combination with flow_ebos on SPE9, Norne, Model2-0 and Model2-5
Tested with flow_ebos_solvent 
