### PR TITLE
Allow parameters to be passed to Simulator.

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -240,6 +240,10 @@ SET_BOOL_PROP(EclBaseProblem, EnableDebuggingChecks, true);
 
 // ebos handles the SWATINIT keyword by default
 SET_BOOL_PROP(EclBaseProblem, EnableSwatinit, true);
+
+//! Set the ParameterMetaData property
+SET_TYPE_PROP(EclBaseProblem, SimulatorParameter, std::pair< std::shared_ptr<Opm::Deck>, std::shared_ptr<Opm::EclipseState> > );
+
 } // namespace Properties
 
 /*!
@@ -489,7 +493,7 @@ public:
             this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
 
         this->model().updateMaxOilSaturations();
-        
+
         if (GET_PROP_VALUE(TypeTag, EnablePolymer))
             updateMaxPolymerAdsorption_();
 

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -173,6 +173,7 @@ NEW_PROP_TAG(ParameterMetaData);
 NEW_PROP_TAG(ParameterGroupPrefix);
 NEW_PROP_TAG(Description);
 
+NEW_PROP_TAG(SimulatorParameter);
 
 //! Set the ParameterMetaData property
 SET_PROP(ParameterSystem, ParameterMetaData)
@@ -214,6 +215,11 @@ private:
         return obj;
     }
 };
+
+struct EmptyParameters {};
+
+//! Set the ParameterMetaData property
+SET_TYPE_PROP(ParameterSystem, SimulatorParameter, EmptyParameters );
 
 SET_STRING_PROP(ParameterSystem, ParameterGroupPrefix, "");
 SET_STRING_PROP(ParameterSystem, Description, "");

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -45,6 +45,7 @@
 #include <string>
 #include <memory>
 
+
 namespace Ewoms {
 namespace Properties {
 NEW_PROP_TAG(Scalar);
@@ -79,12 +80,26 @@ class Simulator
     typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
 
+    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter)  SimulatorParameter;
+
 
 public:
     // do not allow to copy simulators around
     Simulator(const Simulator& ) = delete;
 
     Simulator(bool verbose = true)
+        : simulatorParameter_()
+    {
+        init( verbose );
+    }
+
+    Simulator(const SimulatorParameter& parameter, bool verbose = true)
+        : simulatorParameter_( parameter )
+    {
+        init( verbose );
+    }
+
+    void init( bool verbose )
     {
         Ewoms::TimerGuard setupTimerGuard(setupTimer_);
 
@@ -852,7 +867,12 @@ public:
         restarter.deserializeSectionEnd();
     }
 
+    const SimulatorParameter& simulatorParameter() const { return simulatorParameter_; }
+    SimulatorParameter& simulatorParameter() { return simulatorParameter_; }
+
 private:
+    SimulatorParameter simulatorParameter_;
+
     std::unique_ptr<GridManager> gridManager_;
     std::unique_ptr<Model> model_;
     std::unique_ptr<Problem> problem_;


### PR DESCRIPTION
This PR enables the ability to create the Opm::Deck and Opm::EclipseState outside of the EbosSimulator. The default behavior is unchanged. 