### PR TITLE
make the property system work with multiple compile units

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,20 @@ opm_add_test(lens_immiscible_vcfv_fd
 opm_add_test(lens_immiscible_ecfv_ad
              TEST_ARGS --end-time=3000)
 
+# this test is identical to the simulation of the lens problem that
+# uses the element centered finite volume discretization in
+# conjunction with automatic differentiation
+# (lens_immiscible_ecfv_ad). The only difference is that it uses
+# multiple compile units in order to ensure that eWoms code can be
+# used within libraries that use the same type tag within multiple
+# compile units.
+opm_add_test(lens_immiscible_ecfv_ad_mcu
+             ONLY_COMPILE
+             SOURCES
+                tests/lens_immiscible_ecfv_ad_cu1.cc
+                tests/lens_immiscible_ecfv_ad_cu2.cc
+                tests/lens_immiscible_ecfv_ad_main.cc)
+
 opm_add_test(finger_immiscible_ecfv
              CONDITION ${DUNE_ALUGRID_FOUND})
 

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -234,7 +234,7 @@ void getFlattenedKeyList_(std::list<std::string>& dest,
                           const std::string& prefix = "");
 
 
-void printParamUsage_(std::ostream& os, const ParamInfo& paramInfo)
+inline void printParamUsage_(std::ostream& os, const ParamInfo& paramInfo)
 {
     std::string paramMessage, paramType, paramDescription;
 
@@ -288,9 +288,9 @@ void printParamUsage_(std::ostream& os, const ParamInfo& paramInfo)
     os << paramMessage;
 }
 
-void getFlattenedKeyList_(std::list<std::string>& dest,
-                          const Dune::ParameterTree& tree,
-                          const std::string& prefix)
+inline void getFlattenedKeyList_(std::list<std::string>& dest,
+                                 const Dune::ParameterTree& tree,
+                                 const std::string& prefix)
 {
     // add the keys of the current sub-structure
     auto keyIt = tree.getValueKeys().begin();

--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -84,8 +84,10 @@ namespace Properties {
         }                                                               \
         static std::string propertyName() { return #PropTagName; }      \
     };                                                                  \
-    static const int fooPropInfo_ ## EffTypeTagName ## _ ## PropTagName  = \
-        PropertyInfo<TTAG(EffTypeTagName), PTAG(PropTagName)>::init();
+    namespace fooPropInfo_ ## EffTypeTagName {                          \
+    static const int foo_ ## PropTagName  =                             \
+        PropertyInfo<TTAG(EffTypeTagName), PTAG(PropTagName)>::init();  \
+    }
 
 
 //! Internal macro which is only required if the property introspection is enabled

--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -45,6 +45,7 @@
 #include <dune/common/classname.hh>
 #include <opm/common/ErrorMacros.hpp>
 #include <opm/common/Exceptions.hpp>
+#include <opm/common/Unused.hpp>
 
 #include <type_traits> // required for 'is_base_of<A, B>'
 
@@ -85,7 +86,7 @@ namespace Properties {
         static std::string propertyName() { return #PropTagName; }      \
     };                                                                  \
     namespace fooPropInfo_ ## EffTypeTagName {                          \
-    static const int foo_ ## PropTagName  =                             \
+    static const int foo_ ## PropTagName OPM_UNUSED  =                  \
         PropertyInfo<TTAG(EffTypeTagName), PTAG(PropTagName)>::init();  \
     }
 
@@ -100,7 +101,7 @@ namespace Properties {
             return 0;                                                   \
         }                                                               \
     };                                                                  \
-    static const int fooTypeTagInfo_ ## TagName =                       \
+    static const int fooTypeTagInfo_ ## TagName OPM_UNUSED =            \
         TypeTagInfo<TagName>::init();
 
 //! Internal macro which is only required if the property introspection is enabled
@@ -113,7 +114,7 @@ namespace Properties {
             return 0;                                                   \
         }                                                               \
     };                                                                  \
-    static const int fooSpliceInfo_ ## SpliceName =                     \
+    static const int fooSpliceInfo_ ## SpliceName OPM_UNUSED =          \
         SpliceInfo<TTAG(SpliceName)>::init();
 
 #else

--- a/tests/lens_immiscible_ecfv_ad.hh
+++ b/tests/lens_immiscible_ecfv_ad.hh
@@ -26,14 +26,25 @@
  * \brief Two-phase test for the immiscible model which uses the element-centered finite
  *        volume discretization in conjunction with automatic differentiation
  */
-#include "config.h"
+#ifndef EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH
+#define EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH
 
-#include "lens_immiscible_ecfv_ad.hh"
+#include <ewoms/models/immiscible/immisciblemodel.hh>
+#include <ewoms/disc/ecfv/ecfvdiscretization.hh>
+#include "problems/lensproblem.hh"
 
-#include <ewoms/common/start.hh>
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(LensProblemEcfvAd, INHERITS_FROM(ImmiscibleTwoPhaseModel, LensBaseProblem));
 
-int main(int argc, char **argv)
-{
-    typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
-}
+// use the element centered finite volume spatial discretization
+SET_TAG_PROP(LensProblemEcfvAd, SpatialDiscretizationSplice, EcfvDiscretization);
+
+// use automatic differentiation for this simulator
+SET_TAG_PROP(LensProblemEcfvAd, LocalLinearizerSplice, AutoDiffLocalLinearizer);
+
+// this problem works fine if the linear solver uses single precision scalars
+SET_TYPE_PROP(LensProblemEcfvAd, LinearSolverScalar, float);
+}}
+
+#endif // EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH

--- a/tests/lens_immiscible_ecfv_ad_cu1.cc
+++ b/tests/lens_immiscible_ecfv_ad_cu1.cc
@@ -23,8 +23,14 @@
 /*!
  * \file
  *
- * \brief Two-phase test for the immiscible model which uses the element-centered finite
- *        volume discretization in conjunction with automatic differentiation
+ * \brief This test is identical to the simulation of the lens problem that uses the
+ *        element centered finite volume discretization in conjunction with automatic
+ *        differentiation (lens_immiscible_ecfv_ad).
+ *
+ * The only difference is that it uses multiple compile units in order to ensure that
+ * eWoms code can be used within libraries that use the same type tag within multiple
+ * compile units. This file represents the first compile unit and just defines an startup
+ * function for the simulator.
  */
 #include "config.h"
 
@@ -32,7 +38,7 @@
 
 #include <ewoms/common/start.hh>
 
-int main(int argc, char **argv)
+int mainCU1(int argc, char **argv)
 {
     typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);

--- a/tests/lens_immiscible_ecfv_ad_cu2.cc
+++ b/tests/lens_immiscible_ecfv_ad_cu2.cc
@@ -23,8 +23,14 @@
 /*!
  * \file
  *
- * \brief Two-phase test for the immiscible model which uses the element-centered finite
- *        volume discretization in conjunction with automatic differentiation
+ * \brief This test is identical to the simulation of the lens problem that uses the
+ *        element centered finite volume discretization in conjunction with automatic
+ *        differentiation (lens_immiscible_ecfv_ad).
+ *
+ * The only difference is that it uses multiple compile units in order to ensure that
+ * eWoms code can be used within libraries that use the same type tag within multiple
+ * compile units. This file represents the second compile unit and just defines an
+ * startup function for the simulator.
  */
 #include "config.h"
 
@@ -32,7 +38,7 @@
 
 #include <ewoms/common/start.hh>
 
-int main(int argc, char **argv)
+int mainCU2(int argc, char **argv)
 {
     typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;
     return Ewoms::start<ProblemTypeTag>(argc, argv);

--- a/tests/lens_immiscible_ecfv_ad_main.cc
+++ b/tests/lens_immiscible_ecfv_ad_main.cc
@@ -23,17 +23,19 @@
 /*!
  * \file
  *
- * \brief Two-phase test for the immiscible model which uses the element-centered finite
- *        volume discretization in conjunction with automatic differentiation
+ * \brief This test is identical to the simulation of the lens problem that uses the
+ *        element centered finite volume discretization in conjunction with automatic
+ *        differentiation (lens_immiscible_ecfv_ad).
+ *
+ * The only difference is that it uses multiple compile units in order to ensure that
+ * eWoms code can be used within libraries that use the same type tag within multiple
+ * compile units. This file calls contains main() and just calls the main entry point
+ * defined by the first compile unit.
  */
-#include "config.h"
-
-#include "lens_immiscible_ecfv_ad.hh"
-
-#include <ewoms/common/start.hh>
+int mainCU1(int argc, char **argv);
+int mainCU2(int argc, char **argv);
 
 int main(int argc, char **argv)
 {
-    typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;
-    return Ewoms::start<ProblemTypeTag>(argc, argv);
+    return mainCU1(argc, argv);
 }


### PR DESCRIPTION
so far, the linker bailed out due to duplicate definitions of variables if multiple compile units used the same type tag. This is problematic if the sources are split into separate compile units and that use the same type tag; in particular, this applies for traditional libraries.

Due to various C++ peculiarities, this patch complicates the internal implementation of the property system quite a bit, but given that the usage of it (as well as the compile time) stay unchanged, I do not
consider this to be a big problem. Note that the introspection code is particularly problematic because it needs static initializers that do not cause the linker to choke in the case of multiple compile units.

Finally, to prevent future regressions, this patch adds a unit test for the lens problem which uses multiple compile units. (This test is called lens_immiscible_ecfv_ad_mcu and basically identical to the existing lens_immiscible_ecfv_ad test and I thus think that it is pretty unimaginative -- improvement proposals are welcome.)

This PR should fix the issue raised in #218. if jenkins is happy I indend to self-merge this next week. (if nobody presses green first, permission to do so hereby granted.)