### PR TITLE
Fix to make 2p gasoil and wateroil compile and run

### DIFF
--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -41,6 +41,11 @@ struct BlackOilIndices
     //! Number of phases active at all times
     static const int numPhases = 3;
 
+    //! All phases are enabled
+    static const bool oilEnabled = true;
+    static const bool waterEnabled = true;
+    static const bool gasEnabled = true;
+
     //! Number of solvent components considered
     static const int numSolvents = numSolventsV;
 
@@ -49,6 +54,10 @@ struct BlackOilIndices
 
     //! The number of equations
     static const int numEq = numPhases + numSolvents + numPolymers;
+
+    //! \brief returns the index of "active" component
+    static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
+    { return compIdx; }
 
     ////////
     // Primary variable indices

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -84,8 +84,9 @@ class BlackOilIntensiveQuantities
     enum { dimWorld = GridView::dimensionworld };
     enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
 
-    // if compositionSwitchIdx is negative then this feature is disabled in Indices
-    static const bool compositionSwitchEnabled = (compositionSwitchIdx >= 0 );
+    static const bool compositionSwitchEnabled = Indices::gasEnabled;
+    static const bool waterEnabled = Indices::waterEnabled;
+
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
@@ -120,7 +121,9 @@ public:
         fluidState_.setPvtRegionIndex(pvtRegionIdx);
 
         // extract the water and the gas saturations for convenience
-        Evaluation Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
+        Evaluation Sw = 0.0;
+        if (waterEnabled)
+            Sw = priVars.makeEvaluation(Indices::waterSaturationIdx, timeIdx);
 
         Evaluation Sg = 0.0;
         if (compositionSwitchEnabled)

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -209,8 +209,8 @@ class BlackOilModel
     enum { numComponents = FluidSystem::numComponents };
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
 
-    // if compositionSwitchIdx is negative then this feature is disabled in Indices
-    static const bool compositionSwitchEnabled = (Indices::compositionSwitchIdx >= 0);
+    static const bool compositionSwitchEnabled = Indices::gasEnabled;
+    static const bool waterEnabled = Indices::waterEnabled;
 
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
@@ -512,7 +512,9 @@ public:
                 Scalar So = 0.0;
                 switch (priVars.primaryVarsMeaning()) {
                 case PrimaryVariables::Sw_po_Sg:
-                    So = 1.0 - priVars[Indices::waterSaturationIdx];
+                    So = 1.0;
+                    if( waterEnabled)
+                        So -= priVars[Indices::waterSaturationIdx];
                     if( compositionSwitchEnabled )
                         So -= priVars[Indices::compositionSwitchIdx];
                     break;
@@ -520,7 +522,9 @@ public:
                     So = 0.0;
                     break;
                 case PrimaryVariables::Sw_po_Rs:
-                    So = 1.0 - priVars[Indices::waterSaturationIdx];
+                    So = 1.0;
+                    if (waterEnabled)
+                        So -= priVars[Indices::waterSaturationIdx];
                     break;
                 }
 

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -82,7 +82,6 @@ class BlackOilPolymerModule
 
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr unsigned contiPolymerEqIdx = Indices::contiPolymerEqIdx;
-    static constexpr unsigned contiWaterEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
     static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
 
@@ -477,6 +476,8 @@ public:
         unsigned upIdx = extQuants.upstreamIndex(FluidSystem::waterPhaseIdx);
         unsigned inIdx = extQuants.interiorIndex();
         const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+        const unsigned contiWaterEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
+
 
         if (upIdx == inIdx) {
             flux[contiPolymerEqIdx] =

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -82,7 +82,7 @@ class BlackOilPolymerModule
 
     static constexpr unsigned polymerConcentrationIdx = Indices::polymerConcentrationIdx;
     static constexpr unsigned contiPolymerEqIdx = Indices::contiPolymerEqIdx;
-    static constexpr unsigned contiWaterEqIdx = Indices::conti0EqIdx + FluidSystem::waterCompIdx ;
+    static constexpr unsigned contiWaterEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
     static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
 
 

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -87,7 +87,7 @@ struct BlackOilTwoPhaseIndices
     // Equation indices
     //////////////////////
     //! \brief returns the index of "active" component
-    static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
+    static const unsigned canonicalToActiveComponentIndex(unsigned compIdx)
     {
         // assumes canonical oil = 0, water = 1, gas = 2;
         if(!gasEnabled) {

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -35,9 +35,15 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
 struct BlackOilTwoPhaseIndices
 {
+
+    //! Is phase enabled or not
+    static const bool oilEnabled = disabledCanonicalCompIdx==0? false:true;
+    static const bool waterEnabled = disabledCanonicalCompIdx==1? false:true;
+    static const bool gasEnabled = disabledCanonicalCompIdx==2? false:true;
+
     //! Number of phases active at all times
     static const int numPhases = 2;
 
@@ -54,8 +60,8 @@ struct BlackOilTwoPhaseIndices
     // Primary variable indices
     //////////////////////////////
 
-    //! The index of the water saturation
-    static const int waterSaturationIdx  = PVOffset + 0;
+    //! The index of the water saturation. For two-phase oil gas models this is disabled.
+    static const int waterSaturationIdx  = waterEnabled ? PVOffset + 0: -10000;
 
     //! Index of the oil pressure in a vector of primary variables
     static const int pressureSwitchIdx  = PVOffset + 1;
@@ -64,9 +70,9 @@ struct BlackOilTwoPhaseIndices
      * \brief Index of the switching variable which determines the composition of the
      *        hydrocarbon phases.
      *
-     * \note For Two-Phase models this is disabled.
+     * \note For two-phase water oil models this is disabled.
      */
-    static const int compositionSwitchIdx = -1000000;
+    static const int compositionSwitchIdx = gasEnabled ? PVOffset + 0: -10000;
 
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx  = PVOffset + numPhases;
@@ -76,9 +82,29 @@ struct BlackOilTwoPhaseIndices
 
     // numSolvents-1 primary variables follow
 
+
     //////////////////////
     // Equation indices
     //////////////////////
+    //! \brief returns the index of "active" component
+    static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
+    {
+        // assumes canonical oil = 0, water = 1, gas = 2;
+        if(!gasEnabled) {
+            assert(compIdx != 2);
+            // oil = 0, water = 1
+            return compIdx;
+        } else if (!waterEnabled) {
+            assert(compIdx != 1);
+            // oil = 0, gas = 1
+            return compIdx / 2;
+        } else {
+            assert(!oilEnabled);
+            assert(compIdx != 0);
+        }
+        // water = 0, gas = 1;
+        return compIdx-1;
+    }
 
     //! Index of the continuity equation of the first phase
     static const int conti0EqIdx = PVOffset + 0;
@@ -90,6 +116,7 @@ struct BlackOilTwoPhaseIndices
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx = contiSolventEqIdx + numPolymers;
     // numSolvents-1 continuity equations follow
+
 };
 
 } // namespace Ewoms


### PR DESCRIPTION
- method for mapping from canonicalToActiveComponentIndex() is added
- guards are added to avoid access to non present components. 