### PR TITLE
Bug fix for pvsratevector indices in setMassRate function

### DIFF
--- a/ewoms/models/pvs/pvsratevector.hh
+++ b/ewoms/models/pvs/pvsratevector.hh
@@ -88,8 +88,8 @@ public:
     {
         // convert to molar rates
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
-            (*this)[compIdx] = value[compIdx];
-            (*this)[compIdx] /= FluidSystem::molarMass(compIdx);
+            (*this)[conti0EqIdx + compIdx] = value[conti0EqIdx + compIdx];
+            (*this)[conti0EqIdx + compIdx] /= FluidSystem::molarMass(compIdx);
         }
     }
 


### PR DESCRIPTION
The setMassRate function accesses the wrong index of the pvsRateVector.