### PR TITLE
update packaging to reflect new libecl

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper (>= 9), cmake,
  doxygen, texlive-latex-extra, texlive-latex-recommended, ghostscript,
  libboost-filesystem-dev, libboost-system-dev, libboost-date-time-dev,
  libboost-test-dev, libsuperlu3-dev (>= 3.0) | libsuperlu-dev (>= 4.3),
- gfortran, libsuitesparse-dev, libert.ecl-dev, libopm-output-dev, zlib1g-dev,
+ gfortran, libsuitesparse-dev, libecl-dev, libopm-output-dev, zlib1g-dev,
  libopm-parser-dev, libboost-iostreams-dev, libopm-common-dev, libopm-grid-dev,
  mpi-default-dev, mpi-default-bin
 Standards-Version: 3.9.3

--- a/debian/rules
+++ b/debian/rules
@@ -21,10 +21,12 @@ override_dh_auto_build:
 
 # consider using -DUSE_VERSIONED_DIR=ON if backporting
 override_dh_auto_configure:
-	dh_auto_configure --buildsystem=cmake -- -DUSE_MPI=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libewoms1-dev -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DADD_DISABLED_CTESTS=0 -DUSE_QUADMATH=0 -DBUILD_TESTING=1 -DWITH_NATIVE=OFF
+	dh_auto_configure --buildsystem=cmake -- -DUSE_MPI=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=1 -DCMAKE_INSTALL_DOCDIR=share/doc/libewoms1-dev -DWHOLE_PROG_OPTIM=OFF -DUSE_RUNPATH=OFF -DADD_DISABLED_CTESTS=0 -DUSE_QUADMATH=0 -DBUILD_TESTING=0 -DWITH_NATIVE=OFF
 
 override_dh_auto_install:
 	dh_auto_install -- install-html
 
 override_dh_installdocs:
 	dh_installdocs --link-doc=libewoms1-dev
+
+override_dh_auto_test:


### PR DESCRIPTION
also disable testing in packaging.
the test target in ewoms is rather broken, and incompatible with
packaging.