### PR TITLE
ebos: simplify passing of pre-parsed ECL decks

### DIFF
--- a/ebos/ebos.cc
+++ b/ebos/ebos.cc
@@ -35,6 +35,10 @@
 namespace Ewoms {
 namespace Properties {
 NEW_TYPE_TAG(EclProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
+
+//! Set the SimulatorParameter to be empty to avoid the deprecation warnings.
+//! THE SimulatorParameter MECHANISM IS A DEPRECATED HACK, PLEASE REMOVE IT ASAP!
+SET_TYPE_PROP(EclProblem, SimulatorParameter, Ewoms::EmptySimulationParameters);
 }}
 
 int main(int argc, char **argv)

--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -39,6 +39,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
+#include <dune/common/deprecated.hh>
+
 #if HAVE_MPI
 #include <mpi.h>
 #endif // HAVE_MPI
@@ -46,10 +48,13 @@
 #include <vector>
 #include <unordered_set>
 #include <array>
+#include <type_traits>
 
 namespace Ewoms {
 template <class TypeTag>
 class EclBaseGridManager;
+
+struct EmptySimulationParameters; //< \deprecated, please remove ASAP!
 
 namespace Properties {
 NEW_TYPE_TAG(EclBaseGridManager);
@@ -58,9 +63,13 @@ NEW_TYPE_TAG(EclBaseGridManager);
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(EquilGrid);
 NEW_PROP_TAG(Scalar);
+
 NEW_PROP_TAG(EclDeckFileName);
 
+NEW_PROP_TAG(SimulatorParameter); //< \deprecated, please remove ASAP!
+
 SET_STRING_PROP(EclBaseGridManager, EclDeckFileName, "ECLDECK.DATA");
+
 } // namespace Properties
 
 /*!
@@ -147,33 +156,37 @@ public:
         caseName_ = rawCaseName;
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
 
-        if (!externalDeck_) {
-            if (myRank == 0)
-                std::cout << "Reading the deck file '" << fileName << "'" << std::endl;
+        if (!getDeckFromSimulatorParameter_()) {
+            if (!externalDeck_) {
+                if (myRank == 0)
+                    std::cout << "Reading the deck file '" << fileName << "'" << std::endl;
 
-            Opm::Parser parser;
-            typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
-            typedef std::vector<ParseModePair> ParseModePairs;
+                Opm::Parser parser;
+                typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
+                typedef std::vector<ParseModePair> ParseModePairs;
 
-            ParseModePairs tmp;
-            tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
-            tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
-            tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
-            tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
-            Opm::ParseContext parseContext(tmp);
+                ParseModePairs tmp;
+                tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
+                tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
+                tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
+                tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
+                Opm::ParseContext parseContext(tmp);
 
-            internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName , parseContext)));
-            internalEclState_.reset(new Opm::EclipseState(*internalDeck_, parseContext));
+                internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName , parseContext)));
+                internalEclState_.reset(new Opm::EclipseState(*internalDeck_, parseContext));
 
-            deck_ = &(*internalDeck_);
-            eclState_ = &(*internalEclState_);
-        }
-        else {
-            assert(externalDeck_);
-            assert(externalEclState_);
+                deck_ = &(*internalDeck_);
+                eclState_ = &(*internalEclState_);
+            }
+            // check if the deprecated SimulatorParameter mechanism is used to pass external
+            // parameters.
+            else {
+                assert(externalDeck_);
+                assert(externalEclState_);
 
-            deck_ = externalDeck_;
-            eclState_ = externalEclState_;
+                deck_ = externalDeck_;
+                eclState_ = externalEclState_;
+            }
         }
 
         asImp_().createGrids_();
@@ -287,6 +300,36 @@ private:
 
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
+
+    // set the deck via the deprecated SimulatorParameter mechanism. The template-foo
+    // ensures that if the simulator parameters are non-empty, a deprecation warning is
+    // produced.
+    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter) SimulatorParameter;
+    template <class SimParam = SimulatorParameter>
+    DUNE_DEPRECATED_MSG("Use static setExternalDeck() to pass external parameters to the instead of SimulatorParameter mechanism")
+    typename std::enable_if<!std::is_same<SimParam, Ewoms::EmptySimulationParameters>::value,
+                            bool>::type
+    getDeckFromSimulatorParameter_()
+    {
+        const auto& simParam = this->simulator_.simulatorParameter();
+        if (simParam.first) {
+            externalDeck_ = &(*simParam.first);
+            externalEclState_ = &(*simParam.second);
+
+            deck_ = externalDeck_;
+            eclState_ = externalEclState_;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    template <class SimParam = SimulatorParameter>
+    typename std::enable_if<std::is_same<SimParam, Ewoms::EmptySimulationParameters>::value,
+                            bool>::type
+    getDeckFromSimulatorParameter_()
+    { return false; }
 
     std::string caseName_;
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -240,10 +240,6 @@ SET_BOOL_PROP(EclBaseProblem, EnableDebuggingChecks, true);
 
 // ebos handles the SWATINIT keyword by default
 SET_BOOL_PROP(EclBaseProblem, EnableSwatinit, true);
-
-//! Set the ParameterMetaData property
-SET_TYPE_PROP(EclBaseProblem, SimulatorParameter, std::pair< std::shared_ptr<Opm::Deck>, std::shared_ptr<Opm::EclipseState> > );
-
 } // namespace Properties
 
 /*!

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -240,6 +240,10 @@ SET_BOOL_PROP(EclBaseProblem, EnableDebuggingChecks, true);
 
 // ebos handles the SWATINIT keyword by default
 SET_BOOL_PROP(EclBaseProblem, EnableSwatinit, true);
+
+//! Set the SimulatorParameter property. THIS IS A DEPRECATED HACK, PLEASE REMOVE ASAP!
+SET_TYPE_PROP(EclBaseProblem, SimulatorParameter, std::pair< std::shared_ptr<Opm::Deck>, std::shared_ptr<Opm::EclipseState> > );
+
 } // namespace Properties
 
 /*!

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -173,7 +173,6 @@ NEW_PROP_TAG(ParameterMetaData);
 NEW_PROP_TAG(ParameterGroupPrefix);
 NEW_PROP_TAG(Description);
 
-NEW_PROP_TAG(SimulatorParameter);
 
 //! Set the ParameterMetaData property
 SET_PROP(ParameterSystem, ParameterMetaData)
@@ -215,11 +214,6 @@ private:
         return obj;
     }
 };
-
-struct EmptyParameters {};
-
-//! Set the ParameterMetaData property
-SET_TYPE_PROP(ParameterSystem, SimulatorParameter, EmptyParameters );
 
 SET_STRING_PROP(ParameterSystem, ParameterGroupPrefix, "");
 SET_STRING_PROP(ParameterSystem, Description, "");

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -80,26 +80,11 @@ class Simulator
     typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
 
-    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter)  SimulatorParameter;
-
-
 public:
     // do not allow to copy simulators around
     Simulator(const Simulator& ) = delete;
 
     Simulator(bool verbose = true)
-        : simulatorParameter_()
-    {
-        init( verbose );
-    }
-
-    Simulator(const SimulatorParameter& parameter, bool verbose = true)
-        : simulatorParameter_( parameter )
-    {
-        init( verbose );
-    }
-
-    void init( bool verbose )
     {
         Ewoms::TimerGuard setupTimerGuard(setupTimer_);
 
@@ -861,12 +846,7 @@ public:
         restarter.deserializeSectionEnd();
     }
 
-    const SimulatorParameter& simulatorParameter() const { return simulatorParameter_; }
-    SimulatorParameter& simulatorParameter() { return simulatorParameter_; }
-
 private:
-    SimulatorParameter simulatorParameter_;
-
     std::unique_ptr<GridManager> gridManager_;
     std::unique_ptr<Model> model_;
     std::unique_ptr<Problem> problem_;

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -35,6 +35,7 @@
 #include <ewoms/common/timer.hh>
 #include <ewoms/common/timerguard.hh>
 
+#include <dune/common/deprecated.hh>
 #include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
@@ -44,9 +45,11 @@
 #include <vector>
 #include <string>
 #include <memory>
-
+#include <type_traits>
 
 namespace Ewoms {
+struct EmptySimulationParameters; //< \deprecated, please remove ASAP!
+
 namespace Properties {
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(GridManager);
@@ -57,6 +60,7 @@ NEW_PROP_TAG(EndTime);
 NEW_PROP_TAG(RestartTime);
 NEW_PROP_TAG(InitialTimeStepSize);
 NEW_PROP_TAG(PredeterminedTimeStepsFile);
+NEW_PROP_TAG(SimulatorParameter);
 }
 
 /*!
@@ -79,12 +83,27 @@ class Simulator
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
+    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter) SimulatorParameter;
 
 public:
     // do not allow to copy simulators around
-    Simulator(const Simulator& ) = delete;
+    Simulator(const Simulator&) = delete;
 
     Simulator(bool verbose = true)
+    {
+        init_(verbose);
+    }
+
+    Simulator(SimulatorParameter& param,
+              bool verbose = true)
+        DUNE_DEPRECATED_MSG("Use static attributes/global variables in the target classes to pass external parameters to the instead of SimulatorParameter")
+        : simulatorParameter_(param)
+    {
+        init_(verbose);
+    }
+
+private:
+    void init_(bool verbose = true)
     {
         Ewoms::TimerGuard setupTimerGuard(setupTimer_);
 
@@ -145,6 +164,7 @@ public:
             std::cout << "Construction of simulation done\n" << std::flush;
     }
 
+public:
     /*!
      * \brief Registers all runtime parameters used by the simulation.
      */
@@ -846,7 +866,26 @@ public:
         restarter.deserializeSectionEnd();
     }
 
+    // returns the deprecated SimulatorParameter object. The template-foo ensures that if
+    // the simulator parameters are non-empty, a deprecation warning is produced.
+    template <class SimParam = SimulatorParameter>
+    DUNE_DEPRECATED_MSG("Use static attributes/global variables in the target classes to pass external parameters to the instead of SimulatorParameter")
+    const
+    typename std::enable_if<!std::is_same<SimParam, EmptySimulationParameters>::value,
+                            SimParam>::type&
+    simulatorParameter() const
+    { return simulatorParameter_; }
+
+    template <class SimParam = SimulatorParameter>
+    const
+    typename std::enable_if<std::is_same<SimParam, EmptySimulationParameters>::value,
+                            SimParam>::type&
+    simulatorParameter() const
+    { return simulatorParameter_; }
+
 private:
+    SimulatorParameter simulatorParameter_;
+
     std::unique_ptr<GridManager> gridManager_;
     std::unique_ptr<Model> model_;
     std::unique_ptr<Problem> problem_;

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -82,6 +82,10 @@ namespace Ewoms {
 template<class TypeTag>
 class FvBaseDiscretization;
 
+//! \deprecated please remove ASAP!
+struct EmptySimulationParameters
+{};
+
 namespace Properties {
 //! Set the default type for the time manager
 SET_TYPE_PROP(FvBaseDiscretization, Simulator, Ewoms::Simulator<TypeTag>);
@@ -254,6 +258,8 @@ SET_BOOL_PROP(FvBaseDiscretization, ExtensiveStorageTerm, false);
 // use volumetric residuals is default
 SET_BOOL_PROP(FvBaseDiscretization, UseVolumetricResidual, true);
 
+//! The DEPRECATED structure to pass external runtime parameters to the simulator.
+SET_TYPE_PROP(FvBaseDiscretization, SimulatorParameter, EmptySimulationParameters);
 } // namespace Properties
 
 /*!

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -292,6 +292,13 @@ NEW_PROP_TAG(ExtensiveStorageTerm);
 //! \brief Specify whether to use volumetric residuals or not
 NEW_PROP_TAG(UseVolumetricResidual);
 
+/*!
+ * \brief Structure which stores externally passed runtime parameters for the simulator.
+ *
+ * BEWARE: This property is deprecated
+ */
+NEW_PROP_TAG(SimulatorParameter);
+
 }} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/io/basegridmanager.hh
+++ b/ewoms/io/basegridmanager.hh
@@ -136,6 +136,7 @@ private:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
+protected:
     Simulator& simulator_;
     std::unique_ptr<GridView> gridView_;
 #if HAVE_DUNE_FEM

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -89,7 +89,7 @@ struct BlackOilTwoPhaseIndices
     // Equation indices
     //////////////////////
     //! \brief returns the index of "active" component
-    static const unsigned canonicalToActiveComponentIndex(unsigned compIdx)
+    static unsigned canonicalToActiveComponentIndex(unsigned compIdx)
     {
         // assumes canonical oil = 0, water = 1, gas = 2;
         if(!gasEnabled) {


### PR DESCRIPTION
This gets rid of some special-purpose code in generic places (i.e. the `SimulatorParameter` class) and no special hacks to the property and parameter system are required anymore.