### PR TITLE
remove the deprecated SimulatorParameter mechanism

### DIFF
--- a/ebos/ebos.cc
+++ b/ebos/ebos.cc
@@ -35,10 +35,6 @@
 namespace Ewoms {
 namespace Properties {
 NEW_TYPE_TAG(EclProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
-
-//! Set the SimulatorParameter to be empty to avoid the deprecation warnings.
-//! THE SimulatorParameter MECHANISM IS A DEPRECATED HACK, PLEASE REMOVE IT ASAP!
-SET_TYPE_PROP(EclProblem, SimulatorParameter, Ewoms::EmptySimulationParameters);
 }}
 
 int main(int argc, char **argv)

--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -39,8 +39,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 
-#include <dune/common/deprecated.hh>
-
 #if HAVE_MPI
 #include <mpi.h>
 #endif // HAVE_MPI
@@ -48,13 +46,10 @@
 #include <vector>
 #include <unordered_set>
 #include <array>
-#include <type_traits>
 
 namespace Ewoms {
 template <class TypeTag>
 class EclBaseGridManager;
-
-struct EmptySimulationParameters; //< \deprecated, please remove ASAP!
 
 namespace Properties {
 NEW_TYPE_TAG(EclBaseGridManager);
@@ -63,13 +58,9 @@ NEW_TYPE_TAG(EclBaseGridManager);
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(EquilGrid);
 NEW_PROP_TAG(Scalar);
-
 NEW_PROP_TAG(EclDeckFileName);
 
-NEW_PROP_TAG(SimulatorParameter); //< \deprecated, please remove ASAP!
-
 SET_STRING_PROP(EclBaseGridManager, EclDeckFileName, "ECLDECK.DATA");
-
 } // namespace Properties
 
 /*!
@@ -156,37 +147,33 @@ public:
         caseName_ = rawCaseName;
         std::transform(caseName_.begin(), caseName_.end(), caseName_.begin(), ::toupper);
 
-        if (!getDeckFromSimulatorParameter_()) {
-            if (!externalDeck_) {
-                if (myRank == 0)
-                    std::cout << "Reading the deck file '" << fileName << "'" << std::endl;
+        if (!externalDeck_) {
+            if (myRank == 0)
+                std::cout << "Reading the deck file '" << fileName << "'" << std::endl;
 
-                Opm::Parser parser;
-                typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
-                typedef std::vector<ParseModePair> ParseModePairs;
+            Opm::Parser parser;
+            typedef std::pair<std::string, Opm::InputError::Action> ParseModePair;
+            typedef std::vector<ParseModePair> ParseModePairs;
 
-                ParseModePairs tmp;
-                tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
-                tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
-                tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
-                tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
-                Opm::ParseContext parseContext(tmp);
+            ParseModePairs tmp;
+            tmp.emplace_back(Opm::ParseContext::PARSE_RANDOM_SLASH, Opm::InputError::IGNORE);
+            tmp.emplace_back(Opm::ParseContext::PARSE_MISSING_DIMS_KEYWORD, Opm::InputError::WARN);
+            tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_WELL, Opm::InputError::WARN);
+            tmp.emplace_back(Opm::ParseContext::SUMMARY_UNKNOWN_GROUP, Opm::InputError::WARN);
+            Opm::ParseContext parseContext(tmp);
 
-                internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName , parseContext)));
-                internalEclState_.reset(new Opm::EclipseState(*internalDeck_, parseContext));
+            internalDeck_.reset(new Opm::Deck(parser.parseFile(fileName , parseContext)));
+            internalEclState_.reset(new Opm::EclipseState(*internalDeck_, parseContext));
 
-                deck_ = &(*internalDeck_);
-                eclState_ = &(*internalEclState_);
-            }
-            // check if the deprecated SimulatorParameter mechanism is used to pass external
-            // parameters.
-            else {
-                assert(externalDeck_);
-                assert(externalEclState_);
+            deck_ = &(*internalDeck_);
+            eclState_ = &(*internalEclState_);
+        }
+        else {
+            assert(externalDeck_);
+            assert(externalEclState_);
 
-                deck_ = externalDeck_;
-                eclState_ = externalEclState_;
-            }
+            deck_ = externalDeck_;
+            eclState_ = externalEclState_;
         }
 
         asImp_().createGrids_();
@@ -300,36 +287,6 @@ private:
 
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
-
-    // set the deck via the deprecated SimulatorParameter mechanism. The template-foo
-    // ensures that if the simulator parameters are non-empty, a deprecation warning is
-    // produced.
-    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter) SimulatorParameter;
-    template <class SimParam = SimulatorParameter>
-    DUNE_DEPRECATED_MSG("Use static setExternalDeck() to pass external parameters to the instead of SimulatorParameter mechanism")
-    typename std::enable_if<!std::is_same<SimParam, Ewoms::EmptySimulationParameters>::value,
-                            bool>::type
-    getDeckFromSimulatorParameter_()
-    {
-        const auto& simParam = this->simulator_.simulatorParameter();
-        if (simParam.first) {
-            externalDeck_ = &(*simParam.first);
-            externalEclState_ = &(*simParam.second);
-
-            deck_ = externalDeck_;
-            eclState_ = externalEclState_;
-
-            return true;
-        }
-
-        return false;
-    }
-
-    template <class SimParam = SimulatorParameter>
-    typename std::enable_if<std::is_same<SimParam, Ewoms::EmptySimulationParameters>::value,
-                            bool>::type
-    getDeckFromSimulatorParameter_()
-    { return false; }
 
     std::string caseName_;
 

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -240,10 +240,6 @@ SET_BOOL_PROP(EclBaseProblem, EnableDebuggingChecks, true);
 
 // ebos handles the SWATINIT keyword by default
 SET_BOOL_PROP(EclBaseProblem, EnableSwatinit, true);
-
-//! Set the SimulatorParameter property. THIS IS A DEPRECATED HACK, PLEASE REMOVE ASAP!
-SET_TYPE_PROP(EclBaseProblem, SimulatorParameter, std::pair< std::shared_ptr<Opm::Deck>, std::shared_ptr<Opm::EclipseState> > );
-
 } // namespace Properties
 
 /*!

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -35,7 +35,6 @@
 #include <ewoms/common/timer.hh>
 #include <ewoms/common/timerguard.hh>
 
-#include <dune/common/deprecated.hh>
 #include <dune/common/version.hh>
 #include <dune/common/parallel/mpihelper.hh>
 
@@ -45,11 +44,9 @@
 #include <vector>
 #include <string>
 #include <memory>
-#include <type_traits>
+
 
 namespace Ewoms {
-struct EmptySimulationParameters; //< \deprecated, please remove ASAP!
-
 namespace Properties {
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(GridManager);
@@ -60,7 +57,6 @@ NEW_PROP_TAG(EndTime);
 NEW_PROP_TAG(RestartTime);
 NEW_PROP_TAG(InitialTimeStepSize);
 NEW_PROP_TAG(PredeterminedTimeStepsFile);
-NEW_PROP_TAG(SimulatorParameter);
 }
 
 /*!
@@ -83,27 +79,12 @@ class Simulator
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
-    typedef typename GET_PROP_TYPE(TypeTag, SimulatorParameter) SimulatorParameter;
 
 public:
     // do not allow to copy simulators around
-    Simulator(const Simulator&) = delete;
+    Simulator(const Simulator& ) = delete;
 
     Simulator(bool verbose = true)
-    {
-        init_(verbose);
-    }
-
-    Simulator(SimulatorParameter& param,
-              bool verbose = true)
-        DUNE_DEPRECATED_MSG("Use static attributes/global variables in the target classes to pass external parameters to the instead of SimulatorParameter")
-        : simulatorParameter_(param)
-    {
-        init_(verbose);
-    }
-
-private:
-    void init_(bool verbose = true)
     {
         Ewoms::TimerGuard setupTimerGuard(setupTimer_);
 
@@ -164,7 +145,6 @@ private:
             std::cout << "Construction of simulation done\n" << std::flush;
     }
 
-public:
     /*!
      * \brief Registers all runtime parameters used by the simulation.
      */
@@ -866,26 +846,7 @@ public:
         restarter.deserializeSectionEnd();
     }
 
-    // returns the deprecated SimulatorParameter object. The template-foo ensures that if
-    // the simulator parameters are non-empty, a deprecation warning is produced.
-    template <class SimParam = SimulatorParameter>
-    DUNE_DEPRECATED_MSG("Use static attributes/global variables in the target classes to pass external parameters to the instead of SimulatorParameter")
-    const
-    typename std::enable_if<!std::is_same<SimParam, EmptySimulationParameters>::value,
-                            SimParam>::type&
-    simulatorParameter() const
-    { return simulatorParameter_; }
-
-    template <class SimParam = SimulatorParameter>
-    const
-    typename std::enable_if<std::is_same<SimParam, EmptySimulationParameters>::value,
-                            SimParam>::type&
-    simulatorParameter() const
-    { return simulatorParameter_; }
-
 private:
-    SimulatorParameter simulatorParameter_;
-
     std::unique_ptr<GridManager> gridManager_;
     std::unique_ptr<Model> model_;
     std::unique_ptr<Problem> problem_;

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -82,10 +82,6 @@ namespace Ewoms {
 template<class TypeTag>
 class FvBaseDiscretization;
 
-//! \deprecated please remove ASAP!
-struct EmptySimulationParameters
-{};
-
 namespace Properties {
 //! Set the default type for the time manager
 SET_TYPE_PROP(FvBaseDiscretization, Simulator, Ewoms::Simulator<TypeTag>);
@@ -258,8 +254,6 @@ SET_BOOL_PROP(FvBaseDiscretization, ExtensiveStorageTerm, false);
 // use volumetric residuals is default
 SET_BOOL_PROP(FvBaseDiscretization, UseVolumetricResidual, true);
 
-//! The DEPRECATED structure to pass external runtime parameters to the simulator.
-SET_TYPE_PROP(FvBaseDiscretization, SimulatorParameter, EmptySimulationParameters);
 } // namespace Properties
 
 /*!

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -292,13 +292,6 @@ NEW_PROP_TAG(ExtensiveStorageTerm);
 //! \brief Specify whether to use volumetric residuals or not
 NEW_PROP_TAG(UseVolumetricResidual);
 
-/*!
- * \brief Structure which stores externally passed runtime parameters for the simulator.
- *
- * BEWARE: This property is deprecated
- */
-NEW_PROP_TAG(SimulatorParameter);
-
 }} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/io/basegridmanager.hh
+++ b/ewoms/io/basegridmanager.hh
@@ -136,7 +136,6 @@ private:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-protected:
     Simulator& simulator_;
     std::unique_ptr<GridView> gridView_;
 #if HAVE_DUNE_FEM


### PR DESCRIPTION
since OPM/opm-simulators#1287 has been merged there are no "in tree" OPM upstreams which use that mechanism anymore.