### PR TITLE
Fix OpenMP

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -398,7 +398,7 @@ void printUsage(const std::string& progName, const std::string& errorMsg = "",
  *         not be read.
  */
 template <class TypeTag>
-std::string parseCommandLineOptions(int argc, char **argv, bool handleHelp = true)
+std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp = true)
 {
     Dune::ParameterTree& paramTree = GET_PROP(TypeTag, ParameterMetaData)::tree();
 

--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -91,7 +91,7 @@ namespace Ewoms {
  * \param argv Array with the command line argument strings
  */
 template <class TypeTag>
-static inline int setupParameters_(int argc, char **argv)
+static inline int setupParameters_(int argc, const char **argv)
 {
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, ThreadManager) ThreadManager;
@@ -225,7 +225,7 @@ static inline int start(int argc, char **argv)
 
     try
     {
-        int paramStatus = setupParameters_<TypeTag>(argc, argv);
+        int paramStatus = setupParameters_<TypeTag>(argc, const_cast<const char**>(argv));
         if (paramStatus == 1)
             return 1;
         if (paramStatus == 2)

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -1596,9 +1596,12 @@ public:
                     elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
                 }
 
-                modIt = outputModules_.begin();
-                for (; modIt != modEndIt; ++modIt)
-                    (*modIt)->processElement(elemCtx);
+                // we cannot reuse the "modIt" variable here because the code here might
+                // be threaded and "modIt" is is the same for all threads, i.e., if a
+                // given thread modifies it, the changes affect all threads.
+                auto modIt2 = outputModules_.begin();
+                for (; modIt2 != modEndIt; ++modIt2)
+                    (*modIt2)->processElement(elemCtx);
             }
         }
     }

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -347,7 +347,6 @@ private:
             // constraints are not explictly enabled, so we don't need to consider them!
             return;
 
-        unsigned threadId = ThreadManager::threadId();
         constraintsMap_.clear();
 
         // loop over all elements...
@@ -356,6 +355,7 @@ private:
 #pragma omp parallel
 #endif
         {
+            unsigned threadId = ThreadManager::threadId();
             ElementIterator elemIt = threadedElemIt.beginParallel();
             for (; !threadedElemIt.isFinished(elemIt); elemIt = threadedElemIt.increment()) {
                 // create an element context (the solution-based quantities are not


### PR DESCRIPTION
This makes multi-threaded linearization with OpenMP  work. (note that the linear solver is a quite different beast.)

this issue was only uncovered because the dune buildsystem branches (OPM/opm-common#277 et al) support enabling OpenMP without too much hassle. (I always had major headaches to get OpenMP into working conditions with the current build system.)
