### PR TITLE
fix the build condition for ebos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set(CMAKE_PROJECT_NAME "${PROJECT_NAME}")
 EwomsAddApplication(ebos
                     SOURCES ebos/ebos.cc
                     EXE_NAME ebos
-                    CONDITION ${OPM_GRID_FOUND} AND ${OPM_PARSER_FOUND} AND ${OPM_CORE_FOUND})
+                    CONDITION OPM_GRID_FOUND AND OPM_PARSER_FOUND AND OPM_CORE_FOUND)
 
 if(OPM_GRID_FOUND AND OPM_CORE_FOUND AND OPM_PARSER_FOUND)
   install(TARGETS ebos DESTINATION bin)


### PR DESCRIPTION
Another shenanigan of the current default OPM build system:

this produced a cmake syntax error if ewoms was compiled with only the mandatory opm modules available because some *_FOUND variables expand to the empty string instead of to "0" in this case.