### PR TITLE
update the build instructions and slightly improve the dunecontrol option files

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -3,7 +3,7 @@ Installation Instructions
 
 This file describes how to compile and install eWoms. In this context
 it is useful to keep in mind that eWoms is implemented as a DUNE
-module, i.e., the generic build instructions for DUNE modules should
+module, i.e., the generic build instructions for DUNE modules
 apply [4].
 
 Prerequisites
@@ -19,8 +19,8 @@ In order to compile eWoms, you first need to install the following OPM
 and DUNE modules:
 
   - opm-dune-cmake      from [3]
-  - opm-material        from [1] or [2]
-  - opm-common          from [1] or [2]
+  - opm-material        from [2]
+  - opm-common          from [2]
   - dune-common         from [0]
   - dune-geometry       from [0]
   - dune-grid           from [0]
@@ -30,13 +30,13 @@ and DUNE modules:
 To use the ECL Black-Oil Simulator (ebos), the following OPM modules
 are also required:
 
-  - opm-parser         from [1] or [2]
-  - opm-grid           from [1] or [2]
-  - opm-core           from [1] or [2]
+  - opm-parser         from [2]
+  - opm-grid           from [2]
 
-If you want to use the latest eWoms development version, the latest
+If you want to use the latest eWoms development version, the newest
 release of the DUNE prerequisites usually works best, for the OPM
-prerequisites, the latest master branches need to be used.
+prerequisites, current revisions of the master branches need to be
+used.
 
 Note: Many Linux distributions ship DUNE packages. For reasonably
 current distributions, these packages can be used as an alternative to
@@ -60,9 +60,8 @@ using
   $PATH_TO_DUNECONTROL/dunecontrol --opts=$EWOMS_SOURCE_DIR/optim.opts --module=ewoms all
 
 Depending on the dunecontrol option file used, the test simulators are
-not compiled by default in order to speed up the build process for
-downstream modules. If you want to force a given test simulator to be
-compiled, use e.g.,
+not compiled by default in order to speed up the build process. If you
+want to force a given test simulator to be compiled, use e.g.,
 
   cd $EWOMS_SOURCE_DIR/build-cmake
   make lens_immiscible_ecfv_ad
@@ -71,7 +70,7 @@ to compile the `lens_immiscible_ecfv_ad` executable. Compiling all
 available tests can be achieved via
 
   cd $EWOMS_SOURCE_DIR/build-cmake
-  make test-suite
+  make build_tests
 
 Installing
 ----------
@@ -84,7 +83,7 @@ install it globally on your system. This can be done using
 
 You can specify the target directory for the installation process by
 adding -DCMAKE_INSTALL_PREFIX=$TARGET_DIR to the CMAKE_FLAGS variable
-in the dunecontrol option file that you used for build proceedure.
+in the dunecontrol options file that you used for the build proceedure.
 
 
 Getting started
@@ -96,7 +95,7 @@ usually sufficient to simply run the binary of interest from the
 command line without any arguments. For example, to run the simulator
 for the two-dimensional 'lens' problem that utilizes a multi-phase
 model which assumes immiscibility of the fluid phases in conjunction
-with the element centered finite volume discretization and automatic
+with the element-centered finite volume discretization and automatic
 differentiation, type
 
   cd $EWOMS_SOURCE_DIR/build-cmake
@@ -109,11 +108,12 @@ for example, ParaView [5]:
 
 You may also specify command line parameters to alter the behavior of
 the simulation. The list of recognized parameters and their
-descriptions can usually be obtained by the '--help' command line
+descriptions can usually be obtained via the '--help' command line
 argument, e.g.,
 
   cd $EWOMS_SOURCE_DIR/build-cmake
   ./bin/lens_immiscible_ecfv_ad --help
+
 
 Links
 =====

--- a/debug-clang.opts
+++ b/debug-clang.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \

--- a/debug-gcc.opts
+++ b/debug-gcc.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \

--- a/debug.opts
+++ b/debug.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \

--- a/optim-clang.opts
+++ b/optim-clang.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \

--- a/optim-gcc.opts
+++ b/optim-gcc.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \

--- a/optim.opts
+++ b/optim.opts
@@ -12,13 +12,14 @@
 TMP="$(dirname $DUNE_OPTS_FILE)"
 if test -x "$TMP/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 elif test -x "$TMP/../opm-dune-cmake/bin/cmake-wrapper.sh"; then
    OPM_DUNE_CMAKE_DIR="$TMP/../opm-dune-cmake"
+   CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 fi
-
-CMAKE="$OPM_DUNE_CMAKE_DIR"/bin/cmake-wrapper.sh
 
 CXX_WARNING_OPTS=" \
     -Wall \


### PR DESCRIPTION
the dunecontrol option files should now usually work even with "unwrapped" cmake, i.e. if opm-dune-cmake was not found.