### PR TITLE
consistently rename "heat conduction" to "thermal conduction" and use "solid energy" laws

### DIFF
--- a/ewoms/io/vtkenergymodule.hh
+++ b/ewoms/io/vtkenergymodule.hh
@@ -42,7 +42,7 @@ NEW_TYPE_TAG(VtkEnergy);
 
 // create the property tags needed for the energy module
 NEW_PROP_TAG(VtkWriteSolidInternalEnergy);
-NEW_PROP_TAG(VtkWriteHeatConductivity);
+NEW_PROP_TAG(VtkWriteThermalConductivity);
 NEW_PROP_TAG(VtkWriteInternalEnergies);
 NEW_PROP_TAG(VtkWriteEnthalpies);
 NEW_PROP_TAG(VtkOutputFormat);
@@ -50,7 +50,7 @@ NEW_PROP_TAG(EnableVtkOutput);
 
 // set default values for what quantities to output
 SET_BOOL_PROP(VtkEnergy, VtkWriteSolidInternalEnergy, false);
-SET_BOOL_PROP(VtkEnergy, VtkWriteHeatConductivity, false);
+SET_BOOL_PROP(VtkEnergy, VtkWriteThermalConductivity, false);
 SET_BOOL_PROP(VtkEnergy, VtkWriteInternalEnergies, false);
 SET_BOOL_PROP(VtkEnergy, VtkWriteEnthalpies, false);
 } // namespace Properties
@@ -66,8 +66,9 @@ namespace Ewoms {
  * This module deals with the following quantities:
  * - Specific enthalpy of all fluid phases
  * - Specific internal energy of all fluid phases
- * - Specific heat capacity of the solid phase
- * - Lumped heat conductivity (solid phase plus all fluid phases)
+ * - Volumetric internal energy of the solid phase
+ * - Total thermal conductivity, i.e. the conductivity of the solid and all fluid phases
+ *   combined
  */
 template <class TypeTag>
 class VtkEnergyModule : public BaseOutputModule<TypeTag>
@@ -103,8 +104,8 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteSolidInternalEnergy,
                              "Include the volumetric internal energy of solid"
                              "matrix in the VTK output files");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteHeatConductivity,
-                             "Include the lumped heat conductivity of the "
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteThermalConductivity,
+                             "Include the total thermal conductivity of the"
                              "medium in the VTK output files");
         EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteEnthalpies,
                              "Include the specific enthalpy of the phases in "
@@ -127,8 +128,8 @@ public:
 
         if (solidInternalEnergyOutput_())
             this->resizeScalarBuffer_(solidInternalEnergy_);
-        if (heatConductivityOutput_())
-            this->resizeScalarBuffer_(heatConductivity_);
+        if (thermalConductivityOutput_())
+            this->resizeScalarBuffer_(thermalConductivity_);
     }
 
     /*!
@@ -147,8 +148,8 @@ public:
 
             if (solidInternalEnergyOutput_())
                 solidInternalEnergy_[I] = Toolbox::value(intQuants.solidInternalEnergy());
-            if (heatConductivityOutput_())
-                heatConductivity_[I] = Toolbox::value(intQuants.heatConductivity());
+            if (thermalConductivityOutput_())
+                thermalConductivity_[I] = Toolbox::value(intQuants.thermalConductivity());
 
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (enthalpyOutput_())
@@ -171,8 +172,8 @@ public:
 
         if (solidInternalEnergyOutput_())
             this->commitScalarBuffer_(baseWriter, "internalEnergySolid", solidInternalEnergy_);
-        if (heatConductivityOutput_())
-            this->commitScalarBuffer_(baseWriter, "heatConductivity", heatConductivity_);
+        if (thermalConductivityOutput_())
+            this->commitScalarBuffer_(baseWriter, "thermalConductivity", thermalConductivity_);
 
         if (enthalpyOutput_())
             this->commitPhaseBuffer_(baseWriter, "enthalpy_%s", enthalpy_);
@@ -184,8 +185,8 @@ private:
     static bool solidInternalEnergyOutput_()
     { return EWOMS_GET_PARAM(TypeTag, bool, VtkWriteSolidInternalEnergy); }
 
-    static bool heatConductivityOutput_()
-    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWriteHeatConductivity); }
+    static bool thermalConductivityOutput_()
+    { return EWOMS_GET_PARAM(TypeTag, bool, VtkWriteThermalConductivity); }
 
     static bool enthalpyOutput_()
     { return EWOMS_GET_PARAM(TypeTag, bool, VtkWriteEnthalpies); }
@@ -196,7 +197,7 @@ private:
     PhaseBuffer enthalpy_;
     PhaseBuffer internalEnergy_;
 
-    ScalarBuffer heatConductivity_;
+    ScalarBuffer thermalConductivity_;
     ScalarBuffer solidInternalEnergy_;
 };
 

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -215,7 +215,6 @@ class BlackOilModel
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
 
-
 public:
     BlackOilModel(Simulator& simulator)
         : ParentType(simulator)

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -36,10 +36,14 @@ namespace Properties {
 //! Specifies if the simulation should write output files that are
 //! compatible with those produced by the commercial Eclipse simulator
 NEW_PROP_TAG(EnableEclipseOutput);
-//! The material law for heat conduction
-NEW_PROP_TAG(HeatConductionLaw);
-//! The parameters of the material law for heat conduction
-NEW_PROP_TAG(HeatConductionLawParams);
+//! The material law for thermal conduction
+NEW_PROP_TAG(ThermalConductionLaw);
+//! The parameters of the material law for thermal conduction
+NEW_PROP_TAG(ThermalConductionLawParams);
+//! The material law for energy storage of the rock
+NEW_PROP_TAG(SolidEnergyLaw);
+//! The parameters for material law for energy storage of the rock
+NEW_PROP_TAG(SolidEnergyLawParams);
 //! Enable the ECL-blackoil extension for solvents. ("Second gas")
 NEW_PROP_TAG(EnableSolvent);
 //! Enable the ECL-blackoil extension for polymer.

--- a/ewoms/models/common/multiphasebasemodel.hh
+++ b/ewoms/models/common/multiphasebasemodel.hh
@@ -39,7 +39,7 @@
 
 #include <opm/material/fluidmatrixinteractions/NullMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
-#include <opm/material/thermal/NullHeatConductionLaw.hpp>
+#include <opm/material/thermal/NullThermalConductionLaw.hpp>
 #include <opm/material/thermal/NullSolidEnergyLaw.hpp>
 #include <opm/common/Unused.hpp>
 
@@ -96,28 +96,28 @@ SET_TYPE_PROP(MultiPhaseBaseModel,
               MaterialLawParams,
               typename GET_PROP_TYPE(TypeTag, MaterialLaw)::Params);
 
-//! set the heat storage law for the solid to the one which assumes zero heat
-//! capacity by default
+//! set the energy storage law for the solid to the one which assumes zero heat capacity
+//! by default
 SET_TYPE_PROP(MultiPhaseBaseModel,
               SolidEnergyLaw,
               Opm::NullSolidEnergyLaw<typename GET_PROP_TYPE(TypeTag, Scalar)>);
 
-//! extract the type parameter objects for the solid energy storage law from the law
-//! itself
+//! extract the type of the parameter objects for the solid energy storage law from the
+//! law itself
 SET_TYPE_PROP(MultiPhaseBaseModel,
               SolidEnergyLawParams,
               typename GET_PROP_TYPE(TypeTag, SolidEnergyLaw)::Params);
 
-//! set the heat conduction law to a dummy one by default
+//! set the thermal conduction law to a dummy one by default
 SET_TYPE_PROP(MultiPhaseBaseModel,
-              HeatConductionLaw,
-              Opm::NullHeatConductionLaw<typename GET_PROP_TYPE(TypeTag, Scalar)>);
+              ThermalConductionLaw,
+              Opm::NullThermalConductionLaw<typename GET_PROP_TYPE(TypeTag, Scalar)>);
 
-//! extract the type parameter objects for the heat conduction law
-//! from the law itself
+//! extract the type of the parameter objects for the thermal conduction law from the law
+//! itself
 SET_TYPE_PROP(MultiPhaseBaseModel,
-              HeatConductionLawParams,
-              typename GET_PROP_TYPE(TypeTag, HeatConductionLaw)::Params);
+              ThermalConductionLawParams,
+              typename GET_PROP_TYPE(TypeTag, ThermalConductionLaw)::Params);
 
 //! disable gravity by default
 SET_BOOL_PROP(MultiPhaseBaseModel, EnableGravity, false);

--- a/ewoms/models/common/multiphasebaseproblem.hh
+++ b/ewoms/models/common/multiphasebaseproblem.hh
@@ -44,7 +44,8 @@
 
 namespace Ewoms {
 namespace Properties {
-NEW_PROP_TAG(HeatConductionLawParams);
+NEW_PROP_TAG(SolidEnergyLawParams);
+NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(EnableGravity);
 NEW_PROP_TAG(FluxModule);
 }
@@ -69,7 +70,8 @@ class MultiPhaseBaseProblem
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
-    typedef typename GET_PROP_TYPE(TypeTag, HeatConductionLawParams) HeatConductionLawParams;
+    typedef typename GET_PROP_TYPE(TypeTag, SolidEnergyLawParams) SolidEnergyLawParams;
+    typedef typename GET_PROP_TYPE(TypeTag, ThermalConductionLawParams) ThermalConductionLawParams;
     typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw)::Params MaterialLawParams;
 
     enum { dimWorld = GridView::dimensionworld };
@@ -165,8 +167,8 @@ public:
     }
 
     /*!
-     * \brief Returns the heat capacity [J/(K m^3)] of the solid phase
-     *        with no pores in the sub-control volume.
+     * \brief Returns the parameter object for the energy storage law of the solid in a
+     *        sub-control volume.
      *
      * \param context Reference to the object which represents the
      *                current execution context.
@@ -174,17 +176,18 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    Scalar heatCapacitySolid(const Context& context OPM_UNUSED,
-                             unsigned spaceIdx OPM_UNUSED,
-                             unsigned timeIdx OPM_UNUSED) const
+    const SolidEnergyLawParams&
+    solidEnergyParams(const Context& context OPM_UNUSED,
+                      unsigned spaceIdx OPM_UNUSED,
+                      unsigned timeIdx OPM_UNUSED) const
     {
         OPM_THROW(std::logic_error,
-                  "Not implemented: Problem::heatCapacitySolid()");
+                   "Not implemented: Problem::solidEnergyParams()");
     }
 
     /*!
-     * \brief Returns the parameter object for the heat conductivity law in
-     *        a sub-control volume.
+     * \brief Returns the parameter object for the thermal conductivity law in a
+     *        sub-control volume.
      *
      * \param context Reference to the object which represents the
      *                current execution context.
@@ -192,13 +195,13 @@ public:
      * \param timeIdx The index used by the time discretization.
      */
     template <class Context>
-    const HeatConductionLawParams&
-    heatConductionParams(const Context& context OPM_UNUSED,
+    const ThermalConductionLawParams&
+    thermalConductionParams(const Context& context OPM_UNUSED,
                          unsigned spaceIdx OPM_UNUSED,
                          unsigned timeIdx OPM_UNUSED) const
     {
         OPM_THROW(std::logic_error,
-                   "Not implemented: Problem::heatConductionParams()");
+                   "Not implemented: Problem::thermalConductionParams()");
     }
 
     /*!

--- a/ewoms/models/common/multiphasebaseproperties.hh
+++ b/ewoms/models/common/multiphasebaseproperties.hh
@@ -50,12 +50,12 @@ NEW_PROP_TAG(MaterialLaw);
 NEW_PROP_TAG(MaterialLawParams);
 //! The material law for the energy stored in the solid matrix
 NEW_PROP_TAG(SolidEnergyLaw);
-//! The parameters of the material law for heat conduction
+//! The parameters of the material law for energy storage of the solid
 NEW_PROP_TAG(SolidEnergyLawParams);
-//! The material law for heat conduction
-NEW_PROP_TAG(HeatConductionLaw);
-//! The parameters of the material law for heat conduction
-NEW_PROP_TAG(HeatConductionLawParams);
+//! The material law for thermal conduction
+NEW_PROP_TAG(ThermalConductionLaw);
+//! The parameters of the material law for thermal conduction
+NEW_PROP_TAG(ThermalConductionLawParams);
 //!The fluid systems including the information about the phases
 NEW_PROP_TAG(FluidSystem);
 //! Specifies the relation used for velocity

--- a/ewoms/models/discretefracture/discretefractureproblem.hh
+++ b/ewoms/models/discretefracture/discretefractureproblem.hh
@@ -42,7 +42,7 @@
 
 namespace Ewoms {
 namespace Properties {
-NEW_PROP_TAG(HeatConductionLawParams);
+NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(EnableGravity);
 NEW_PROP_TAG(FluxModule);
 }

--- a/ewoms/models/flash/flashboundaryratevector.hh
+++ b/ewoms/models/flash/flashboundaryratevector.hh
@@ -130,13 +130,13 @@ public:
                 else
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
 
-                // currently we neglect heat conduction!
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
             }
         }
 
-        EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
+        // thermal conduction
+        EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i) {

--- a/ewoms/models/flash/flashlocalresidual.hh
+++ b/ewoms/models/flash/flashlocalresidual.hh
@@ -104,7 +104,7 @@ public:
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             addPhaseStorage(storage, elemCtx, dofIdx, timeIdx, phaseIdx);
 
-        EnergyModule::addSolidHeatStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
+        EnergyModule::addSolidEnergyStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
     }
 
     /*!

--- a/ewoms/models/flash/flashproperties.hh
+++ b/ewoms/models/flash/flashproperties.hh
@@ -44,10 +44,10 @@ NEW_PROP_TAG(FlashSolver);
 //! The maximum accepted error of the flash solver
 NEW_PROP_TAG(FlashTolerance);
 
-//! The heat conduction law which ought to be used
-NEW_PROP_TAG(HeatConductionLaw);
-//! The parameters of the heat conduction law
-NEW_PROP_TAG(HeatConductionLawParams);
+//! The thermal conduction law which ought to be used
+NEW_PROP_TAG(ThermalConductionLaw);
+//! The parameters of the thermal conduction law
+NEW_PROP_TAG(ThermalConductionLawParams);
 
 //! Specifies whether energy should be considered as a conservation quantity or not
 NEW_PROP_TAG(EnableEnergy);

--- a/ewoms/models/immiscible/immiscibleboundaryratevector.hh
+++ b/ewoms/models/immiscible/immiscibleboundaryratevector.hh
@@ -131,13 +131,13 @@ public:
                 else
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
 
-                // currently we neglect heat conduction!
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
             }
         }
 
-        EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
+        // thermal conduction
+        EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i)

--- a/ewoms/models/immiscible/immisciblelocalresidual.hh
+++ b/ewoms/models/immiscible/immisciblelocalresidual.hh
@@ -105,7 +105,7 @@ public:
         for (int phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             asImp_().addPhaseStorage(storage, elemCtx, dofIdx, timeIdx, phaseIdx);
 
-        EnergyModule::addSolidHeatStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
+        EnergyModule::addSolidEnergyStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
     }
 
     /*!
@@ -157,9 +157,8 @@ public:
     /*!
      * \brief Adds the diffusive flux at a given flux integration point.
      *
-     * For the immiscible model, this is a no-op for mass fluxes. For
-     * energy it adds the contribution of heat conduction to the
-     * enthalpy flux.
+     * For the immiscible model, this is a no-op for mass fluxes. For energy it adds the
+     * contribution of thermal conduction to the enthalpy flux.
      *
      * \copydetails computeFlux
      */
@@ -170,7 +169,7 @@ public:
     {
         // no diffusive mass fluxes for the immiscible model
 
-        // heat conduction
+        // thermal conduction
         EnergyModule::addDiffusiveFlux(flux, elemCtx, scvfIdx, timeIdx);
     }
 

--- a/ewoms/models/ncp/ncpboundaryratevector.hh
+++ b/ewoms/models/ncp/ncpboundaryratevector.hh
@@ -130,13 +130,13 @@ public:
                 else
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
 
-                // currently we neglect heat conduction!
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
             }
         }
 
-        EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
+        // thermal conduction
+        EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i) {

--- a/ewoms/models/ncp/ncplocalresidual.hh
+++ b/ewoms/models/ncp/ncplocalresidual.hh
@@ -109,7 +109,7 @@ public:
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             addPhaseStorage(storage, elemCtx, dofIdx, timeIdx, phaseIdx);
 
-        EnergyModule::addSolidHeatStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
+        EnergyModule::addSolidEnergyStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
     }
 
     /*!

--- a/ewoms/models/pvs/pvsboundaryratevector.hh
+++ b/ewoms/models/pvs/pvsboundaryratevector.hh
@@ -129,13 +129,13 @@ public:
                 else
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
 
-                // currently we neglect heat conduction!
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
             }
         }
 
-        EnergyModule::addToEnthalpyRate(*this, EnergyModule::heatConductionRate(extQuants));
+        // thermal conduction
+        EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i)

--- a/ewoms/models/pvs/pvslocalresidual.hh
+++ b/ewoms/models/pvs/pvslocalresidual.hh
@@ -105,7 +105,7 @@ public:
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             addPhaseStorage(storage, elemCtx, dofIdx, timeIdx, phaseIdx);
 
-        EnergyModule::addSolidHeatStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
+        EnergyModule::addSolidEnergyStorage(storage, elemCtx.intensiveQuantities(dofIdx, timeIdx));
     }
 
     /*!

--- a/tests/problems/infiltrationproblem.hh
+++ b/tests/problems/infiltrationproblem.hh
@@ -34,7 +34,6 @@
 #include <opm/material/fluidmatrixinteractions/ThreePhaseParkerVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
 #include <opm/material/constraintsolvers/ComputeFromReferencePhase.hpp>
-#include <opm/material/thermal/SomertonHeatConductionLaw.hpp>
 #include <opm/common/Valgrind.hpp>
 #include <opm/common/Unused.hpp>
 
@@ -93,18 +92,6 @@ private:
 
 public:
     typedef Opm::ThreePhaseParkerVanGenuchten<Traits> type;
-};
-
-// Set the heat conduction law
-SET_PROP(InfiltrationBaseProblem, HeatConductionLaw)
-{
-private:
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
-
-public:
-    // define the material law parameterized by absolute saturations
-    typedef Opm::SomertonHeatConductionLaw<FluidSystem, Scalar> type;
 };
 
 // The default for the end time of the simulation
@@ -317,20 +304,6 @@ public:
                       unsigned spaceIdx OPM_UNUSED,
                       unsigned timeIdx OPM_UNUSED) const
     { return materialParams_; }
-
-    /*!
-     * \copydoc FvBaseMultiPhaseProblem::heatCapacitySolid
-     *
-     * In this case, we assume the rock-matrix to be quartz.
-     */
-    template <class Context>
-    Scalar heatCapacitySolid(const Context& context OPM_UNUSED,
-                             unsigned spaceIdx OPM_UNUSED,
-                             unsigned timeIdx OPM_UNUSED) const
-    {
-        return 850.     // specific heat capacity [J / (kg K)]
-               * 2650.; // density of sand [kg/m^3]
-    }
 
     //! \}
 


### PR DESCRIPTION
according to wikipedia the term "heat" is the energy transferred due to a temperature gradient, i.e., it only makes sense if such a gradient is present and this is not necessary for the storage term.

this means that technically the term "heat conductivity" is meaningful, but "thermal conductivity" is IMO more consistent.

this has partially already been done in opm-material and eWoms it was pretty inconsistent, so it also depends on OPM/opm-material#273.