### PR TITLE
Revert "add back the epsilon value when switching from {oil,gas}-only to both hydrocarbon phases"

### DIFF
--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -461,7 +461,7 @@ public:
                                                                     SoMax);
 
             Scalar Rs = (*this)[Indices::compositionSwitchIdx];
-            if (Rs > (1.0 + eps)*std::min(RsMax, RsSat)) {
+            if (Rs > std::min(RsMax, RsSat*(1.0 + eps))) {
                 // the gas phase appears, i.e., switch the primary variables to { Sw, po,
                 // Sg }.
                 setPrimaryVarsMeaning(Sw_po_Sg);
@@ -518,7 +518,7 @@ public:
                                                                      SoMax);
 
             Scalar Rv = (*this)[Indices::compositionSwitchIdx];
-            if (Rv > (1.0 + eps)*std::min(RvMax, RvSat)) {
+            if (Rv > std::min(RvMax, RvSat*(1.0 + eps))) {
                 // switch to phase equilibrium mode because the oil phase appears. here
                 // we also need the capillary pressures to calculate the oil phase
                 // pressure using the gas phase pressure


### PR DESCRIPTION
this makes flow work for SPE1CASE1 (actually, I do not really know why), but it might lead to different convergence behaviour in some cases.

@totto82: can you test and assess?