### PR TITLE
Add FIP, INIT and EGRID output 

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -460,6 +460,8 @@ public:
             int numElements = gridView.size(/*codim=*/0);
             maxPolymerAdsorption_.resize(numElements, 0.0);
         }
+
+        eclWriter_->writeInit();
     }
 
     void prefetch(const Element& elem) const
@@ -702,11 +704,10 @@ public:
         }
         Scalar totalSolverTime = 0.0;
         Scalar nextstep = this->simulator().timeStepSize();
-        Opm::data::Solution fip;
-        writeOutput(dw, t, false, totalSolverTime, nextstep, fip, verbose);
+        writeOutput(dw, t, false, totalSolverTime, nextstep, verbose);
     }
 
-    void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, const Opm::data::Solution& fip, bool verbose = true)
+    void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, bool verbose = true)
     {
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
@@ -714,7 +715,7 @@ public:
 
         // output using eclWriter if enabled
         if (eclWriter_)
-            eclWriter_->writeOutput(dw, t, substep, totalSolverTime, nextstep, fip);
+            eclWriter_->writeOutput(dw, t, substep, totalSolverTime, nextstep);
     }
 
     /*!
@@ -1165,9 +1166,6 @@ public:
     const InitialFluidState& initialFluidState(unsigned globalDofIdx ) const {
         return initialFluidStates_[globalDofIdx];
     }
-
-    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO)
-    { eclWriter_->setEclIO(std::move(eclIO)); }
 
     const Opm::EclipseIO& eclIO() const
     { return eclWriter_->eclIO(); }

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -113,6 +113,9 @@ NEW_PROP_TAG(EnableWriteAllSolutions);
 // The number of time steps skipped between writing two consequtive restart files
 NEW_PROP_TAG(RestartWritingInterval);
 
+// The default location for the ECL output files
+NEW_PROP_TAG(EclOutputDir);
+
 // Disable well treatment (for users which do this externally)
 NEW_PROP_TAG(DisableWells);
 
@@ -220,8 +223,8 @@ SET_TYPE_PROP(EclBaseProblem, FluxModule, Ewoms::EclTransFluxModule<TypeTag>);
 // Use the dummy gradient calculator in order not to do unnecessary work.
 SET_TYPE_PROP(EclBaseProblem, GradientCalculator, Ewoms::EclDummyGradientCalculator<TypeTag>);
 
-// The default name of the data file to load
-SET_STRING_PROP(EclBaseProblem, GridFile, "data/ecl.DATA");
+// The default location for the ECL output files
+SET_STRING_PROP(EclBaseProblem, EclOutputDir, ".");
 
 // The frequency of writing restart (*.ers) files. This is the number of time steps
 // between writing restart files
@@ -317,6 +320,8 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableEclOutput,
                              "Write binary output which is compatible with the commercial "
                              "Eclipse simulator");
+        EWOMS_REGISTER_PARAM(TypeTag, std::string, EclOutputDir,
+                             "The directory to which the ECL result files are written");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
     }
@@ -329,14 +334,38 @@ public:
         , transmissibilities_(simulator.gridManager())
         , thresholdPressures_(simulator)
         , wellManager_(simulator)
-        , eclWriter_( EWOMS_GET_PARAM(TypeTag, bool, EnableEclOutput)
-                        ? new EclWriterType(simulator) : nullptr )
         , pffDofData_(simulator.gridView(), this->elementMapper())
     {
         // Tell the extra modules to initialize its internal data structures
         const auto& gridManager = simulator.gridManager();
         SolventModule::initFromDeck(gridManager.deck(), gridManager.eclState());
         PolymerModule::initFromDeck(gridManager.deck(), gridManager.eclState());
+
+        if (EWOMS_GET_PARAM(TypeTag, bool, EnableEclOutput)) {
+            // retrieve the location where the output is supposed to go
+            const auto& outputDir = EWOMS_GET_PARAM(TypeTag, std::string, EclOutputDir);
+
+            // ensure that the output directory exists and that it is a directory
+            if (outputDir != ".") { // Do not try to create the current directory.
+                if (!boost::filesystem::is_directory(outputDir)) {
+                    try {
+                        boost::filesystem::create_directories(outputDir);
+                    }
+                    catch (...) {
+                        OPM_THROW(std::runtime_error, "Creation of output directory '"<<outputDir<<"' failed\n");
+                    }
+                }
+            }
+
+            // specify the directory output. This is not a very nice mechanism because
+            // the eclState is supposed to be immutable here, IMO.
+            auto& eclState = this->simulator().gridManager().eclState();
+            auto& ioConfig = eclState.getIOConfig();
+            ioConfig.setOutputDir(outputDir);
+
+            // create the actual ECL writer
+            eclWriter_.reset(new EclWriterType(simulator));
+        }
 
         // Hack to compute the initial thpressure values for restarts
         restartApplied = false;
@@ -684,10 +713,8 @@ public:
         ParentType::writeOutput(verbose);
 
         // output using eclWriter if enabled
-        if ( eclWriter_ ) {
+        if (eclWriter_)
             eclWriter_->writeOutput(dw, t, substep, totalSolverTime, nextstep, fip);
-        }
-
     }
 
     /*!
@@ -1139,12 +1166,11 @@ public:
         return initialFluidStates_[globalDofIdx];
     }
 
-    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO) {
-        eclWriter_->setEclIO(std::move(eclIO));
-    }
+    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO)
+    { eclWriter_->setEclIO(std::move(eclIO)); }
 
     const Opm::EclipseIO& eclIO() const
-    {return eclWriter_->eclIO();}
+    { return eclWriter_->eclIO(); }
 
 private:
     Scalar cellCenterDepth( const Element& element ) const
@@ -1842,7 +1868,7 @@ private:
 
     EclWellManager<TypeTag> wellManager_;
 
-    std::unique_ptr< EclWriterType > eclWriter_;
+    std::unique_ptr<EclWriterType> eclWriter_;
 
     PffGridVector<GridView, Stencil, PffDofData_, DofMapper> pffDofData_;
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -145,9 +145,6 @@ public:
         const ElementIterator& elemEndIt = gridView.template end</*codim=*/0>();
         for (; elemIt != elemEndIt; ++elemIt) {
             const Element& elem = *elemIt;
-            if (elem.partitionType() != Dune::InteriorEntity)
-                continue;
-
             elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
             eclOutputModule_.processElement(elemCtx);

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -188,7 +188,7 @@ public:
                                   false);
         }
 
-        #endif
+#endif
     }
 
     void restartBegin()

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -28,13 +28,12 @@
 #ifndef EWOMS_ECL_WRITER_HH
 #define EWOMS_ECL_WRITER_HH
 
-#include <opm/material/densead/Evaluation.hpp>
-
 #include "collecttoiorank.hh"
 #include "ecloutputblackoilmodule.hh"
 
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include <ewoms/io/baseoutputwriter.hh>
+
 #include <opm/output/eclipse/EclipseIO.hpp>
 
 #include <opm/common/Valgrind.hpp>
@@ -58,7 +57,6 @@ NEW_PROP_TAG(EnableEclOutput);
 
 template <class TypeTag>
 class EclWriter;
-
 
 /*!
  * \ingroup EclBlackOilSimulator
@@ -87,17 +85,15 @@ class EclWriter
     typedef typename GridView::template Codim<0>::Entity Element;
     typedef typename GridView::template Codim<0>::Iterator ElementIterator;
 
-
     typedef CollectDataToIORank< GridManager > CollectDataToIORankType;
 
     typedef std::vector<Scalar> ScalarBuffer;
-
 
 public:
     EclWriter(const Simulator& simulator)
         : simulator_(simulator)
         , eclOutputModule_(simulator)
-        , collectToIORank_( simulator_.gridManager() )
+        , collectToIORank_(simulator_.gridManager())
     {
         Grid globalGrid = simulator_.gridManager().grid();
         globalGrid.switchToGlobalView();
@@ -110,23 +106,21 @@ public:
     ~EclWriter()
     { }
 
-    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO) {
-        eclIO_ = std::move(eclIO);
-    }
+    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO)
+    { eclIO_ = std::move(eclIO); }
 
     const Opm::EclipseIO& eclIO() const
-    {return *eclIO_;}
+    { return *eclIO_; }
 
     /*!
      * \brief collect and pass data and pass it to eclIO writer
      */
     void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, const Opm::data::Solution& fip)
     {
-
-        #if !HAVE_OPM_OUTPUT
-                OPM_THROW(std::runtime_error,
-                          "Opm-output must be available to write ECL output!");
-        #else
+#if !HAVE_OPM_OUTPUT
+        OPM_THROW(std::runtime_error,
+                  "Opm-output must be available to write ECL output!");
+#else
 
         int episodeIdx = simulator_.episodeIndex() + 1;
         const auto& gridView = simulator_.gridManager().gridView();
@@ -179,7 +173,8 @@ public:
 #endif
     }
 
-    void restartBegin() {
+    void restartBegin()
+    {
         std::map<std::string, Opm::RestartKey> solution_keys {{"PRESSURE" , Opm::RestartKey(Opm::UnitSystem::measure::pressure)},
                                                          {"SWAT" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},
                                                          {"SGAS" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},


### PR DESCRIPTION
Writes INIT and EGRID files initially
Adds Fip to summary output if required.
Output Fip to log (.PRT) if Opm-logger is set
Add feature for setting ECL output directory. 

Should be merged together with PR in opm-simulator. 