### PR TITLE
adapt to the reordering template arguments of get*_(fluidState) in opm-material

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1207,9 +1207,8 @@ private:
                 if (!dRsDtOnlyFreeGas_ || fs.saturation(gasPhaseIdx) > freeGasMinSaturation_)
                     lastRs_[compressedDofIdx] =
                         Opm::BlackOil::template getRs_<FluidSystem,
-                                                       Scalar,
-                                                       FluidState>(fs,
-                                                                   iq.pvtRegionIndex());
+                                                       FluidState,
+                                                       Scalar>(fs, iq.pvtRegionIndex());
                 else
                     lastRs_[compressedDofIdx] = std::numeric_limits<Scalar>::infinity();
             }
@@ -1236,9 +1235,8 @@ private:
 
                 lastRv_[compressedDofIdx] =
                     Opm::BlackOil::template getRv_<FluidSystem,
-                                                   Scalar,
-                                                   FluidState>(fs,
-                                                               iq.pvtRegionIndex());
+                                                   FluidState,
+                                                   Scalar>(fs, iq.pvtRegionIndex());
             }
         }
     }

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -300,7 +300,7 @@ public:
                 (*this)[compositionSwitchIdx] = FsToolbox::value(fluidState.saturation(gasPhaseIdx));
         }
         else if (primaryVarsMeaning() == Sw_po_Rs) {
-            const auto& Rs = Opm::BlackOil::getRs_<FluidSystem, Scalar, FluidState>(fluidState, pvtRegionIdx_);
+            const auto& Rs = Opm::BlackOil::getRs_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
 
             if (waterEnabled)
                 (*this)[waterSaturationIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
@@ -311,7 +311,7 @@ public:
         else {
             assert(primaryVarsMeaning() == Sw_pg_Rv);
 
-            const auto& Rv = Opm::BlackOil::getRv_<FluidSystem, Scalar, FluidState>(fluidState, pvtRegionIdx_);
+            const auto& Rv = Opm::BlackOil::getRv_<FluidSystem, FluidState, Scalar>(fluidState, pvtRegionIdx_);
             if (waterEnabled)
                 (*this)[waterSaturationIdx] = FsToolbox::value(fluidState.saturation(waterPhaseIdx));
 


### PR DESCRIPTION
this is the downstream mop-up of OPM/opm-material#278