### PR TITLE
refactor the boundary condition handling slightly

### DIFF
--- a/ewoms/disc/common/fvbaseextensivequantities.hh
+++ b/ewoms/disc/common/fvbaseextensivequantities.hh
@@ -90,8 +90,7 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState OPM_UNUSED,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache OPM_UNUSED)
+                        const FluidState& fluidState OPM_UNUSED)
     {
         unsigned dofIdx = context.interiorScvIndex(bfIdx, timeIdx);
         interiorScvIdx_ = static_cast<unsigned short>(dofIdx);

--- a/ewoms/models/common/darcyfluxmodule.hh
+++ b/ewoms/models/common/darcyfluxmodule.hh
@@ -337,8 +337,7 @@ protected:
     void calculateBoundaryGradients_(const ElementContext& elemCtx,
                                      unsigned boundaryFaceIdx,
                                      unsigned timeIdx,
-                                     const FluidState& fluidState,
-                                     const typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                                     const FluidState& fluidState)
     {
         const auto& gradCalc = elemCtx.gradientCalculator();
         Ewoms::BoundaryPressureCallback<TypeTag, FluidState> pressureCallback(elemCtx, fluidState);
@@ -443,9 +442,15 @@ protected:
             }
 
             // take the phase mobility from the DOF in upstream direction
-            if (upstreamDofIdx_[phaseIdx] < 0)
-                mobility_[phaseIdx] =
-                    kr[phaseIdx] / FluidSystem::viscosity(fluidState, paramCache, phaseIdx);
+            if (upstreamDofIdx_[phaseIdx] < 0) {
+                if (interiorDofIdx_ == focusDofIdx)
+                    mobility_[phaseIdx] =
+                        kr[phaseIdx] / fluidState.viscosity(phaseIdx);
+                else
+                    mobility_[phaseIdx] =
+                        Toolbox::value(kr[phaseIdx])
+                        / Toolbox::value(fluidState.viscosity(phaseIdx));
+            }
             else if (upstreamDofIdx_[phaseIdx] != focusDofIdx)
                 mobility_[phaseIdx] = Toolbox::value(intQuantsIn.mobility(phaseIdx));
             else

--- a/ewoms/models/common/forchheimerfluxmodule.hh
+++ b/ewoms/models/common/forchheimerfluxmodule.hh
@@ -278,16 +278,16 @@ protected:
         if (focusDofIdx == i) {
             ergunCoefficient_ =
                 (intQuantsIn.ergunCoefficient() +
-                 Toolbox::value(intQuantsEx.ergunCoefficient()))/2;
+                 Opm::getValue(intQuantsEx.ergunCoefficient()))/2;
         }
         else if (focusDofIdx == j)
             ergunCoefficient_ =
-                (Toolbox::value(intQuantsIn.ergunCoefficient()) +
+                (Opm::getValue(intQuantsIn.ergunCoefficient()) +
                  intQuantsEx.ergunCoefficient())/2;
         else
             ergunCoefficient_ =
-                (Toolbox::value(intQuantsIn.ergunCoefficient()) +
-                 Toolbox::value(intQuantsEx.ergunCoefficient()))/2;
+                (Opm::getValue(intQuantsIn.ergunCoefficient()) +
+                 Opm::getValue(intQuantsEx.ergunCoefficient()))/2;
 
         // obtain the mobility to passability ratio for each phase.
         for (unsigned phaseIdx=0; phaseIdx < numPhases; phaseIdx++) {
@@ -305,9 +305,9 @@ protected:
             }
             else {
                 density_[phaseIdx] =
-                    Toolbox::value(up.fluidState().density(phaseIdx));
+                    Opm::getValue(up.fluidState().density(phaseIdx));
                 mobilityPassabilityRatio_[phaseIdx] =
-                    Toolbox::value(up.mobilityPassabilityRatio(phaseIdx));
+                    Opm::getValue(up.mobilityPassabilityRatio(phaseIdx));
             }
         }
     }
@@ -316,14 +316,12 @@ protected:
     void calculateBoundaryGradients_(const ElementContext& elemCtx,
                                      unsigned boundaryFaceIdx,
                                      unsigned timeIdx,
-                                     const FluidState& fluidState,
-                                     const typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                                     const FluidState& fluidState)
     {
         DarcyExtQuants::calculateBoundaryGradients_(elemCtx,
                                                     boundaryFaceIdx,
                                                     timeIdx,
-                                                    fluidState,
-                                                    paramCache);
+                                                    fluidState);
 
         auto focusDofIdx = elemCtx.focusDofIndex();
         unsigned i = static_cast<unsigned>(this->interiorDofIdx_);
@@ -334,7 +332,7 @@ protected:
         if (focusDofIdx == i)
             ergunCoefficient_ = intQuantsIn.ergunCoefficient();
         else
-            ergunCoefficient_ = Toolbox::value(intQuantsIn.ergunCoefficient());
+            ergunCoefficient_ = Opm::getValue(intQuantsIn.ergunCoefficient());
 
         // calculate the square root of the intrinsic permeability
         assert(isDiagonal_(this->K_));
@@ -352,9 +350,9 @@ protected:
             }
             else {
                 density_[phaseIdx] =
-                    Toolbox::value(intQuantsIn.fluidState().density(phaseIdx));
+                    Opm::getValue(intQuantsIn.fluidState().density(phaseIdx));
                 mobilityPassabilityRatio_[phaseIdx] =
-                    Toolbox::value(intQuantsIn.mobilityPassabilityRatio(phaseIdx));
+                    Opm::getValue(intQuantsIn.mobilityPassabilityRatio(phaseIdx));
             }
         }
     }
@@ -382,15 +380,15 @@ protected:
         if (focusDofIdx == i)
             ergunCoefficient_ =
                 (intQuantsI.ergunCoefficient() +
-                 Toolbox::value(intQuantsJ.ergunCoefficient())) / 2;
+                 Opm::getValue(intQuantsJ.ergunCoefficient())) / 2;
         else if (focusDofIdx == j)
             ergunCoefficient_ =
-                (Toolbox::value(intQuantsI.ergunCoefficient()) +
+                (Opm::getValue(intQuantsI.ergunCoefficient()) +
                  intQuantsJ.ergunCoefficient()) / 2;
         else
             ergunCoefficient_ =
-                (Toolbox::value(intQuantsI.ergunCoefficient()) +
-                 Toolbox::value(intQuantsJ.ergunCoefficient())) / 2;
+                (Opm::getValue(intQuantsI.ergunCoefficient()) +
+                 Opm::getValue(intQuantsJ.ergunCoefficient())) / 2;
 
         ///////////////
         // calculate the weights of the upstream and the downstream control volumes

--- a/ewoms/models/common/multiphasebaseextensivequantities.hh
+++ b/ewoms/models/common/multiphasebaseextensivequantities.hh
@@ -116,16 +116,14 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                        const FluidState& fluidState)
     {
-        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState);
 
         FluxExtensiveQuantities::calculateBoundaryGradients_(context.elementContext(),
                                                              bfIdx,
                                                              timeIdx,
-                                                             fluidState,
-                                                             paramCache);
+                                                             fluidState);
         FluxExtensiveQuantities::calculateBoundaryFluxes_(context.elementContext(),
                                                           bfIdx,
                                                           timeIdx);

--- a/ewoms/models/flash/flashextensivequantities.hh
+++ b/ewoms/models/flash/flashextensivequantities.hh
@@ -83,10 +83,9 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                        const FluidState& fluidState)
     {
-        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
         EnergyExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
     }

--- a/ewoms/models/immiscible/immiscibleboundaryratevector.hh
+++ b/ewoms/models/immiscible/immiscibleboundaryratevector.hh
@@ -97,39 +97,51 @@ public:
     template <class Context, class FluidState>
     void setFreeFlow(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fluidState)
     {
-        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
-        paramCache.updateAll(fluidState);
-
         ExtensiveQuantities extQuants;
-        extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState);
         const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        unsigned focusDofIdx = context.focusDofIndex();
+        unsigned interiorDofIdx = context.interiorScvIndex(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            const auto& pBoundary = fluidState.pressure(phaseIdx);
+            const Evaluation& pInside = insideIntQuants.fluidState().pressure(phaseIdx);
+
+            // mass conservation
             Evaluation density;
-            if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
-                density = FluidSystem::density(fluidState, paramCache, phaseIdx);
-            else
+            if  (pBoundary > pInside) {
+                if (focusDofIdx == interiorDofIdx)
+                    density = fluidState.density(phaseIdx);
+                else
+                    density = Opm::getValue(fluidState.density(phaseIdx));
+            }
+            else if (focusDofIdx == interiorDofIdx)
                 density = insideIntQuants.fluidState().density(phaseIdx);
+            else
+                density = Opm::getValue(insideIntQuants.fluidState().density(phaseIdx));
 
             Opm::Valgrind::CheckDefined(density);
             Opm::Valgrind::CheckDefined(extQuants.volumeFlux(phaseIdx));
 
-            // add advective flux of current component in current
-            // phase
             (*this)[conti0EqIdx + phaseIdx] += extQuants.volumeFlux(phaseIdx)*density;
 
+            // energy conservation
             if (enableEnergy) {
                 Evaluation specificEnthalpy;
-                Scalar pBoundary = fluidState.pressure(phaseIdx);
-                const Evaluation& pElement = insideIntQuants.fluidState().pressure(phaseIdx);
-                if (pBoundary > pElement)
-                    specificEnthalpy = FluidSystem::enthalpy(fluidState, paramCache, phaseIdx);
-                else
+                if (pBoundary > pInside) {
+                    if (focusDofIdx == interiorDofIdx)
+                        specificEnthalpy = fluidState.enthalpy(phaseIdx);
+                    else
+                        specificEnthalpy = Opm::getValue(fluidState.enthalpy(phaseIdx));
+                }
+                else if (focusDofIdx == interiorDofIdx)
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
+                else
+                    specificEnthalpy = Opm::getValue(insideIntQuants.fluidState().enthalpy(phaseIdx));
 
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);

--- a/ewoms/models/immiscible/immiscibleextensivequantities.hh
+++ b/ewoms/models/immiscible/immiscibleextensivequantities.hh
@@ -85,10 +85,9 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                        const FluidState& fluidState)
     {
-        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState);
         EnergyExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
     }
 };

--- a/ewoms/models/ncp/ncpextensivequantities.hh
+++ b/ewoms/models/ncp/ncpextensivequantities.hh
@@ -78,10 +78,9 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                        const FluidState& fluidState)
     {
-        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
         EnergyExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
     }

--- a/ewoms/models/pvs/pvsboundaryratevector.hh
+++ b/ewoms/models/pvs/pvsboundaryratevector.hh
@@ -87,35 +87,41 @@ public:
     template <class Context, class FluidState>
     void setFreeFlow(const Context& context, unsigned bfIdx, unsigned timeIdx, const FluidState& fluidState)
     {
-        typename FluidSystem::template ParameterCache<typename FluidState::Scalar> paramCache;
-        paramCache.updateAll(fluidState);
-
         ExtensiveQuantities extQuants;
-        extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        extQuants.updateBoundary(context, bfIdx, timeIdx, fluidState);
         const auto& insideIntQuants = context.intensiveQuantities(bfIdx, timeIdx);
+        unsigned focusDofIdx = context.focusDofIndex();
+        unsigned interiorDofIdx = context.interiorScvIndex(bfIdx, timeIdx);
 
         ////////
         // advective fluxes of all components in all phases
         ////////
         (*this) = Evaluation(0.0);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            Evaluation meanMBoundary = 0;
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-                meanMBoundary +=
-                    fluidState.moleFraction(phaseIdx, compIdx)*FluidSystem::molarMass(compIdx);
-
             Evaluation density;
-            if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
-                density = FluidSystem::density(fluidState, paramCache, phaseIdx);
-            else
+            if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx)) {
+                if (focusDofIdx == interiorDofIdx)
+                    density = fluidState.density(phaseIdx);
+                else
+                    density = Opm::getValue(fluidState.density(phaseIdx));
+            }
+            else if (focusDofIdx == interiorDofIdx)
                 density = insideIntQuants.fluidState().density(phaseIdx);
+            else
+                density = Opm::getValue(insideIntQuants.fluidState().density(phaseIdx));
 
             for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx) {
                 Evaluation molarity;
-                if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
-                    molarity = fluidState.moleFraction(phaseIdx, compIdx)*density/meanMBoundary;
-                else
+                if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx)) {
+                    if (focusDofIdx == interiorDofIdx)
+                        molarity = fluidState.molarity(phaseIdx, compIdx);
+                    else
+                        molarity = Opm::getValue(fluidState.molarity(phaseIdx, compIdx));
+                }
+                else if (focusDofIdx == interiorDofIdx)
                     molarity = insideIntQuants.fluidState().molarity(phaseIdx, compIdx);
+                else
+                    molarity = Opm::getValue(insideIntQuants.fluidState().molarity(phaseIdx, compIdx));
 
                 // add advective flux of current component in current
                 // phase
@@ -124,18 +130,25 @@ public:
 
             if (enableEnergy) {
                 Evaluation specificEnthalpy;
-                if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx))
-                    specificEnthalpy = FluidSystem::enthalpy(fluidState, paramCache, phaseIdx);
-                else
+                if (fluidState.pressure(phaseIdx) > insideIntQuants.fluidState().pressure(phaseIdx)) {
+                    if (focusDofIdx == interiorDofIdx)
+                        specificEnthalpy = fluidState.enthalpy(phaseIdx);
+                    else
+                        specificEnthalpy = Opm::getValue(fluidState.enthalpy(phaseIdx));
+                }
+                else if (focusDofIdx == interiorDofIdx)
                     specificEnthalpy = insideIntQuants.fluidState().enthalpy(phaseIdx);
+                else
+                    specificEnthalpy = Opm::getValue(insideIntQuants.fluidState().enthalpy(phaseIdx));
 
                 Evaluation enthalpyRate = density*extQuants.volumeFlux(phaseIdx)*specificEnthalpy;
                 EnergyModule::addToEnthalpyRate(*this, enthalpyRate);
             }
         }
 
-        // thermal conduction
-        EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
+        if (enableEnergy)
+            // heat conduction
+            EnergyModule::addToEnthalpyRate(*this, EnergyModule::thermalConductionRate(extQuants));
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < numEq; ++i)

--- a/ewoms/models/pvs/pvsextensivequantities.hh
+++ b/ewoms/models/pvs/pvsextensivequantities.hh
@@ -81,10 +81,9 @@ public:
     void updateBoundary(const Context& context,
                         unsigned bfIdx,
                         unsigned timeIdx,
-                        const FluidState& fluidState,
-                        typename FluidSystem::template ParameterCache<typename FluidState::Scalar>& paramCache)
+                        const FluidState& fluidState)
     {
-        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState, paramCache);
+        ParentType::updateBoundary(context, bfIdx, timeIdx, fluidState);
         DiffusionExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
         EnergyExtensiveQuantities::updateBoundary_(context, bfIdx, timeIdx, fluidState);
     }

--- a/tests/problems/fingerproblem.hh
+++ b/tests/problems/fingerproblem.hh
@@ -177,6 +177,7 @@ class FingerProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
 
     enum {
         // number of phases
+        numPhases = FluidSystem::numPhases,
 
         // phase indices
         wettingPhaseIdx = FluidSystem::wettingPhaseIdx,
@@ -520,6 +521,14 @@ private:
         Scalar pn = 1e5;
         fs.setPressure(nonWettingPhaseIdx, pn);
         fs.setPressure(wettingPhaseIdx, pn);
+
+        typename FluidSystem::template ParameterCache<Scalar> paramCache;
+        paramCache.updateAll(fs);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            fs.setDensity(phaseIdx, FluidSystem::density(fs, paramCache, phaseIdx));
+            fs.setViscosity(phaseIdx, FluidSystem::viscosity(fs, paramCache, phaseIdx));
+        }
+
     }
 
     DimMatrix K_;

--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -470,6 +470,15 @@ public:
             fluidState.setPressure(wettingPhaseIdx, 1e5);
             fluidState.setPressure(nonWettingPhaseIdx, fluidState.pressure(wettingPhaseIdx));
 
+            typename FluidSystem::template ParameterCache<Scalar> paramCache;
+            paramCache.updateAll(fluidState);
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+                fluidState.setDensity(phaseIdx,
+                                      FluidSystem::density(fluidState, paramCache, phaseIdx));
+                fluidState.setViscosity(phaseIdx,
+                                        FluidSystem::viscosity(fluidState, paramCache, phaseIdx));
+            }
+
             // set a free flow (i.e. Dirichlet) boundary
             values.setFreeFlow(context, spaceIdx, timeIdx, fluidState);
         }

--- a/tests/problems/infiltrationproblem.hh
+++ b/tests/problems/infiltrationproblem.hh
@@ -449,7 +449,7 @@ private:
         typedef Opm::ComputeFromReferencePhase<Scalar, FluidSystem> CFRP;
         typename FluidSystem::template ParameterCache<Scalar> paramCache;
         CFRP::solve(fs, paramCache, gasPhaseIdx,
-                    /*setViscosity=*/false,
+                    /*setViscosity=*/true,
                     /*setEnthalpy=*/false);
 
         fs.setMoleFraction(waterPhaseIdx, H2OIdx,

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -426,9 +426,9 @@ public:
         const GlobalPosition& pos = context.pos(spaceIdx, timeIdx);
 
         if (onLeftBoundary_(pos) || onRightBoundary_(pos)) {
-            // free flow boundary
-            Scalar densityW = WettingPhase::density(temperature_,
-                                                     /*pressure=*/Scalar(1e5));
+            // free flow boundary. we assume incompressible fluids
+            Scalar densityW = WettingPhase::density(temperature_, /*pressure=*/Scalar(1e5));
+            Scalar densityN = NonwettingPhase::density(temperature_, /*pressure=*/Scalar(1e5));
 
             Scalar T = temperature(context, spaceIdx, timeIdx);
             Scalar pw, Sw;
@@ -464,6 +464,12 @@ public:
             MaterialLaw::capillaryPressures(pC, matParams, fs);
             fs.setPressure(wettingPhaseIdx, pw);
             fs.setPressure(nonWettingPhaseIdx, pw + pC[nonWettingPhaseIdx] - pC[wettingPhaseIdx]);
+
+            fs.setDensity(wettingPhaseIdx, densityW);
+            fs.setDensity(nonWettingPhaseIdx, densityN);
+
+            fs.setViscosity(wettingPhaseIdx, WettingPhase::viscosity(temperature_, fs.pressure(wettingPhaseIdx)));
+            fs.setViscosity(nonWettingPhaseIdx, NonwettingPhase::viscosity(temperature_, fs.pressure(nonWettingPhaseIdx)));
 
             // impose an freeflow boundary condition
             values.setFreeFlow(context, spaceIdx, timeIdx, fs);

--- a/tests/problems/obstacleproblem.hh
+++ b/tests/problems/obstacleproblem.hh
@@ -528,12 +528,11 @@ private:
 
         // make the fluid state consistent with local thermodynamic
         // equilibrium
-        typedef Opm::ComputeFromReferencePhase<Scalar, FluidSystem>
-        ComputeFromReferencePhase;
+        typedef Opm::ComputeFromReferencePhase<Scalar, FluidSystem> ComputeFromReferencePhase;
 
         typename FluidSystem::template ParameterCache<Scalar> paramCache;
         ComputeFromReferencePhase::solve(fs, paramCache, refPhaseIdx,
-                                         /*setViscosity=*/false,
+                                         /*setViscosity=*/true,
                                          /*setEnthalpy=*/false);
     }
 

--- a/tests/problems/outflowproblem.hh
+++ b/tests/problems/outflowproblem.hh
@@ -122,6 +122,8 @@ class OutflowProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
         dim = GridView::dimension,
         dimWorld = GridView::dimensionworld,
 
+        numPhases = FluidSystem::numPhases,
+
         // component indices
         H2OIdx = FluidSystem::H2OIdx,
         N2Idx = FluidSystem::N2Idx
@@ -267,6 +269,13 @@ public:
             fs.setMoleFraction(/*phaseIdx=*/0, N2Idx, xlN2);
             fs.setMoleFraction(/*phaseIdx=*/0, H2OIdx, 1 - xlN2);
 
+            typename FluidSystem::template ParameterCache<Scalar> paramCache;
+            paramCache.updateAll(fs);
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+                fs.setDensity(phaseIdx, FluidSystem::density(fs, paramCache, phaseIdx));
+                fs.setViscosity(phaseIdx, FluidSystem::viscosity(fs, paramCache, phaseIdx));
+            }
+
             // impose an freeflow boundary condition
             values.setFreeFlow(context, spaceIdx, timeIdx, fs);
         }
@@ -343,6 +352,13 @@ private:
         fs.setMoleFraction(/*phaseIdx=*/0, H2OIdx, 1.0);
         fs.setMoleFraction(/*phaseIdx=*/0, N2Idx, 0);
         fs.setTemperature(T);
+
+        typename FluidSystem::template ParameterCache<Scalar> paramCache;
+        paramCache.updateAll(fs);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            fs.setDensity(phaseIdx, FluidSystem::density(fs, paramCache, phaseIdx));
+            fs.setViscosity(phaseIdx, FluidSystem::viscosity(fs, paramCache, phaseIdx));
+        }
     }
 
     const Scalar eps_;

--- a/tests/problems/powerinjectionproblem.hh
+++ b/tests/problems/powerinjectionproblem.hh
@@ -170,6 +170,7 @@ class PowerInjectionProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
 
     enum {
         // number of phases
+        numPhases = FluidSystem::numPhases,
 
         // phase indices
         wettingPhaseIdx = FluidSystem::wettingPhaseIdx,
@@ -409,6 +410,15 @@ private:
         Scalar p = 1e5;
         initialFluidState_.setPressure(wettingPhaseIdx, p);
         initialFluidState_.setPressure(nonWettingPhaseIdx, p);
+
+        typename FluidSystem::template ParameterCache<Scalar> paramCache;
+        paramCache.updateAll(initialFluidState_);
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            initialFluidState_.setDensity(phaseIdx,
+                                          FluidSystem::density(initialFluidState_, paramCache, phaseIdx));
+            initialFluidState_.setViscosity(phaseIdx,
+                                            FluidSystem::viscosity(initialFluidState_, paramCache, phaseIdx));
+        }
     }
 
     DimMatrix K_;

--- a/tests/problems/reservoirproblem.hh
+++ b/tests/problems/reservoirproblem.hh
@@ -663,7 +663,7 @@ private:
         CFRP::solve(injFs,
                     paramCache,
                     /*refPhaseIdx=*/waterPhaseIdx,
-                    /*setViscosities=*/false,
+                    /*setViscosities=*/true,
                     /*setEnthalpies=*/false);
 
         // set up the fluid state used for the producer
@@ -681,7 +681,7 @@ private:
         CFRP::solve(prodFs,
                     paramCache,
                     /*refPhaseIdx=*/oilPhaseIdx,
-                    /*setViscosities=*/false,
+                    /*setViscosities=*/true,
                     /*setEnthalpies=*/false);
     }
 

--- a/tests/problems/richardslensproblem.hh
+++ b/tests/problems/richardslensproblem.hh
@@ -368,6 +368,14 @@ public:
             fs.setPressure(wettingPhaseIdx, pnRef_ + pC[wettingPhaseIdx] - pC[nonWettingPhaseIdx]);
             fs.setPressure(nonWettingPhaseIdx, pnRef_);
 
+            typename FluidSystem::template ParameterCache<Scalar> paramCache;
+            paramCache.updateAll(fs);
+            fs.setDensity(wettingPhaseIdx, FluidSystem::density(fs, paramCache, wettingPhaseIdx));
+            //fs.setDensity(nonWettingPhaseIdx, FluidSystem::density(fs, paramCache, nonWettingPhaseIdx));
+
+            fs.setViscosity(wettingPhaseIdx, FluidSystem::viscosity(fs, paramCache, wettingPhaseIdx));
+            //fs.setViscosity(nonWettingPhaseIdx, FluidSystem::viscosity(fs, paramCache, nonWettingPhaseIdx));
+
             values.setFreeFlow(context, spaceIdx, timeIdx, fs);
         }
         else if (onInlet_(pos)) {

--- a/tests/problems/waterairproblem.hh
+++ b/tests/problems/waterairproblem.hh
@@ -527,7 +527,7 @@ private:
 
         typename FluidSystem::template ParameterCache<Scalar> paramCache;
         typedef Opm::ComputeFromReferencePhase<Scalar, FluidSystem> CFRP;
-        CFRP::solve(fs, paramCache, liquidPhaseIdx, /*setViscosity=*/false,  /*setEnthalpy=*/true);
+        CFRP::solve(fs, paramCache, liquidPhaseIdx, /*setViscosity=*/true,  /*setEnthalpy=*/true);
     }
 
     void computeThermalCondParams_(ThermalConductionLawParams& params, Scalar poro)

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -243,6 +243,13 @@ public:
             fs.setPressure(wettingPhaseIdx, 200e3);
             fs.setPressure(nonWettingPhaseIdx, 200e3 + pC[nonWettingPhaseIdx] - pC[nonWettingPhaseIdx]);
 
+            typename FluidSystem::template ParameterCache<Scalar> paramCache;
+            paramCache.updateAll(fs);
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+                fs.setDensity(phaseIdx, FluidSystem::density(fs, paramCache, phaseIdx));
+                fs.setViscosity(phaseIdx, FluidSystem::viscosity(fs, paramCache, phaseIdx));
+            }
+
             values.setFreeFlow(context, spaceIdx, timeIdx, fs);
         }
         else if (pos[0] > this->boundingBoxMax()[0] - eps_) {


### PR DESCRIPTION
instead of passing a "minimal" fluid state that defines the thermodynamic conditions on the domain boundary and the models calculating everything they need based on this, it is now assumed that all quantities needed by the code that computes the boundary fluxes are defined. This simplifies the boundary flux computation code, it allows to get rid of the `paramCache` argument for these methods and to potentially speed things up because quantities do not get re-calculated unconditionally.

on the flipside, this requires slightly more effort to define the conditions at the boundary on the problem level and it makes it less obvious which quantities are actually used. That said, one now has the
freedom to shoot oneself into the foot more easily when specifying boundary conditions and also tools like valgrind or ASAN will normally complain about undefined quantities if this happens.