### PR TITLE
FluidInPlace, INIT and EGRID output to Ebos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,11 @@ opm_add_test(test_equil
              DRIVER_ARGS --plain
              CONDITION OPM_PARSER_FOUND AND OPM_GRID_FOUND)
 
+# Output ECL tests
+opm_add_test(test_ecl_output
+             DRIVER_ARGS --plain
+             CONDITION OPM_PARSER_FOUND AND OPM_GRID_FOUND AND OPM_OUTPUT_FOUND)
+
 # add targets for all tests of the models. we add the water-air test
 # first because it take longest and so that we don't have to wait for
 # them as long for parallel test runs

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,7 +51,7 @@ list(APPEND TEST_DATA_FILES
 	tests/data/equil_capillary.DATA
 	tests/data/equil_capillary_swatinit.DATA
 	tests/data/equil_base.DATA
-	tests/data/equil_livegas.DATAq
+	tests/data/equil_livegas.DATA
 	tests/data/equil_liveoil.DATA
 	tests/data/summary_deck_non_constant_porosity.DATA
 	)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -51,8 +51,9 @@ list(APPEND TEST_DATA_FILES
 	tests/data/equil_capillary.DATA
 	tests/data/equil_capillary_swatinit.DATA
 	tests/data/equil_base.DATA
-	tests/data/equil_livegas.DATA
+	tests/data/equil_livegas.DATAq
 	tests/data/equil_liveoil.DATA
+	tests/data/summary_deck_non_constant_porosity.DATA
 	)
 
 list(APPEND TEST_SOURCE_FILES)

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -501,6 +501,20 @@ namespace Ewoms
             return globalRanks_;
         }
 
+        bool isGlobalIdxOnThisRank(const unsigned globalIdx) const
+        {
+            if ( ! isParallel() )
+            {
+                return true;
+            }
+            // the last indexMap is the local one
+            const IndexMapType& indexMap = indexMaps_.back();
+            if( indexMap.empty() )
+                OPM_THROW(std::logic_error,"index map is not created on this rank");
+
+            return std::find(indexMap.begin(), indexMap.end(), globalIdx) != indexMap.end();
+        }
+
     protected:
         P2PCommunicatorType             toIORankComm_;
         IndexMapType                    globalCartesianIndex_;

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -361,7 +361,7 @@ namespace Ewoms
                     read( buffer, indexMap, data);
                 }
 
-                // write all block data
+                // read all block data
                 unsigned int size = 0;
                 buffer.read(size);
                 for (size_t i = 0; i < size; ++i) {

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1169,7 +1169,7 @@ private:
         if (units.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_METRIC) {
             ss << "                                                  :      PAV  =" << std::setw(14) << pav << " BARSA                 :\n"
                << std::fixed << std::setprecision(0)
-               << "                                                  :      PORV =" << std::setw(14) << oip[FIPDataType::PoreVolume] << "   RM3                 :\n";
+               << "                                                  :      PORV =" << std::setw(14) << cip[FIPDataType::PoreVolume] << "   RM3                 :\n";
             if (!reg) {
                 ss << "                                                  : Pressure is weighted by hydrocarbon pore volume :\n"
                    << "                                                  : Porv volumes are taken at reference conditions  :\n";
@@ -1179,7 +1179,7 @@ private:
         if (units.getType() == Opm::UnitSystem::UnitType::UNIT_TYPE_FIELD) {
             ss << "                                                  :      PAV  =" << std::setw(14) << pav << "  PSIA                 :\n"
                << std::fixed << std::setprecision(0)
-               << "                                                  :      PORV =" << std::setw(14) << oip[FIPDataType::PoreVolume] << "   RB                  :\n";
+               << "                                                  :      PORV =" << std::setw(14) << cip[FIPDataType::PoreVolume] << "   RB                  :\n";
             if (!reg) {
                 ss << "                                                  : Pressure is weighted by hydrocarbon pore volume :\n"
                    << "                                                  : Pore volumes are taken at reference conditions  :\n";

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -346,7 +346,11 @@ public:
             if (oilPressure_.size() > 0) {
                 oilPressure_[globalDofIdx] = Opm::getValue(fs.pressure(oilPhaseIdx));
                 Opm::Valgrind::CheckDefined(oilPressure_[globalDofIdx]);
+            }
 
+            if (temperature_.size() > 0) {
+                temperature_[globalDofIdx] = Opm::getValue(fs.temperature(oilPhaseIdx));
+                Opm::Valgrind::CheckDefined(temperature_[globalDofIdx]);
             }
             if (gasDissolutionFactor_.size() > 0) {
                 Scalar SoMax = elemCtx.problem().maxOilSaturation(globalDofIdx);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1176,6 +1176,11 @@ public:
     const Opm::EclipseIO& eclIO() const
     { return eclWriter_->eclIO(); }
 
+    bool vapparsActive() const
+    {
+        return vapparsActive_;
+    }
+
 private:
     Scalar cellCenterDepth( const Element& element ) const
     {

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1529,10 +1529,9 @@ private:
         const auto& eclState = gridManager.eclState();
         const auto& eclProps = eclState.get3DProperties();
 
-        // since the values specified in the deck do not need to be consistent, we use an
-        // initial condition that conserves the total mass specified by these values, but
-        // for this to work all three phases must be active.
-        useMassConservativeInitialCondition_ = (FluidSystem::numActivePhases() == 3);
+        // the values specified in the deck do not need to be consistent,
+        // we still don't try to make the consistent.
+        useMassConservativeInitialCondition_ = false;
 
         // make sure all required quantities are enables
         if (FluidSystem::phaseIsActive(waterPhaseIdx) && !eclProps.hasDeckDoubleGridProperty("SWAT"))

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -210,6 +210,10 @@ SET_BOOL_PROP(EclBaseProblem, EnableVtkOutput, false);
 // ... but enable the ECL output by default
 SET_BOOL_PROP(EclBaseProblem, EnableEclOutput, true);
 
+// Output single precision is default
+SET_BOOL_PROP(EclBaseProblem, EclOutputDoublePrecision, false);
+
+
 // the cache for intensive quantities can be used for ECL problems and also yields a
 // decent speedup...
 SET_BOOL_PROP(EclBaseProblem, EnableIntensiveQuantityCache, true);
@@ -322,6 +326,8 @@ public:
                              "Eclipse simulator");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, EclOutputDir,
                              "The directory to which the ECL result files are written");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EclOutputDoublePrecision,
+                             "Tell the output writer to use double precision. Useful for 'perfect' restarts");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
     }

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -460,6 +460,8 @@ public:
             int numElements = gridView.size(/*codim=*/0);
             maxPolymerAdsorption_.resize(numElements, 0.0);
         }
+
+        eclWriter_->writeInit();
     }
 
     void prefetch(const Element& elem) const
@@ -702,11 +704,10 @@ public:
         }
         Scalar totalSolverTime = 0.0;
         Scalar nextstep = this->simulator().timeStepSize();
-        Opm::data::Solution fip;
-        writeOutput(dw, t, false, totalSolverTime, nextstep, fip, verbose);
+        writeOutput(dw, t, false, totalSolverTime, nextstep, verbose);
     }
 
-    void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, const Opm::data::Solution& fip, bool verbose = true)
+    void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, bool verbose = true)
     {
         // use the generic code to prepare the output fields and to
         // write the desired VTK files.
@@ -714,7 +715,7 @@ public:
 
         // output using eclWriter if enabled
         if (eclWriter_)
-            eclWriter_->writeOutput(dw, t, substep, totalSolverTime, nextstep, fip);
+            eclWriter_->writeOutput(dw, t, substep, totalSolverTime, nextstep);
     }
 
     /*!
@@ -1165,9 +1166,6 @@ public:
     const InitialFluidState& initialFluidState(unsigned globalDofIdx ) const {
         return initialFluidStates_[globalDofIdx];
     }
-
-    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO)
-    { eclWriter_->setEclIO(std::move(eclIO)); }
 
     const Opm::EclipseIO& eclIO() const
     { return eclWriter_->eclIO(); }

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -145,9 +145,6 @@ public:
         const ElementIterator& elemEndIt = gridView.template end</*codim=*/0>();
         for (; elemIt != elemEndIt; ++elemIt) {
             const Element& elem = *elemIt;
-            if (elem.partitionType() != Dune::InteriorEntity)
-                continue;
-
             elemCtx.updatePrimaryStencil(elem);
             elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
             eclOutputModule_.processElement(elemCtx);

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -188,7 +188,7 @@ public:
                                   false);
         }
 
-        #endif
+#endif
     }
 
     void restartBegin()

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -163,7 +163,7 @@ public:
 
         std::map<std::string, double> miscSummaryData;
         std::map<std::string, std::vector<double>> regionData;
-        eclOutputModule_.outputFIPLog(miscSummaryData, regionData, substep);
+        eclOutputModule_.outputFipLog(miscSummaryData, regionData, substep);
 
         // write output on I/O rank
         if (collectToIORank_.isIORank()) {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -140,7 +140,7 @@ public:
         const auto& gridView = simulator_.gridManager().gridView();
         int numElements = gridView.size(/*codim=*/0);
         bool log = collectToIORank_.isIORank();
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, simulator_.gridManager().eclState().getRestartConfig(), substep, log);
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, substep, log, collectToIORank_);
 
         ElementContext elemCtx(simulator_);
         ElementIterator elemIt = gridView.template begin</*codim=*/0>();
@@ -218,7 +218,7 @@ public:
         unsigned episodeIdx = simulator_.episodeIndex();
         const auto& gridView = simulator_.gridManager().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, simulator_.gridManager().eclState().getRestartConfig(), false, false);
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, false, false, collectToIORank_);
 
         auto restart_values = eclIO_->loadRestart(solution_keys, extra_keys);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -94,8 +94,8 @@ class EclWriter
 public:
     EclWriter(const Simulator& simulator)
         : simulator_(simulator)
-        , eclOutputModule_(simulator)
         , collectToIORank_(simulator_.gridManager())
+        , eclOutputModule_(simulator, collectToIORank_)
     {
         globalGrid_ = simulator_.gridManager().grid();
         globalGrid_.switchToGlobalView();
@@ -140,7 +140,7 @@ public:
         const auto& gridView = simulator_.gridManager().gridView();
         int numElements = gridView.size(/*codim=*/0);
         bool log = collectToIORank_.isIORank();
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, substep, log, collectToIORank_);
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, substep, log);
 
         ElementContext elemCtx(simulator_);
         ElementIterator elemIt = gridView.template begin</*codim=*/0>();
@@ -218,7 +218,7 @@ public:
         unsigned episodeIdx = simulator_.episodeIndex();
         const auto& gridView = simulator_.gridManager().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, /*substep=*/false, /*log=*/false, collectToIORank_);
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, /*substep=*/false, /*log=*/false);
 
         auto restart_values = eclIO_->loadRestart(solution_keys, extra_keys);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
@@ -393,8 +393,8 @@ private:
     { return simulator_.gridManager().eclState(); }
 
     const Simulator& simulator_;
-    EclOutputBlackOilModule<TypeTag> eclOutputModule_;
     CollectDataToIORankType collectToIORank_;
+    EclOutputBlackOilModule<TypeTag> eclOutputModule_;
     std::unique_ptr<Opm::EclipseIO> eclIO_;
     Grid globalGrid_;
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -218,7 +218,7 @@ public:
         unsigned episodeIdx = simulator_.episodeIndex();
         const auto& gridView = simulator_.gridManager().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
-        eclOutputModule_.allocBuffers(numElements, episodeIdx, false, false, collectToIORank_);
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, /*substep=*/false, /*log=*/false, collectToIORank_);
 
         auto restart_values = eclIO_->loadRestart(solution_keys, extra_keys);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -178,7 +178,7 @@ public:
             if (totalSolverTime != 0.0) {
                 miscSummaryData["TCPU"] = totalSolverTime;
             }
-            bool enableDoublePrecisionOutput = false; //EWOMS_GET_PARAM(TypeTag, bool, EclOutputDoublePrecision);
+            bool enableDoublePrecisionOutput = EWOMS_GET_PARAM(TypeTag, bool, EclOutputDoublePrecision);
             const Opm::data::Solution& cellData = collectToIORank_.isParallel() ? collectToIORank_.globalCellData() : localCellData;
             const std::map<std::pair<std::string, int>, double>& blockValues = collectToIORank_.isParallel() ? collectToIORank_.globalBlockValues() : eclOutputModule_.getBlockValues();
 

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -83,6 +83,7 @@ class EclWriter
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
     typedef typename GridView::template Codim<0>::Entity Element;
     typedef typename GridView::template Codim<0>::Iterator ElementIterator;
 
@@ -199,11 +200,11 @@ public:
     void restartBegin()
     {
         std::map<std::string, Opm::RestartKey> solution_keys {{"PRESSURE" , Opm::RestartKey(Opm::UnitSystem::measure::pressure)},
-                                                         {"SWAT" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},
-                                                         {"SGAS" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},
-                                                         {"TEMP" , Opm::RestartKey(Opm::UnitSystem::measure::temperature)},
-                                                         {"RS" , Opm::RestartKey(Opm::UnitSystem::measure::gas_oil_ratio)},
-                                                         {"RV" , Opm::RestartKey(Opm::UnitSystem::measure::oil_gas_ratio)},
+                                                         {"SWAT" , Opm::RestartKey(Opm::UnitSystem::measure::identity, FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},
+                                                         {"SGAS" , Opm::RestartKey(Opm::UnitSystem::measure::identity, FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))},
+                                                         {"TEMP" , Opm::RestartKey(Opm::UnitSystem::measure::temperature)}, // always required for now
+                                                         {"RS" , Opm::RestartKey(Opm::UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas())},
+                                                         {"RV" , Opm::RestartKey(Opm::UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil())},
                                                          {"SOMAX", {Opm::UnitSystem::measure::identity, false}},
                                                          {"PCSWM_OW", {Opm::UnitSystem::measure::identity, false}},
                                                          {"KRNSW_OW", {Opm::UnitSystem::measure::identity, false}},

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -255,8 +255,14 @@ private:
 
         const auto& globalGridView = globalGrid_.leafGridView();
         typedef typename Grid::LeafGridView GridView;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
+        typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView> ElementMapper;
+        ElementMapper globalElemMapper(globalGridView, Dune::mcmgElementLayout());
+#else
         typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView, Dune::MCMGElementLayout> ElementMapper;
         ElementMapper globalElemMapper(globalGridView);
+#endif
+
         const auto& cartesianCellIdx = globalGrid_.globalCell();
 
         const auto* globalTrans = &(simulator_.gridManager().globalTransmissibility());
@@ -323,8 +329,14 @@ private:
 
         const auto& globalGridView = globalGrid_.leafGridView();
         typedef typename Grid::LeafGridView GridView;
+#if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
+        typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView> ElementMapper;
+        ElementMapper globalElemMapper(globalGridView, Dune::mcmgElementLayout());
+
+#else
         typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView, Dune::MCMGElementLayout> ElementMapper;
         ElementMapper globalElemMapper(globalGridView);
+#endif
 
         const auto* globalTrans = &(simulator_.gridManager().globalTransmissibility());
         if (!collectToIORank_.isParallel()) {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -28,13 +28,12 @@
 #ifndef EWOMS_ECL_WRITER_HH
 #define EWOMS_ECL_WRITER_HH
 
-#include <opm/material/densead/Evaluation.hpp>
-
 #include "collecttoiorank.hh"
 #include "ecloutputblackoilmodule.hh"
 
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include <ewoms/io/baseoutputwriter.hh>
+
 #include <opm/output/eclipse/EclipseIO.hpp>
 
 #include <opm/common/Valgrind.hpp>
@@ -58,7 +57,6 @@ NEW_PROP_TAG(EnableEclOutput);
 
 template <class TypeTag>
 class EclWriter;
-
 
 /*!
  * \ingroup EclBlackOilSimulator
@@ -87,17 +85,15 @@ class EclWriter
     typedef typename GridView::template Codim<0>::Entity Element;
     typedef typename GridView::template Codim<0>::Iterator ElementIterator;
 
-
     typedef CollectDataToIORank< GridManager > CollectDataToIORankType;
 
     typedef std::vector<Scalar> ScalarBuffer;
-
 
 public:
     EclWriter(const Simulator& simulator)
         : simulator_(simulator)
         , eclOutputModule_(simulator)
-        , collectToIORank_( simulator_.gridManager() )
+        , collectToIORank_(simulator_.gridManager())
     {
         Grid globalGrid = simulator_.gridManager().grid();
         globalGrid.switchToGlobalView();
@@ -110,23 +106,21 @@ public:
     ~EclWriter()
     { }
 
-    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO) {
-        eclIO_ = std::move(eclIO);
-    }
+    void setEclIO(std::unique_ptr<Opm::EclipseIO>&& eclIO)
+    { eclIO_ = std::move(eclIO); }
 
     const Opm::EclipseIO& eclIO() const
-    {return *eclIO_;}
+    { return *eclIO_; }
 
     /*!
      * \brief collect and pass data and pass it to eclIO writer
      */
     void writeOutput(const Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, const Opm::data::Solution& fip)
     {
-
-        #if !HAVE_OPM_OUTPUT
-                OPM_THROW(std::runtime_error,
-                          "Opm-output must be available to write ECL output!");
-        #else
+#if !HAVE_OPM_OUTPUT
+        OPM_THROW(std::runtime_error,
+                  "Opm-output must be available to write ECL output!");
+#else
 
         int episodeIdx = simulator_.episodeIndex() + 1;
         const auto& gridView = simulator_.gridManager().gridView();
@@ -179,7 +173,8 @@ public:
 #endif
     }
 
-    void restartBegin() {
+    void restartBegin()
+    {
         std::map<std::string, Opm::RestartKey> solution_keys {{"PRESSURE" , Opm::RestartKey(Opm::UnitSystem::measure::pressure)},
                                                          {"SWAT" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},
                                                          {"SGAS" , Opm::RestartKey(Opm::UnitSystem::measure::identity)},

--- a/tests/data/summary_deck_non_constant_porosity.DATA
+++ b/tests/data/summary_deck_non_constant_porosity.DATA
@@ -1,0 +1,658 @@
+-- Synthetic test deck based on Norne. This data set is meant to be a simple,
+-- well-documented deck for the behaviour of SUMMARY specified output. Data
+-- is mostly entered to *traceable* and does not necessarily make sense from
+-- a simulation point of view.
+
+START
+10 MAI 2007 /
+RUNSPEC
+
+TITLE
+SUMMARYTESTS
+
+-- A simple 10x10x10 cube. Simple to reason about, large enough for all tests
+DIMENS
+ 10 10 10 /
+
+REGDIMS
+  3 /
+
+OIL
+GAS
+WATER
+DISGAS
+
+METRIC
+
+GRID
+
+DX
+1000*1 /
+DY
+1000*1 /
+DZ
+1000*1 /
+TOPS
+100*1 /
+
+ACTNUM
+  1000*1/
+  
+PORO
+500*0.1 500*0.2/
+
+PERMX
+        1000*500 /
+
+REGIONS
+
+FIPNUM
+   400*1
+   200*2
+   400*3 /
+   
+PROPS
+
+PVTW
+        1 1000 0 0.318 0.0 /
+
+ROCK
+        14.7 3E-6 /
+
+SWOF
+0.12	0    		 	1	0
+0.18	4.64876033057851E-008	1	0
+0.24	0.000000186		0.997	0
+0.3	4.18388429752066E-007	0.98	0
+0.36	7.43801652892562E-007	0.7	0
+0.42	1.16219008264463E-006	0.35	0
+0.48	1.67355371900826E-006	0.2	0
+0.54	2.27789256198347E-006	0.09	0
+0.6	2.97520661157025E-006	0.021	0
+0.66	3.7654958677686E-006	0.01	0
+0.72	4.64876033057851E-006	0.001	0
+0.78	0.000005625		0.0001	0
+0.84	6.69421487603306E-006	0	0
+0.91	8.05914256198347E-006	0	0
+1	0.00001			0	0 /
+
+
+SGOF
+0	0	1	0
+0.001	0	1	0
+0.02	0	0.997	0
+0.05	0.005	0.980	0
+0.12	0.025	0.700	0
+0.2	0.075	0.350	0
+0.25	0.125	0.200	0
+0.3	0.190	0.090	0
+0.4	0.410	0.021	0
+0.45	0.60	0.010	0
+0.5	0.72	0.001	0
+0.6	0.87	0.0001	0
+0.7	0.94	0.000	0
+0.85	0.98	0.000	0
+0.88	0.984	0.000	0 /
+
+DENSITY
+        53.66 64.49 0.0533 /
+
+PVDG
+1	100	1
+10	10	1 /
+
+PVTO
+0 1	10	1 /
+1 1	10	1 
+  10    1       1 / 
+/
+
+SUMMARY
+DATE
+PERFORMA
+--
+-- Field Data
+-- Production Rates
+FVPR
+FWPR
+FWPRH
+FOPR
+FOPRH
+FGPR
+FGPRH
+FLPR
+FLPRH
+FGSR
+FGCR
+FNPR -- solvent
+--FTPRSEA
+-- Injection Rates
+FVIR
+FWIR
+FWIRH
+FGIR
+FNIR -- solvent
+FGIRH
+-- Production Cummulatives
+FVPT
+FWPT
+FOPT
+FLPT
+FLPTH
+FGPT
+FNPT
+FOPTH
+FGPTH
+FWPTH
+FGST
+FGCT
+-- Injection Cummulatives
+FVIT
+FWIT
+FWITH
+FGIT
+FNIT
+FGITH
+-- In place
+FWIP
+FOIP
+FGIP
+-- Ratios
+FWCT
+FWCTH
+FGOR
+FGORH
+
+-- From model2
+FMWPR
+FMWIN
+FOE
+
+-- Pressures
+FPR
+FPRP
+
+BPR
+  1  1  1 /
+  1  1  2 /
+  1  1  3 /
+  1  1  4 /
+  1  1  5 /
+  1  1  6 /
+  1  1  7 /
+  1  1  8 /
+  1  1  9 /
+  1  1  10 /    
+  2  1  10 /  -- This cell is not ACTIVE
+/
+
+BSGAS
+  1  1  1 /
+/
+
+
+BSWAT
+  1  1  1 /
+/
+
+
+--  Region data
+RPR
+/
+ROPT
+/
+RGPT
+/
+RWPT
+/
+RGFT
+/
+RWFT
+/
+ROIP
+/
+ROP
+/
+ROPR
+/
+RGPR
+/
+RWPR
+/
+RGIR
+/
+RGIT
+/
+RWIR
+/
+RWIT
+/
+RWPT
+/
+ROIPL
+/
+ROIPG
+/
+RGIP
+/
+RGIPL
+/
+RGIPG
+/
+RWIP
+/
+RPPO
+/
+
+--  Group data --
+GPR
+/
+GLPR
+/
+GOPT
+/
+GGPT
+/
+GWPT
+/
+GNPT
+/
+GOPR
+/
+GGPR
+/
+GWPR
+/
+GWPRH
+/
+GGIR
+/
+GNPR
+/
+
+GNIR
+/
+GGIRH
+/
+GGIT
+/
+GNIT
+/
+GGITH
+/
+GWCT
+/
+GWCTH
+/
+GGOR
+/
+GGORH
+/
+GWIR
+/
+GWIT
+/
+GWIRH
+/
+GWITH
+/
+GOPRH
+/
+GGPRH
+/
+GLPRH
+/
+GWPTH
+/
+GOPTH
+/
+GGPTH
+/
+GLPTH
+/
+GPRG
+/
+GPRW
+/
+GOPTF
+/
+GOPTS
+/
+GOPTH
+/
+GOPRF
+/
+GOPRS
+/
+GOPRH
+/
+GGPTF
+/
+GGPTS
+/
+GGPTH
+/
+GGPTF
+/
+GGPTS
+/
+GGPTH
+/
+GGLR
+/
+GGLIR
+/
+GGLRH
+/
+GVPR
+/
+GVPT
+/
+GMCTP
+/
+GOPP
+/
+GVIR
+/
+GVIT
+/
+GVPRT
+/
+GMWPR
+/
+GMWIN
+/
+-- Well Data
+-- Production Rates
+WWPR
+/
+WWPRH
+/
+WOPR
+/
+WOPRH
+/
+WGPR
+/
+WNPR
+/
+WGPRH
+/
+WLPR
+/
+WLPRH
+/
+
+WLPT
+/
+
+WLPTH
+/
+
+-- Injection Rates
+WWIR
+ W_3
+/
+WWIT
+ W_3
+/
+WWIRH
+  W_3
+/
+WWITH
+  W_3
+/
+
+WGIT
+  W_3
+/
+WGIR
+  W_3
+/
+WGIRH
+  W_3
+/
+WGITH
+  W_3
+/
+WNIR
+ W_3
+/
+WNIT
+ W_3
+/
+
+-- Production Cummulatives
+WWPT
+/
+WWPTH
+/
+WOPT
+/
+WOPTH
+/
+WGPT
+/
+WGPTH
+/
+WNPT
+/
+
+-- Tracers
+--WTPRSEA
+--/
+--WTPTSEA
+--/
+-- Injection Cummulatives
+WWIT
+  W_3
+/
+-- Ratios
+WWCT
+/
+WWCTH
+/
+WGOR
+/
+WGORH
+/
+WGLR
+/
+WGLRH
+/
+
+
+-- Performance
+WBHP
+/
+WBHPH
+/
+WTHP
+/
+WTHPH
+/
+WPI
+/
+WBP
+/
+WBP4
+/
+
+-- from model2
+WOPTF
+/
+WOPTS
+/
+WOPTH
+/
+WOPRS
+/
+WOPRF
+/
+WGPTF
+/
+WGPTS
+/
+WGPRF
+/
+WTPRS
+/
+WGLIR
+/
+WVPR
+/
+WVPT
+/
+WOPP
+/
+WVIR
+/
+WVIT
+/
+WMCTL
+/
+
+-- Water injection per connection
+CWIR
+  * /
+/
+
+-- Gas injection on 3 1 1 (45)
+CGIR
+'W_3' 3 1 1 /
+/
+
+CWIT
+'W_3' /
+/
+
+CGIT
+* /
+/
+
+-- Production per connection
+-- Using all the different ways of specifying connections here
+-- as an informal test that we still get the data we want
+CWPR
+ 'W_1' 1 1 1 /
+/
+
+COPR
+ 'W_1' /
+ 'W_2' /
+ 'W_3' /
+/
+
+CGPR
+ '*' /
+/
+
+CNFR
+ '*' /
+/
+
+CNPT
+ '*' /
+/
+
+CNIT
+ '*' /
+/
+
+CWPT
+ 'W_1' 1 1 1 /
+/
+
+COPT
+ 'W_1' /
+/
+
+CGPT
+ 'W_1' /
+ 'W_2' /
+ 'W_3' /
+/
+
+---- Connection production rates
+----CGFR
+----'E-4AH' /
+----/
+----CWFR
+----'E-2H' /
+----/
+
+SOLUTION
+
+SWAT
+ 1000*0.2 /
+
+SGAS
+ 1000*0.0 /
+
+PRESSURE
+ 100*1.0
+ 100*2.0
+ 100*3.0
+ 100*4.0
+ 100*5.0
+ 100*6.0
+ 100*7.0
+ 100*8.0
+ 100*9.0
+ 100*10.0/
+
+RS
+ 1000*0 /
+
+
+SCHEDULE
+
+-- Three wells, two producers (so that we can form a group) and one injector
+WELSPECS
+     'W_1'        'G_1'   1    1  3.33       'OIL'  7* /
+     'W_2'        'G_1'   2    1  3.33       'OIL'  7* /
+     'W_3'        'G_2'   3    1  3.92       'WATER'  7* /
+/
+
+-- Completion data.
+COMPDAT
+-- 'Well' I J K1 K2
+-- Passing 0 to I/J means they'll get the well head I/J
+    W_1 0 0 1 1 /   -- Active index: 0
+    W_2 0 0 1 1 /   -- Active index: 1
+    W_2 0 0 2 2 /   -- Active index: 101
+    W_3 0 0 1 1 /   -- Active index: 2
+/
+
+WCONHIST
+-- history rates are set so that W_1 produces 1, W_2 produces 2 etc.
+-- index.offset.
+-- organised as oil-water-gas
+    W_1 SHUT ORAT 10.1 10 10.2 /
+    W_2 SHUT ORAT 20.1 20 20.2 /
+/
+
+WCONINJH
+-- Injection historical rates (water only, as we only support pure injectors)
+    W_3 WATER STOP 30.0 /
+/
+
+TSTEP
+-- register time steps (in days). This allows us to write *two* report steps (1
+-- and 2. Without this, totals/accumulations would fail (segfault) when looking
+-- up historical rates and volumes. These volumes however don't change, i.e.
+-- every time step has the same set of values
+10 10 /
+
+-- Register a fourth well with completions later. This ensure we handle when
+-- wells are registered or activated later in a simulation
+WELSPECS
+     'W_4'        'G_3'   1    1  3.33       'OIL'  7* /
+/
+
+COMPDAT
+    W_4 1 1 3 3 /
+/
+
+TSTEP
+10 10 /

--- a/tests/test_ecl_output.cpp
+++ b/tests/test_ecl_output.cpp
@@ -1,0 +1,192 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+#include "config.h"
+
+#include <ebos/equil/equilibrationhelpers.hh>
+#include <ebos/eclproblem.hh>
+#include <ewoms/common/start.hh>
+
+#include <opm/core/grid.h>
+#include <opm/core/grid/GridManager.hpp>
+
+#include <opm/parser/eclipse/Units/Units.hpp>
+
+
+#include <opm/output/eclipse/Summary.hpp>
+#include <ebos/collecttoiorank.hh>
+#include <ebos/ecloutputblackoilmodule.hh>
+#include <ebos/eclwriter.hh>
+
+#if HAVE_DUNE_FEM
+#include <dune/fem/misc/mpimanager.hh>
+#else
+#include <dune/common/parallel/mpihelper.hh>
+#endif
+
+#include <array>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <string.h>
+#define CHECK(value, expected)             \
+    {                                      \
+        if ((value) != (expected))         \
+            std::abort();                  \
+    }
+
+#define CHECK_CLOSE(value, expected, reltol)                            \
+    {                                                                   \
+        if (std::fabs((expected) - (value)) > 1e-14 &&                  \
+            std::fabs(((expected) - (value))/((expected) + (value))) > reltol) \
+            { \
+            std::cout << "Test failure: "; \
+            std::cout << "expected value " << expected << " is not close to value " << value << std::endl; \
+            std::abort();                                               \
+            } \
+    } \
+
+#define REQUIRE(cond)                      \
+    {                                      \
+        if (!(cond))                       \
+            std::abort();                  \
+    }
+
+namespace Ewoms {
+namespace Properties {
+NEW_TYPE_TAG(TestEclOutputTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem));
+SET_BOOL_PROP(TestEclOutputTypeTag, EnableGravity, false);
+}}
+
+static const int day = 24 * 60 * 60;
+
+template <class TypeTag>
+std::unique_ptr<typename GET_PROP_TYPE(TypeTag, Simulator)>
+initSimulator(const char *filename)
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+
+    std::string filenameArg = "--ecl-deck-file-name=";
+    filenameArg += filename;
+
+    const char* argv[] = {
+        "test_equil",
+        filenameArg.c_str()
+    };
+
+    Ewoms::setupParameters_<TypeTag>(/*argc=*/sizeof(argv)/sizeof(argv[0]), argv, /*registerParams=*/false);
+
+    return std::unique_ptr<Simulator>(new Simulator);
+}
+
+ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > readsum( const std::string& base ) {
+    return ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free >(
+            ecl_sum_fread_alloc_case( base.c_str(), ":" )
+           );
+}
+
+void test_summary()
+{
+    typedef typename TTAG(TestEclOutputTypeTag) TypeTag;
+    const std::string filename = "data/summary_deck_non_constant_porosity.DATA";
+    const std::string casename = "summary_deck_non_constant_porosity";
+
+    auto simulator = initSimulator<TypeTag>(filename.data());
+    typedef typename GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef Ewoms::CollectDataToIORank< GridManager > CollectDataToIORankType;
+    CollectDataToIORankType collectToIORank(simulator->gridManager());
+    Ewoms::EclOutputBlackOilModule<TypeTag> eclOutputModule(*simulator, collectToIORank);
+
+    typedef Ewoms::EclWriter<TypeTag> EclWriterType;
+    // create the actual ECL writer
+    std::unique_ptr<EclWriterType> eclWriter = std::unique_ptr<EclWriterType>(new EclWriterType(*simulator));
+
+    simulator->model().applyInitialSolution();
+    Opm::data::Wells dw;
+    bool substep = false;
+    Scalar totalSolverTime = 0;
+    Scalar nextstep = 0;
+    simulator->setEpisodeIndex(0);
+    eclWriter->writeOutput(dw, 0 * day, substep, totalSolverTime, nextstep);
+    simulator->setEpisodeIndex(1);
+    eclWriter->writeOutput(dw, 1 * day, substep, totalSolverTime, nextstep);
+    simulator->setEpisodeIndex(2);
+    eclWriter->writeOutput(dw, 2 * day, substep, totalSolverTime, nextstep);
+
+    auto res = readsum( casename );
+    const auto* resp = res.get();
+
+    // fpr = sum_ (p * hcpv ) / hcpv, hcpv = pv * (1 - sw)
+    const double fpr =  ( (3 * 0.1 + 8 * 0.2) * 500 * (1 - 0.2) ) / ( (500*0.1 + 500*0.2) * (1 - 0.2));
+    CHECK_CLOSE( fpr, ecl_sum_get_field_var( resp, 1, "FPR" ) , 1e-5 );
+
+    // foip = sum_ (b * s * pv), rs == 0;
+    const double foip = ( (0.3 * 0.1 + 0.8 * 0.2) * 500 * (1 - 0.2) );
+    CHECK_CLOSE(foip, ecl_sum_get_field_var( resp, 1, "FOIP" ), 1e-3 );
+
+    // fgip = sum_ (b * pv * s), sg == 0;
+    const double fgip = 0.0;
+    CHECK_CLOSE(fgip, ecl_sum_get_field_var( resp, 1, "FGIP" ), 1e-3 );
+
+    // fgip = sum_ (b * pv * s),
+    const double fwip = 1.0/1000 * ( 0.1 + 0.2) * 500 * 0.2;
+    CHECK_CLOSE(fwip, ecl_sum_get_field_var( resp, 1, "FWIP" ), 1e-3 );
+
+    // region 1
+    // rpr = sum_ (p * hcpv ) / hcpv, hcpv = pv * (1 - sw)
+    const double rpr1 =  ( 2.5 * 0.1 * 400 * (1 - 0.2) ) / (400*0.1 * (1 - 0.2));
+    CHECK_CLOSE( rpr1, ecl_sum_get_general_var( resp, 1, "RPR:1" ) , 1e-5 );
+    // roip = sum_ (b * s * pv) // rs == 0;
+    const double roip1 = ( 0.25 * 0.1 * 400 * (1 - 0.2) );
+    CHECK_CLOSE(roip1, ecl_sum_get_general_var( resp, 1, "ROIP:1" ), 1e-3 );
+
+
+    // region 2
+    // rpr = sum_ (p * hcpv ) / hcpv, hcpv = pv * (1 - sw)
+    const double rpr2 =  ( (5 * 0.1 * 100 + 6 * 0.2 * 100) * (1 - 0.2) ) / ( (100*0.1 + 100*0.2) * (1 - 0.2));
+    CHECK_CLOSE( rpr2, ecl_sum_get_general_var( resp, 1, "RPR:2" ) , 1e-5 );
+    // roip = sum_ (b * s * pv) // rs == 0;
+    const double roip2 = ( (0.5 * 0.1 * 100 + 0.6 * 0.2 * 100) * (1 - 0.2) );
+    CHECK_CLOSE(roip2, ecl_sum_get_general_var( resp, 1, "ROIP:2" ), 1e-3 );
+}
+
+int main(int argc, char** argv)
+{
+#if HAVE_DUNE_FEM
+    Dune::Fem::MPIManager::initialize(argc, argv);
+#else
+    Dune::MPIHelper::instance(argc, argv);
+#endif
+
+    typedef TTAG(TestEclOutputTypeTag) TypeTag;
+    Ewoms::registerAllParameters_<TypeTag>();
+    test_summary();
+
+    return 0;
+}
+
+


### PR DESCRIPTION
This PR build on #272 and makes the old PR absolute.  
1) EGRID and INIT output is added to new output module ebos
2) Adds option for double_si restart output
3) Compute region FIP and block values on each core and communicates the results instead of depending on these being computed by opm-output
4) Only compute and communicate values asked for by the deck. 

Depends on OPM/opm-grid#302, OPM/opm-output#235

and needs update in opm-simulator. 

TODO: 
- [x] Double check big models 
- [x] Double check MPI run  
