### PR TITLE
Implement blackoil energy

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -44,6 +44,7 @@ NEW_PROP_TAG(FluidSystem);
 NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(MaterialLaw);
+NEW_PROP_TAG(EnableEnergy);
 }
 
 /*!
@@ -65,10 +66,6 @@ class EclEquilInitializer
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
 
-    typedef Opm::BlackOilFluidState<Scalar,
-    FluidSystem,
-    /*enableTemperature=*/true> ScalarFluidState;
-
     enum { numPhases = FluidSystem::numPhases };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
@@ -80,6 +77,12 @@ class EclEquilInitializer
     enum { waterCompIdx = FluidSystem::waterCompIdx };
 
     enum { dimWorld = GridView::dimensionworld };
+    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
+
+    typedef Opm::BlackOilFluidState<Scalar,
+                                    FluidSystem,
+                                    /*enableTemperature=*/true,
+                                    /*enableEnthalpy=*/enableEnergy> ScalarFluidState;
 
 public:
     template <class EclMaterialLawManager>

--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -115,6 +115,7 @@ class EclTransExtensiveQuantities
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
     enum { numPhases = FluidSystem::numPhases };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
+    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldVector<Scalar, dimWorld> DimVector;

--- a/ebos/eclpeacemanwell.hh
+++ b/ebos/eclpeacemanwell.hh
@@ -116,8 +116,13 @@ class EclPeacemanWell : public BaseAuxiliaryModule<TypeTag>
 
     static const unsigned numModelEq = GET_PROP_VALUE(TypeTag, NumEq);
     static const unsigned conti0EqIdx = GET_PROP_TYPE(TypeTag, Indices)::conti0EqIdx;
+    static const unsigned contiEnergyEqIdx = GET_PROP_TYPE(TypeTag, Indices)::contiEnergyEqIdx;
 
-    typedef Opm::CompositionalFluidState<Scalar, FluidSystem, /*storeEnthalpy=*/false> FluidState;
+    static constexpr unsigned historySize = GET_PROP_VALUE(TypeTag, TimeDiscHistorySize);
+
+    static constexpr bool enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy);
+
+    typedef Opm::CompositionalFluidState<Scalar, FluidSystem, /*storeEnthalpy=*/true> FluidState;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
 
     // all quantities that need to be stored per degree of freedom that intersects the
@@ -318,6 +323,17 @@ public:
 
         int wellGlobalDof = AuxModule::localToGlobalDof(/*localDofIdx=*/0);
         sol[wellGlobalDof] = 0.0;
+
+        // make valgrind shut up about the DOFs for the well even if the PrimaryVariables
+        // class contains some "holes" due to alignment
+        Opm::Valgrind::SetDefined(sol[wellGlobalDof]);
+
+        // also apply the initial solution of the well to the "old" time steps
+        for (unsigned timeIdx = 1; timeIdx < historySize; ++timeIdx) {
+            auto& oldSol = const_cast<SolutionVector&>(simulator_.model().solution(timeIdx));
+
+            oldSol[wellGlobalDof] = sol[wellGlobalDof];
+        }
     }
 
     /*!
@@ -707,6 +723,12 @@ public:
      */
     void setControlMode(ControlMode controlMode)
     { controlMode_ = controlMode; }
+
+    /*!
+     * \brief Set the temperature of the injected fluids [K]
+     */
+    void setTemperature(Scalar value)
+    { wellTemperature_ = value; }
 
     /*!
      * \brief Set the connection transmissibility factor for a given degree of freedom.
@@ -1104,15 +1126,59 @@ public:
         computeVolumetricDofRates_(volumetricRates, actualBottomHolePressure_, tmp);
 
         // convert to mass rates
-        RateVector modelRate;
+        RateVector modelRate(0.0);
         const auto& intQuants = context.intensiveQuantities(dofIdx, timeIdx);
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
             if (!FluidSystem::phaseIsActive(phaseIdx))
                 continue;
 
+            // energy is disabled or we have production for the given phase, i.e., we
+            // can use the intensive quantities' fluid state
             modelRate.setVolumetricRate(intQuants.fluidState(), phaseIdx, volumetricRates[phaseIdx]);
-            for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-                q[conti0EqIdx + compIdx] += modelRate[conti0EqIdx + compIdx];
+
+            if (enableEnergy) {
+                if (volumetricRates[phaseIdx] < 0.0) {
+                    // producer
+                    const auto& fs = intQuants.fluidState();
+                    modelRate[contiEnergyEqIdx] += volumetricRates[phaseIdx]*fs.density(phaseIdx)*fs.enthalpy(phaseIdx);
+                }
+                else if (volumetricRates[phaseIdx] > 0.0
+                         && injectedPhaseIdx_ == phaseIdx)
+                {
+                    // injector for the right phase. we need to use the thermodynamic
+                    // quantities from the borehole as upstream
+                    //
+                    // TODO: This is not implemented in a very efficient way, the
+                    // required quantities could be precomputed at initialization!
+                    auto fs = injectionFluidState_;
+
+                    // TODO: maybe we need to use a depth dependent pressure here. the
+                    // difference is probably not very large, and for wells that span
+                    // multiple perforations it is unclear what "well temperature" means
+                    // anyway.
+                    fs.setPressure(phaseIdx, actualBottomHolePressure_);
+
+                    fs.setTemperature(wellTemperature_);
+
+                    typename FluidSystem::template ParameterCache<Evaluation> paramCache;
+                    unsigned globalSpaceIdx = context.globalSpaceIndex(dofIdx, timeIdx);
+                    unsigned pvtRegionIdx = context.primaryVars(dofIdx, timeIdx).pvtRegionIndex();
+                    paramCache.setRegionIndex(pvtRegionIdx);
+                    paramCache.setMaxOilSat(context.problem().maxOilSaturation(globalSpaceIdx));
+                    paramCache.updatePhase(fs, phaseIdx);
+
+                    const auto& rho = FluidSystem::density(fs, paramCache, phaseIdx);
+                    fs.setDensity(phaseIdx, rho);
+
+                    const auto& h = FluidSystem::enthalpy(fs, paramCache, phaseIdx);
+                    fs.setEnthalpy(phaseIdx, h);
+
+                    modelRate[contiEnergyEqIdx] += volumetricRates[phaseIdx]*fs.density(phaseIdx)*fs.enthalpy(phaseIdx);
+                }
+            }
+
+            for (unsigned eqIdx = 0; eqIdx < modelRate.size(); ++eqIdx)
+                q[conti0EqIdx + eqIdx] += modelRate[conti0EqIdx + eqIdx];
         }
 
         Opm::Valgrind::CheckDefined(q);
@@ -1561,6 +1627,9 @@ protected:
 
     // the sum of the total volumes of all the degrees of freedoms that interact with the well
     Scalar wellTotalVolume_;
+
+    // the temperature assumed for the fluid (in the case of an injector well)
+    Scalar wellTemperature_;
 
     // The assumed bottom hole and tubing head pressures as specified by the user
     Scalar bhpLimit_;

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -268,6 +268,15 @@ SET_BOOL_PROP(EclBaseProblem, DisableWells, false);
 // By default, we enable the debugging checks if we're compiled in debug mode
 SET_BOOL_PROP(EclBaseProblem, EnableDebuggingChecks, true);
 
+// store temperature (but do not conserve energy, as long as EnableEnergy is false)
+SET_BOOL_PROP(EclBaseProblem, EnableTemperature, true);
+
+// disable all extensions supported by black oil model. this should not really be
+// necessary but it makes things a bit more explicit
+SET_BOOL_PROP(EclBaseProblem, EnablePolymer, false);
+SET_BOOL_PROP(EclBaseProblem, EnableSolvent, false);
+SET_BOOL_PROP(EclBaseProblem, EnableEnergy, false);
+
 } // namespace Properties
 
 /*!
@@ -296,6 +305,7 @@ class EclProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
     enum { numComponents = FluidSystem::numComponents };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+    enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { gasPhaseIdx = FluidSystem::gasPhaseIdx };
     enum { oilPhaseIdx = FluidSystem::oilPhaseIdx };
@@ -325,8 +335,8 @@ class EclProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
 
     typedef Opm::BlackOilFluidState<Scalar,
                                     FluidSystem,
-                                    /*enableTemperature=*/true,
-                                    /*enableEnthalpy=*/enableEnergy> InitialFluidState;
+                                    enableTemperature,
+                                    enableEnergy> InitialFluidState;
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -103,6 +103,9 @@ public:
         {
             const Opm::Well* deckWell = deckSchedule.getWells()[deckWellIdx];
             const std::string& wellName = deckWell->name();
+            Scalar wellTemperature = 273.15 + 15.56; // [K]
+            if (deckWell->isInjector(/*timeStep=*/0))
+                wellTemperature = deckWell->getInjectionProperties(/*timeStep=*/0).temperature;
 
             // set the name of the well but not much else. (i.e., if it is not completed,
             // the well primarily serves as a placeholder.) The big rest of the well is
@@ -110,6 +113,7 @@ public:
             auto well = std::make_shared<Well>(simulator_);
             well->setName(wellName);
             well->setWellStatus(Well::Shut);
+            well->setTemperature(wellTemperature);
 
             wells_.push_back(well);
             wellNameToIndex_[well->name()] = wells_.size() - 1;
@@ -143,6 +147,9 @@ public:
                 continue;
 
             auto well = this->well(deckWell->name());
+
+            if (deckWell->isInjector(episodeIdx))
+                well->setTemperature(deckWell->getInjectionProperties(episodeIdx).temperature);
 
             Opm::WellCommon::StatusEnum deckWellStatus = deckWell->getStatus(episodeIdx);
             switch (deckWellStatus) {

--- a/ewoms/disc/common/fvbaselocalresidual.hh
+++ b/ewoms/disc/common/fvbaselocalresidual.hh
@@ -279,6 +279,16 @@ public:
                 }
             }
         }
+
+#ifndef NDEBUG
+        size_t numPrimaryDof = elemCtx.numPrimaryDof(/*timeIdx=*/0);
+        for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                Opm::Valgrind::CheckDefined(storage[dofIdx][eqIdx]);
+                assert(Opm::isfinite(storage[dofIdx][eqIdx]));
+            }
+        }
+#endif
     }
 
     /*!
@@ -305,10 +315,17 @@ public:
             Opm::Valgrind::SetUndefined(flux);
             asImp_().computeFlux(flux, /*context=*/elemCtx, scvfIdx, timeIdx);
             Opm::Valgrind::CheckDefined(flux);
+#ifndef NDEBUG
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
+                assert(Opm::isfinite(flux[eqIdx]));
+#endif
 
             Scalar alpha = elemCtx.extensiveQuantities(scvfIdx, timeIdx).extrusionFactor();
             alpha *= face.area();
             Opm::Valgrind::CheckDefined(alpha);
+            assert(alpha > 0.0);
+            assert(Opm::isfinite(alpha));
+
             for (unsigned eqIdx = 0; eqIdx < numEq; ++ eqIdx)
                 flux[eqIdx] *= alpha;
 
@@ -326,6 +343,7 @@ public:
             // volume i and into sub-control volume j, we need to add the flux to finite
             // volume i and subtract it from finite volume j
             for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
+                assert(Opm::isfinite(flux[eqIdx]));
                 residual[i][eqIdx] += flux[eqIdx];
                 residual[j][eqIdx] -= flux[eqIdx];
             }
@@ -336,7 +354,7 @@ public:
         size_t numDof = elemCtx.numDof(timeIdx);
         for (unsigned i=0; i < numDof; i++) {
             for (unsigned j = 0; j < numEq; ++ j) {
-                assert(std::isfinite(Toolbox::value(residual[i][j])));
+                assert(Opm::isfinite(residual[i][j]));
                 Opm::Valgrind::CheckDefined(residual[i][j]);
             }
         }
@@ -451,10 +469,14 @@ protected:
         const auto& stencil = boundaryCtx.stencil(timeIdx);
         unsigned dofIdx = stencil.boundaryFace(boundaryFaceIdx).interiorIndex();
         const auto& insideIntQuants = boundaryCtx.elementContext().intensiveQuantities(dofIdx, timeIdx);
-        for (unsigned eqIdx = 0; eqIdx < values.size(); ++eqIdx)
+        for (unsigned eqIdx = 0; eqIdx < values.size(); ++eqIdx)  {
             values[eqIdx] *=
                 stencil.boundaryFace(boundaryFaceIdx).area()
                 * insideIntQuants.extrusionFactor();
+
+            Opm::Valgrind::CheckDefined(values[eqIdx]);
+            assert(Opm::isfinite(values[eqIdx]));
+        }
 
         for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
             residual[dofIdx][eqIdx] += values[eqIdx];
@@ -480,9 +502,14 @@ protected:
         for (unsigned dofIdx=0; dofIdx < numPrimaryDof; dofIdx++) {
             Scalar extrusionFactor =
                 elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).extrusionFactor();
+            Opm::Valgrind::CheckDefined(extrusionFactor);
+            assert(Opm::isfinite(extrusionFactor));
+            assert(extrusionFactor > 0.0);
             Scalar scvVolume =
                elemCtx.stencil(/*timeIdx=*/0).subControlVolume(dofIdx).volume() * extrusionFactor;
             Opm::Valgrind::CheckDefined(scvVolume);
+            assert(Opm::isfinite(scvVolume));
+            assert(scvVolume > 0.0);
 
             // if the model uses extensive quantities in its storage term, and we use
             // automatic differention and current DOF is also not the one we currently
@@ -497,7 +524,12 @@ protected:
             }
             else
                 asImp_().computeStorage(tmp, elemCtx, dofIdx, /*timeIdx=*/0);
+
+#ifndef NDEBUG
             Opm::Valgrind::CheckDefined(tmp);
+            for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx)
+                assert(Opm::isfinite(tmp[eqIdx]));
+#endif
 
             if (elemCtx.enableStorageCache()) {
                 const auto& model = elemCtx.model();

--- a/ewoms/disc/common/fvbaseprimaryvariables.hh
+++ b/ewoms/disc/common/fvbaseprimaryvariables.hh
@@ -109,9 +109,9 @@ public:
         throw std::runtime_error("The PrimaryVariables class does not define "
                                  "an assignNaive() method");
     }
+
     /*!
-     * \brief Instruct valgrind to check the definedness of all
-     *        attributes of this class.
+     * \brief Instruct valgrind to check the definedness of all attributes of this class.
      */
     void checkDefined() const
     {

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -360,8 +360,8 @@ public:
      * \brief Returns the face object belonging to a given face index
      *        in the interior of the domain.
      */
-    const SubControlVolumeFace& interiorFace(unsigned bfIdx) const
-    { return interiorFaces_[bfIdx]; }
+    const SubControlVolumeFace& interiorFace(unsigned faceIdx) const
+    { return interiorFaces_[faceIdx]; }
 
     /*!
      * \brief Returns the number of boundary faces of the stencil.

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -212,6 +212,7 @@ public:
     };
 
     typedef EcfvSubControlVolumeFace<needFaceIntegrationPos, needFaceNormal> SubControlVolumeFace;
+    typedef EcfvSubControlVolumeFace</*needFaceIntegrationPos=*/true, needFaceNormal> BoundaryFace;
 
     EcfvStencil(const GridView& gridView, const Mapper& mapper)
         : gridView_(gridView)
@@ -372,7 +373,7 @@ public:
      * \brief Returns the boundary face object belonging to a given
      *        boundary face index.
      */
-    const SubControlVolumeFace& boundaryFace(unsigned bfIdx) const
+    const BoundaryFace& boundaryFace(unsigned bfIdx) const
     { return boundaryFaces_[bfIdx]; }
 
 protected:
@@ -382,7 +383,7 @@ protected:
     std::vector<Element> elements_;
     std::vector<SubControlVolume>      subControlVolumes_;
     std::vector<SubControlVolumeFace>  interiorFaces_;
-    std::vector<SubControlVolumeFace>  boundaryFaces_;
+    std::vector<BoundaryFace>  boundaryFaces_;
 };
 
 } // namespace Ewoms

--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -142,7 +142,7 @@ public:
     /*!
      * \brief Represents a face of a sub-control volume.
      */
-    template <bool needNormal, bool needIntegrationPos>
+    template <bool needIntegrationPos, bool needNormal>
     class EcfvSubControlVolumeFace
     {
     public:

--- a/ewoms/io/vtkblackoilenergymodule.hh
+++ b/ewoms/io/vtkblackoilenergymodule.hh
@@ -1,0 +1,221 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ * \copydoc Ewoms::VtkBlackOilEnergyModule
+ */
+#ifndef EWOMS_VTK_BLACK_OIL_ENERGY_MODULE_HH
+#define EWOMS_VTK_BLACK_OIL_ENERGY_MODULE_HH
+
+#include <opm/material/densead/Math.hpp>
+
+#include "vtkmultiwriter.hh"
+#include "baseoutputmodule.hh"
+
+#include <ewoms/common/propertysystem.hh>
+#include <ewoms/common/parametersystem.hh>
+#include <ewoms/models/blackoil/blackoilproperties.hh>
+
+#include <dune/common/fvector.hh>
+
+#include <cstdio>
+
+namespace Ewoms {
+namespace Properties {
+// create new type tag for the VTK multi-phase output
+NEW_TYPE_TAG(VtkBlackOilEnergy);
+
+// create the property tags needed for the energy module
+NEW_PROP_TAG(VtkWriteRockInternalEnergy);
+NEW_PROP_TAG(VtkWriteTotalThermalConductivity);
+NEW_PROP_TAG(VtkWriteFluidInternalEnergies);
+NEW_PROP_TAG(VtkWriteFluidEnthalpies);
+NEW_PROP_TAG(VtkOutputFormat);
+NEW_PROP_TAG(EnableVtkOutput);
+
+// set default values for what quantities to output
+SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteRockInternalEnergy, true);
+SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteTotalThermalConductivity, true);
+SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteFluidInternalEnergies, true);
+SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteFluidEnthalpies, true);
+} // namespace Properties
+} // namespace Ewoms
+
+namespace Ewoms {
+/*!
+ * \ingroup Vtk
+ *
+ * \brief VTK output module for the black oil model's energy related quantities.
+ */
+template <class TypeTag>
+class VtkBlackOilEnergyModule : public BaseOutputModule<TypeTag>
+{
+    typedef BaseOutputModule<TypeTag> ParentType;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    static const int vtkFormat = GET_PROP_VALUE(TypeTag, VtkOutputFormat);
+    typedef Ewoms::VtkMultiWriter<GridView, vtkFormat> VtkMultiWriter;
+
+    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
+    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+
+    typedef typename ParentType::ScalarBuffer ScalarBuffer;
+    typedef typename ParentType::PhaseBuffer PhaseBuffer;
+
+public:
+    VtkBlackOilEnergyModule(const Simulator& simulator)
+        : ParentType(simulator)
+    { }
+
+    /*!
+     * \brief Register all run-time parameters for the multi-phase VTK output
+     * module.
+     */
+    static void registerParameters()
+    {
+        if (!enableEnergy)
+            return;
+
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteRockInternalEnergy,
+                             "Include the volumetric internal energy of rock "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteTotalThermalConductivity,
+                             "Include the total thermal conductivity of the medium and the fluids "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFluidInternalEnergies,
+                             "Include the internal energies of the fluids "
+                             "in the VTK output files");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, VtkWriteFluidEnthalpies,
+                             "Include the enthalpies of the fluids "
+                             "in the VTK output files");
+    }
+
+    /*!
+     * \brief Allocate memory for the scalar fields we would like to
+     *        write to the VTK file.
+     */
+    void allocBuffers()
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enableEnergy)
+            return;
+
+        if (rockInternalEnergyOutput_())
+            this->resizeScalarBuffer_(rockInternalEnergy_);
+        if (totalThermalConductivityOutput_())
+            this->resizeScalarBuffer_(totalThermalConductivity_);
+        if (fluidInternalEnergiesOutput_())
+            this->resizePhaseBuffer_(fluidInternalEnergies_);
+        if (fluidEnthalpiesOutput_())
+            this->resizePhaseBuffer_(fluidEnthalpies_);
+    }
+
+    /*!
+     * \brief Modify the internal buffers according to the intensive quantities relevant for
+     *        an element
+     */
+    void processElement(const ElementContext& elemCtx)
+    {
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
+            return;
+
+        if (!enableEnergy)
+            return;
+
+        for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
+            const auto& intQuants = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0);
+            unsigned globalDofIdx = elemCtx.globalSpaceIndex(dofIdx, /*timeIdx=*/0);
+
+            if (rockInternalEnergyOutput_())
+                rockInternalEnergy_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.rockInternalEnergy());
+
+            if (totalThermalConductivityOutput_())
+                totalThermalConductivity_[globalDofIdx] =
+                    Opm::scalarValue(intQuants.totalThermalConductivity());
+
+            for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+                if (fluidInternalEnergiesOutput_())
+                    fluidInternalEnergies_[phaseIdx][globalDofIdx] =
+                        Opm::scalarValue(intQuants.fluidState().internalEnergy(phaseIdx));
+
+                if (fluidEnthalpiesOutput_())
+                    fluidEnthalpies_[phaseIdx][globalDofIdx] =
+                        Opm::scalarValue(intQuants.fluidState().enthalpy(phaseIdx));
+            }
+        }
+    }
+
+    /*!
+     * \brief Add all buffers to the VTK output writer.
+     */
+    void commitBuffers(BaseOutputWriter& baseWriter)
+    {
+        VtkMultiWriter *vtkWriter = dynamic_cast<VtkMultiWriter*>(&baseWriter);
+        if (!vtkWriter)
+            return;
+
+        if (!enableEnergy)
+            return;
+
+        if (rockInternalEnergyOutput_())
+            this->commitScalarBuffer_(baseWriter, "volumetric internal energy rock", rockInternalEnergy_);
+
+        if (totalThermalConductivityOutput_())
+            this->commitScalarBuffer_(baseWriter, "total thermal conductivity", totalThermalConductivity_);
+
+        if (fluidInternalEnergiesOutput_())
+            this->commitPhaseBuffer_(baseWriter, "internal energy_%s", fluidInternalEnergies_);
+
+        if (fluidEnthalpiesOutput_())
+            this->commitPhaseBuffer_(baseWriter, "enthalpy_%s", fluidEnthalpies_);
+    }
+
+private:
+    static bool rockInternalEnergyOutput_()
+    { return GET_PROP_VALUE(TypeTag, VtkWriteRockInternalEnergy); }
+
+    static bool totalThermalConductivityOutput_()
+    { return GET_PROP_VALUE(TypeTag, VtkWriteTotalThermalConductivity); }
+
+    static bool fluidInternalEnergiesOutput_()
+    { return GET_PROP_VALUE(TypeTag, VtkWriteFluidInternalEnergies); }
+
+    static bool fluidEnthalpiesOutput_()
+    { return GET_PROP_VALUE(TypeTag, VtkWriteFluidEnthalpies); }
+
+    ScalarBuffer rockInternalEnergy_;
+    ScalarBuffer totalThermalConductivity_;
+    PhaseBuffer fluidInternalEnergies_;
+    PhaseBuffer fluidEnthalpies_;
+};
+} // namespace Ewoms
+
+#endif

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -493,6 +493,7 @@ public:
         const auto& stencil = elemCtx.stencil(timeIdx);
         const auto& scvf = stencil.interiorFace(scvfIdx);
 
+        Scalar faceArea = scvf.area();
         unsigned inIdx = scvf.interiorIndex();
         unsigned exIdx = scvf.exteriorIndex();
         const auto& inIq = elemCtx.intensiveQuantities(inIdx, timeIdx);
@@ -533,9 +534,9 @@ public:
         if (inLambda > 0.0 && exLambda > 0.0) {
             // compute the "thermal transmissibility". In contrast to the normal
             // transmissibility this cannot be done as a preprocessing step because the
-            // average thermal thermal conductivity is analogous to the permeability but depends
-            // on the solution.
-            Scalar alpha = elemCtx.problem().thermalHalfTransmissibility(elemCtx, inIdx, exIdx);
+            // average thermal thermal conductivity is analogous to the permeability but
+            // depends on the solution.
+            Scalar alpha = elemCtx.problem().thermalHalfTransmissibility(elemCtx, scvfIdx, timeIdx);
             const Evaluation& inH = inLambda*alpha;
             const Evaluation& exH = exLambda*alpha;
             H = 1.0/(1.0/inH + 1.0/exH);
@@ -543,7 +544,7 @@ public:
         else
             H = 0.0;
 
-        energyFlux_ = deltaT * (-H);
+        energyFlux_ = deltaT * (-H/faceArea);
     }
 
     template <class Context, class BoundaryFluidState>

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -29,6 +29,7 @@
 #define EWOMS_BLACK_OIL_ENERGY_MODULE_HH
 
 #include "blackoilproperties.hh"
+#include <ewoms/io/vtkblackoilenergymodule.hh>
 #include <ewoms/models/common/quantitycallbacks.hh>
 
 #include <opm/material/common/Tabulated1DFunction.hpp>
@@ -79,6 +80,8 @@ public:
         if (!enableEnergy)
             // energys have been disabled at compile time
             return;
+
+        Ewoms::VtkBlackOilEnergyModule<TypeTag>::registerParameters();
     }
 
     /*!
@@ -90,6 +93,8 @@ public:
         if (!enableEnergy)
             // energys have been disabled at compile time
             return;
+
+        model.addOutputModule(new Ewoms::VtkBlackOilEnergyModule<TypeTag>(simulator));
     }
 
     static bool primaryVarApplies(unsigned pvIdx)

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -1,0 +1,573 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Contains the classes required to extend the black-oil model by energy.
+ */
+#ifndef EWOMS_BLACK_OIL_ENERGY_MODULE_HH
+#define EWOMS_BLACK_OIL_ENERGY_MODULE_HH
+
+#include "blackoilproperties.hh"
+#include <ewoms/models/common/quantitycallbacks.hh>
+
+#include <opm/material/common/Tabulated1DFunction.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+
+#include <dune/common/fvector.hh>
+
+#include <string>
+
+namespace Ewoms {
+/*!
+ * \ingroup BlackOil
+ * \brief Contains the high level supplements required to extend the black oil
+ *        model by energy.
+ */
+template <class TypeTag, bool enableEnergyV = GET_PROP_VALUE(TypeTag, EnableEnergy)>
+class BlackOilEnergyModule
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, EqVector) EqVector;
+    typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+
+    static constexpr unsigned temperatureIdx = Indices::temperatureIdx;
+    static constexpr unsigned contiEnergyEqIdx = Indices::contiEnergyEqIdx;
+
+    static constexpr unsigned enableEnergy = enableEnergyV;
+    static constexpr unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    static constexpr unsigned numPhases = FluidSystem::numPhases;
+
+public:
+    /*!
+     * \brief Register all run-time parameters for the black-oil energy module.
+     */
+    static void registerParameters()
+    {
+        if (!enableEnergy)
+            // energys have been disabled at compile time
+            return;
+    }
+
+    /*!
+     * \brief Register all energy specific VTK and ECL output modules.
+     */
+    static void registerOutputModules(Model& model,
+                                      Simulator& simulator)
+    {
+        if (!enableEnergy)
+            // energys have been disabled at compile time
+            return;
+    }
+
+    static bool primaryVarApplies(unsigned pvIdx)
+    {
+        if (!enableEnergy)
+            // energys have been disabled at compile time
+            return false;
+
+        return pvIdx == temperatureIdx;
+    }
+
+    static std::string primaryVarName(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+        assert(primaryVarApplies(pvIdx));
+
+        return "temperature";
+    }
+
+    static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+        assert(primaryVarApplies(pvIdx));
+
+        // TODO: it may be beneficial to chose this differently.
+        return static_cast<Scalar>(1.0);
+    }
+
+    static bool eqApplies(unsigned eqIdx)
+    {
+        if (!enableEnergy)
+            return false;
+
+        return eqIdx == contiEnergyEqIdx;
+    }
+
+    static std::string eqName(unsigned eqIdx OPM_OPTIM_UNUSED)
+    {
+        assert(eqApplies(eqIdx));
+
+        return "conti^energy";
+    }
+
+    static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
+    {
+        assert(eqApplies(eqIdx));
+
+        // Inverse of the energy required to heat up one kg of water by 30 Kelvin. If we
+        // conserve surface volumes, this must be divided by the weight of one cubic
+        // meter of water.
+        static const Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        static const Scalar beta = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume) ? 1000.0 : 1.0;
+        return static_cast<Scalar>(1.0/(30*4184.0*alpha*beta));
+    }
+
+    // must be called after water storage is computed
+    template <class LhsEval>
+    static void addStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                           const IntensiveQuantities& intQuants)
+    {
+        if (!enableEnergy)
+            return;
+
+        const auto& poro = Opm::decay<LhsEval>(intQuants.porosity());
+
+        // accumulate the internal energy of the fluids
+        const auto& fs = intQuants.fluidState();
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            if (!FluidSystem::phaseIsActive(phaseIdx))
+                continue;
+
+            const auto& u = Opm::decay<LhsEval>(fs.internalEnergy(phaseIdx));
+            const auto& S = Opm::decay<LhsEval>(fs.saturation(phaseIdx));
+            const auto& rho = Opm::decay<LhsEval>(fs.density(phaseIdx));
+
+            storage[contiEnergyEqIdx] += poro*S*u*rho;
+        }
+
+        // add the internal energy of the rock
+        const auto& uRock = Opm::decay<LhsEval>(intQuants.rockInternalEnergy());
+        storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
+
+        storage[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+    }
+
+    static void computeFlux(RateVector& flux,
+                            const ElementContext& elemCtx,
+                            unsigned scvfIdx,
+                            unsigned timeIdx)
+    {
+        if (!enableEnergy)
+            return;
+
+        flux[contiEnergyEqIdx] = 0.0;
+
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        unsigned focusIdx = elemCtx.focusDofIndex();
+        for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+            if (!FluidSystem::phaseIsActive(phaseIdx))
+                continue;
+
+            unsigned upIdx = extQuants.upstreamIndex(phaseIdx);
+            if (upIdx == focusIdx)
+                addPhaseEnthalpyFlux_<Evaluation>(flux, phaseIdx, elemCtx, scvfIdx, timeIdx);
+            else
+                addPhaseEnthalpyFlux_<Scalar>(flux, phaseIdx, elemCtx, scvfIdx, timeIdx);
+        }
+
+        // diffusive energy flux
+        flux[contiEnergyEqIdx] += extQuants.energyFlux();
+
+        flux[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+    }
+
+    template <class UpstreamEval>
+    static void addPhaseEnthalpyFlux_(RateVector& flux,
+                                      unsigned phaseIdx,
+                                      const ElementContext& elemCtx,
+                                      unsigned scvfIdx,
+                                      unsigned timeIdx)
+    {
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+        unsigned upIdx = extQuants.upstreamIndex(phaseIdx);
+        const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+        const auto& fs = up.fluidState();
+
+        const auto& volFlux = extQuants.volumeFlux(phaseIdx);
+        flux[contiEnergyEqIdx] +=
+            Opm::decay<UpstreamEval>(fs.enthalpy(phaseIdx))
+            * Opm::decay<UpstreamEval>(fs.density(phaseIdx))
+            * volFlux;
+    }
+
+    static void addToEnthalpyRate(RateVector& flux,
+                                  const Evaluation& hRate)
+    {
+        if (!enableEnergy)
+            return;
+
+        flux[contiEnergyEqIdx] += hRate;
+    }
+
+    /*!
+     * \brief Assign the energy specific primary variables to a PrimaryVariables object
+     */
+    static void assignPrimaryVars(PrimaryVariables& priVars,
+                                  Scalar temperature)
+    {
+        if (!enableEnergy)
+            return;
+
+        priVars[temperatureIdx] = temperatureIdx;
+    }
+
+    /*!
+     * \brief Assign the energy specific primary variables to a PrimaryVariables object
+     */
+    template <class FluidState>
+    static void assignPrimaryVars(PrimaryVariables& priVars,
+                                  const FluidState& fluidState)
+    {
+        if (!enableEnergy)
+            return;
+
+        priVars[temperatureIdx] = fluidState.temperature(/*phaseIdx=*/0);
+    }
+
+    /*!
+     * \brief Do a Newton-Raphson update the primary variables of the energys.
+     */
+    static void updatePrimaryVars(PrimaryVariables& newPv,
+                                  const PrimaryVariables& oldPv,
+                                  const EqVector& delta)
+    {
+        if (!enableEnergy)
+            return;
+
+        // do a plain unchopped Newton update
+        newPv[temperatureIdx] = oldPv[temperatureIdx] - delta[temperatureIdx];
+    }
+
+    /*!
+     * \brief Return how much a Newton-Raphson update is considered an error
+     */
+    static Scalar computeUpdateError(const PrimaryVariables& oldPv OPM_UNUSED,
+                                     const EqVector& delta OPM_UNUSED)
+    {
+        // do not consider consider the cange of energy primary variables for
+        // convergence
+        // TODO: maybe this should be changed
+        return static_cast<Scalar>(0.0);
+    }
+
+    /*!
+     * \brief Return how much a residual is considered an error
+     */
+    static Scalar computeResidualError(const EqVector& resid)
+    {
+        // do not weight the residual of energy when it comes to convergence
+        return std::abs(Opm::scalarValue(resid[contiEnergyEqIdx]));
+    }
+
+    template <class DofEntity>
+    static void serializeEntity(const Model& model, std::ostream& outstream, const DofEntity& dof)
+    {
+        if (!enableEnergy)
+            return;
+
+        unsigned dofIdx = model.dofMapper().index(dof);
+        const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
+        outstream << priVars[temperatureIdx];
+    }
+
+    template <class DofEntity>
+    static void deserializeEntity(Model& model, std::istream& instream, const DofEntity& dof)
+    {
+        if (!enableEnergy)
+            return;
+
+        unsigned dofIdx = model.dofMapper().index(dof);
+        PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
+        PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
+
+        instream >> priVars0[temperatureIdx];
+
+        // set the primary variables for the beginning of the current time step.
+        priVars1 = priVars0[temperatureIdx];
+    }
+};
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilEnergyIntensiveQuantities
+ *
+ * \brief Provides the volumetric quantities required for the equations needed by the
+ *        energys extension of the black-oil model.
+ */
+template <class TypeTag, bool enableEnergyV = GET_PROP_VALUE(TypeTag, EnableEnergy)>
+class BlackOilEnergyIntensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, SolidEnergyLaw) SolidEnergyLaw;
+    typedef typename GET_PROP_TYPE(TypeTag, ThermalConductionLaw) ThermalConductionLaw;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    typedef BlackOilEnergyModule<TypeTag> EnergyModule;
+
+    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+    static constexpr int temperatureIdx = Indices::temperatureIdx;
+    static constexpr int waterPhaseIdx = FluidSystem::waterPhaseIdx;
+
+
+public:
+    /*!
+     * \brief Update the temperature of the intensive quantity's fluid state
+     *
+     */
+    void updateTemperature_(const ElementContext& elemCtx,
+                            unsigned dofIdx,
+                            unsigned timeIdx)
+    {
+        auto& fs = asImp_().fluidState_;
+        const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+
+        // set temperature
+        fs.setTemperature(priVars.makeEvaluation(temperatureIdx, timeIdx));
+    }
+
+    /*!
+     * \brief Compute the intensive quantities needed to handle energy conservation
+     *
+     */
+    void updateEnergyQuantities_(const ElementContext& elemCtx,
+                                 unsigned dofIdx,
+                                 unsigned timeIdx,
+                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache)
+    {
+        auto& fs = asImp_().fluidState_;
+
+        // compute the specific enthalpy of the fluids, the specific enthalpy of the rock
+        // and the thermal condictivity coefficients
+        for (int phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
+            if (!FluidSystem::phaseIsActive(phaseIdx)) {
+                fs.setEnthalpy(phaseIdx, 0.0);
+                continue;
+            }
+
+            const auto& h = FluidSystem::enthalpy(fs, paramCache, phaseIdx);
+            fs.setEnthalpy(phaseIdx, h);
+        }
+
+        const auto& solidEnergyLawParams = elemCtx.problem().solidEnergyLawParams(elemCtx, dofIdx, timeIdx);
+        rockInternalEnergy_ = SolidEnergyLaw::solidInternalEnergy(solidEnergyLawParams, fs);
+
+        const auto& thermalConductionLawParams = elemCtx.problem().thermalConductionLawParams(elemCtx, dofIdx, timeIdx);
+        totalThermalConductivity_ = ThermalConductionLaw::thermalConductivity(thermalConductionLawParams, fs);
+    }
+
+    const Evaluation& rockInternalEnergy() const
+    { return rockInternalEnergy_; }
+
+    const Evaluation& totalThermalConductivity() const
+    { return totalThermalConductivity_; }
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation rockInternalEnergy_;
+    Evaluation totalThermalConductivity_;
+};
+
+template <class TypeTag>
+class BlackOilEnergyIntensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+
+    static constexpr bool enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature);
+
+public:
+    void updateTemperature_(const ElementContext& elemCtx,
+                            unsigned dofIdx,
+                            unsigned timeIdx)
+    {
+        if (enableTemperature) {
+            // even if energy is conserved, the temperature can vary over the spatial
+            // domain if the EnableTemperature property is set to true
+            auto& fs = asImp_().fluidState_;
+            Scalar T = elemCtx.problem().temperature(elemCtx, dofIdx, timeIdx);
+            fs.setTemperature(T);
+        }
+    }
+
+    void updateEnergyQuantities_(const ElementContext& elemCtx,
+                                 unsigned dofIdx,
+                                 unsigned timeIdx,
+                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache)
+    { }
+
+    const Evaluation& rockInternalEnergy() const
+    { throw std::logic_error("Requested the rock internal energy, which is "
+                             "unavailable because energy is not conserved"); }
+
+    const Evaluation& totalThermalConductivity() const
+    { throw std::logic_error("Requested the total thermal conductivity, which is "
+                             "unavailable because energy is not conserved"); }
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+};
+
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilEnergyExtensiveQuantities
+ *
+ * \brief Provides the energy specific extensive quantities to the generic black-oil
+ *        module's extensive quantities.
+ */
+template <class TypeTag, bool enableEnergyV = GET_PROP_VALUE(TypeTag, EnableEnergy)>
+class BlackOilEnergyExtensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+
+    typedef Opm::MathToolbox<Evaluation> Toolbox;
+
+    typedef BlackOilEnergyModule<TypeTag> EnergyModule;
+
+    static const int dimWorld = GridView::dimensionworld;
+    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
+    typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
+
+public:
+    void updateEnergy(const ElementContext& elemCtx,
+                      unsigned scvfIdx,
+                      unsigned timeIdx)
+    {
+        const auto& stencil = elemCtx.stencil(timeIdx);
+        const auto& scvf = stencil.interiorFace(scvfIdx);
+
+        unsigned inIdx = scvf.interiorIndex();
+        unsigned exIdx = scvf.exteriorIndex();
+        const auto& inIq = elemCtx.intensiveQuantities(inIdx, timeIdx);
+        const auto& exIq = elemCtx.intensiveQuantities(exIdx, timeIdx);
+        const auto& inFs = inIq.fluidState();
+        const auto& exFs = exIq.fluidState();
+
+        Evaluation deltaT;
+        if (elemCtx.focusDofIndex() == inIdx)
+            deltaT =
+                Opm::decay<Scalar>(exFs.temperature(/*phaseIdx=*/0))
+                - inFs.temperature(/*phaseIdx=*/0);
+        else if (elemCtx.focusDofIndex() == exIdx)
+            deltaT =
+                exFs.temperature(/*phaseIdx=*/0)
+                - Opm::decay<Scalar>(inFs.temperature(/*phaseIdx=*/0));
+        else
+            deltaT =
+                Opm::decay<Scalar>(exFs.temperature(/*phaseIdx=*/0))
+                - Opm::decay<Scalar>(inFs.temperature(/*phaseIdx=*/0));
+
+        Evaluation inLambda;
+        if (elemCtx.focusDofIndex() == inIdx)
+            inLambda = inIq.totalThermalConductivity();
+        else
+            inLambda = Opm::decay<Scalar>(inIq.totalThermalConductivity());
+
+        Evaluation exLambda;
+        if (elemCtx.focusDofIndex() == exIdx)
+            exLambda = exIq.totalThermalConductivity();
+        else
+            exLambda = Opm::decay<Scalar>(exIq.totalThermalConductivity());
+
+        auto distVec = elemCtx.pos(exIdx, timeIdx);
+        distVec -= elemCtx.pos(inIdx, timeIdx);
+
+        Evaluation H;
+        if (inLambda > 0.0 && exLambda > 0.0) {
+            // compute the "thermal transmissibility". In contrast to the normal
+            // transmissibility this cannot be done as a preprocessing step because the
+            // average thermal thermal conductivity is analogous to the permeability but depends
+            // on the solution.
+            Scalar alpha = elemCtx.problem().thermalHalfTransmissibility(elemCtx, inIdx, exIdx);
+            const Evaluation& inH = inLambda*alpha;
+            const Evaluation& exH = exLambda*alpha;
+            H = 1.0/(1.0/inH + 1.0/exH);
+        }
+        else
+            H = 0.0;
+
+        energyFlux_ = deltaT * (-H);
+    }
+
+    const Evaluation& energyFlux()  const
+    { return energyFlux_; }
+
+private:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation energyFlux_;
+};
+
+template <class TypeTag>
+class BlackOilEnergyExtensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+
+public:
+    void updateEnergy(const ElementContext& elemCtx OPM_UNUSED,
+                      unsigned scvfIdx OPM_UNUSED,
+                      unsigned timeIdx OPM_UNUSED)
+    {}
+
+    const Evaluation& energyFlux()  const
+    { throw std::logic_error("Requested the energy flux, but energy is not conserved"); }
+};
+
+
+} // namespace Ewoms
+
+#endif

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -140,12 +140,7 @@ public:
     {
         assert(eqApplies(eqIdx));
 
-        // Inverse of the energy required to heat up one kg of water by 30 Kelvin. If we
-        // conserve surface volumes, this must be divided by the weight of one cubic
-        // meter of water.
-        static const Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
-        static const Scalar beta = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume) ? 1000.0 : 1.0;
-        return static_cast<Scalar>(1.0/(30*4184.0*alpha*beta));
+        return 1.0;
     }
 
     // must be called after water storage is computed
@@ -175,7 +170,8 @@ public:
         const auto& uRock = Opm::decay<LhsEval>(intQuants.rockInternalEnergy());
         storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
 
-        storage[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        storage[contiEnergyEqIdx] *= alpha;
     }
 
     static void computeFlux(RateVector& flux,
@@ -204,7 +200,8 @@ public:
         // diffusive energy flux
         flux[contiEnergyEqIdx] += extQuants.energyFlux();
 
-        flux[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        flux[contiEnergyEqIdx] *= alpha;
     }
 
     template <class UpstreamEval>

--- a/ewoms/models/blackoil/blackoilextensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilextensivequantities.hh
@@ -79,6 +79,17 @@ public:
         asImp_().updateEnergy(elemCtx, scvfIdx, timeIdx);
     }
 
+    template <class Context, class FluidState>
+    void updateBoundary(const Context& ctx,
+                        unsigned bfIdx,
+                        unsigned timeIdx,
+                        const FluidState& fluidState)
+    {
+        MultiPhaseParent::updateBoundary(ctx, bfIdx, timeIdx, fluidState);
+
+        asImp_().updateEnergyBoundary(ctx, bfIdx, timeIdx, fluidState);
+    }
+
 protected:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }

--- a/ewoms/models/blackoil/blackoilextensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilextensivequantities.hh
@@ -31,7 +31,7 @@
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
-
+#include "blackoilenergymodules.hh"
 
 #include <ewoms/models/common/multiphasebaseextensivequantities.hh>
 
@@ -53,14 +53,13 @@ class BlackOilExtensiveQuantities
     : public MultiPhaseBaseExtensiveQuantities<TypeTag>
     , public BlackOilSolventExtensiveQuantities<TypeTag>
     , public BlackOilPolymerExtensiveQuantities<TypeTag>
+    , public BlackOilEnergyExtensiveQuantities<TypeTag>
 {
     typedef MultiPhaseBaseExtensiveQuantities<TypeTag> MultiPhaseParent;
-    typedef BlackOilSolventExtensiveQuantities<TypeTag> SolventParent;
-    typedef BlackOilPolymerExtensiveQuantities<TypeTag> PolymerParent;
-
 
     typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
 
 public:
     /*!
@@ -77,6 +76,7 @@ public:
 
         asImp_().updateSolvent(elemCtx, scvfIdx, timeIdx);
         asImp_().updatePolymer(elemCtx, scvfIdx, timeIdx);
+        asImp_().updateEnergy(elemCtx, scvfIdx, timeIdx);
     }
 
 protected:

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -35,7 +35,7 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset>
+template <bool enableSolventV, bool enablePolymerV, bool enableEnergyV, unsigned PVOffset>
 struct BlackOilIndices
 {
     //! Number of phases active at all times
@@ -46,14 +46,28 @@ struct BlackOilIndices
     static const bool waterEnabled = true;
     static const bool gasEnabled = true;
 
-    //! Number of solvent components considered
-    static const int numSolvents = numSolventsV;
+    //! Are solvents involved?
+    static const bool enableSolvent = enableSolventV;
 
-    //! Number of polymer components considered
-    static const int numPolymers = numPolymersV;
+    //! Are polymers involved?
+    static const bool enablePolymer = enablePolymerV;
 
+    //! Shall energy be conserved?
+    static const bool enableEnergy = enableEnergyV;
+
+private:
+    //! Number of solvent components to be considered
+    static const int numSolvents_ = enableSolvent ? 1 : 0;
+
+    //! Number of polymer components to be considered
+    static const int numPolymers_ = enablePolymer ? 1 : 0;
+
+    //! Number of energy equations to be considered
+    static const int numEnergy_ = enableEnergy ? 1 : 0;
+
+public:
     //! The number of equations
-    static const int numEq = numPhases + numSolvents + numPolymers;
+    static const int numEq = numPhases + numSolvents_ + numPolymers_ + numEnergy_;
 
     //! \brief returns the index of "active" component
     static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
@@ -67,10 +81,10 @@ struct BlackOilIndices
     ////////
 
     //! The index of the water saturation
-    static const int waterSaturationIdx  = PVOffset + 0;
+    static const int waterSaturationIdx = PVOffset + 0;
 
     //! Index of the oil pressure in a vector of primary variables
-    static const int pressureSwitchIdx  = PVOffset + 1;
+    static const int pressureSwitchIdx = PVOffset + 1;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the
@@ -83,12 +97,16 @@ struct BlackOilIndices
     static const int compositionSwitchIdx = PVOffset + 2;
 
     //! Index of the primary variable for the first solvent
-    static const int solventSaturationIdx  = compositionSwitchIdx + numSolvents;
+    static const int solventSaturationIdx =
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
 
     //! Index of the primary variable for the first polymer
-    static const int polymerConcentrationIdx  = solventSaturationIdx + numPolymers;
+    static const int polymerConcentrationIdx =
+        enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
 
-    // numSolvents-1 primary variables follow
+    //! Index of the primary variable for temperature
+    static const int temperatureIdx  =
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
 
     ////////
     // Equation indices
@@ -99,11 +117,16 @@ struct BlackOilIndices
     // two continuity equations follow
 
     //! Index of the continuity equation for the first solvent component
-    static const int contiSolventEqIdx = PVOffset + numPhases - 1 + numSolvents;
+    static const int contiSolventEqIdx =
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
 
     //! Index of the continuity equation for the first polymer component
-    static const int contiPolymerEqIdx = contiSolventEqIdx + numPolymers;
-    // numSolvents-1 continuity equations follow
+    static const int contiPolymerEqIdx =
+        enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+
+    //! Index of the continuity equation for energy
+    static const int contiEnergyEqIdx =
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : -1000;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -71,6 +71,8 @@ class BlackOilIntensiveQuantities
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+    enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
+    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
@@ -89,7 +91,7 @@ class BlackOilIntensiveQuantities
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
     typedef typename FluxModule::FluxIntensiveQuantities FluxIntensiveQuantities;
-    typedef Opm::BlackOilFluidState<Evaluation, FluidSystem> FluidState;
+    typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy> FluidState;
 
 public:
     BlackOilIntensiveQuantities()

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -88,7 +88,6 @@ class BlackOilIntensiveQuantities
     static const bool compositionSwitchEnabled = Indices::gasEnabled;
     static const bool waterEnabled = Indices::waterEnabled;
 
-
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
     typedef typename FluxModule::FluxIntensiveQuantities FluxIntensiveQuantities;

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -31,7 +31,7 @@
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
-
+#include "blackoilenergymodules.hh"
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
@@ -54,6 +54,7 @@ class BlackOilIntensiveQuantities
     , public GET_PROP_TYPE(TypeTag, FluxModule)::FluxIntensiveQuantities
     , public BlackOilSolventIntensiveQuantities<TypeTag>
     , public BlackOilPolymerIntensiveQuantities<TypeTag>
+    , public BlackOilEnergyIntensiveQuantities<TypeTag>
 {
     typedef typename GET_PROP_TYPE(TypeTag, DiscIntensiveQuantities) ParentType;
     typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) Implementation;
@@ -111,10 +112,10 @@ public:
     {
         ParentType::update(elemCtx, dofIdx, timeIdx);
 
-        //fluidState_.setTemperature(elemCtx.problem().temperature(elemCtx, dofIdx, timeIdx));
-
         const auto& problem = elemCtx.problem();
         const auto& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+
+        asImp_().updateTemperature_(elemCtx, dofIdx, timeIdx);
 
         unsigned globalSpaceIdx = elemCtx.globalSpaceIndex(dofIdx, timeIdx);
         unsigned pvtRegionIdx = priVars.pvtRegionIndex();
@@ -329,7 +330,7 @@ public:
 
         asImp_().solventPvtUpdate_(elemCtx, dofIdx, timeIdx);
         asImp_().polymerPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
-
+        asImp_().updateEnergyQuantities_(elemCtx, dofIdx, timeIdx, paramCache);
 
         // update the quantities which are required by the chosen
         // velocity model
@@ -399,7 +400,7 @@ public:
 private:
     friend BlackOilSolventIntensiveQuantities<TypeTag>;
     friend BlackOilPolymerIntensiveQuantities<TypeTag>;
-
+    friend BlackOilEnergyIntensiveQuantities<TypeTag>;
 
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -68,8 +68,10 @@ class BlackOilLocalResidual : public GET_PROP_TYPE(TypeTag, DiscLocalResidual)
     enum { waterCompIdx = FluidSystem::waterCompIdx };
     enum { compositionSwitchIdx = Indices::compositionSwitchIdx };
 
-    static const bool compositionSwitchEnabled = Indices::gasEnabled;
     static const bool waterEnabled = Indices::waterEnabled;
+    static const bool gasEnabled = Indices::gasEnabled;
+    static const bool oilEnabled = Indices::oilEnabled;
+    static const bool compositionSwitchEnabled = (compositionSwitchIdx >= 0);
 
     static constexpr bool blackoilConserveSurfaceVolume = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume);
     static constexpr bool enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy);
@@ -124,23 +126,7 @@ public:
             }
         }
 
-        // convert surface volumes to component masses
-        if (!blackoilConserveSurfaceVolume) {
-            unsigned pvtRegionIdx = intQuants.pvtRegionIndex();
-            if (waterEnabled) {
-                unsigned activeWaterCompIdx = Indices::canonicalToActiveComponentIndex(waterCompIdx);
-                storage[conti0EqIdx +  activeWaterCompIdx] *=
-                        FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
-            }
-            if (compositionSwitchEnabled) {
-                unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(gasCompIdx);
-                storage[conti0EqIdx + activeGasCompIdx] *=
-                        FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
-            }
-            unsigned activeOilCompIdx = Indices::canonicalToActiveComponentIndex(oilCompIdx);
-            storage[conti0EqIdx + activeOilCompIdx] *=
-                    FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
-        }
+        adaptMassConservationQuantities_(storage, intQuants.pvtRegionIndex());
 
         // deal with solvents (if present)
         SolventModule::addStorage(storage, intQuants);
@@ -172,21 +158,11 @@ public:
 
             unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
             const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+            unsigned pvtRegionIdx = up.pvtRegionIndex();
             if (upIdx == focusDofIdx)
-                evalPhaseFluxes_<Evaluation>(flux, phaseIdx, extQuants, up);
+                evalPhaseFluxes_<Evaluation>(flux, phaseIdx, pvtRegionIdx, extQuants, up.fluidState());
             else
-                evalPhaseFluxes_<Scalar>(flux, phaseIdx, extQuants, up);
-        }
-
-        if (!blackoilConserveSurfaceVolume) {
-           for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++ phaseIdx) {
-               unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
-               unsigned upIdx = static_cast<unsigned>(extQuants.upstreamIndex(phaseIdx));
-               const IntensiveQuantities& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
-               unsigned pvtRegionIdx = up.pvtRegionIndex();
-               Scalar refDensity = FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
-               flux[conti0EqIdx + activeCompIdx] *= refDensity;
-           }
+                evalPhaseFluxes_<Scalar>(flux, phaseIdx, pvtRegionIdx, extQuants, up.fluidState());
         }
 
         // deal with solvents (if present)
@@ -217,40 +193,91 @@ public:
         }
     }
 
-protected:
-    template <class UpEval>
-    void evalPhaseFluxes_(RateVector& flux,
-                          unsigned phaseIdx,
-                          const ExtensiveQuantities& extQuants,
-                          const IntensiveQuantities& up) const
+    /*!
+     * \brief Helper function to calculate the flux of mass in terms of conservation
+     *        quantities via specific fluid phase over a face.
+     */
+    template <class UpEval, class FluidState>
+    static void evalPhaseFluxes_(RateVector& flux,
+                                 unsigned phaseIdx,
+                                 unsigned pvtRegionIdx,
+                                 const ExtensiveQuantities& extQuants,
+                                 const FluidState& upFs)
     {
-        unsigned compIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
-        const auto& fs = up.fluidState();
+        const auto& invB = Opm::getInvB_<FluidSystem, FluidState, UpEval>(upFs, phaseIdx, pvtRegionIdx);
+        const auto& surfaceVolumeFlux = invB*extQuants.volumeFlux(phaseIdx);
+        unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
 
-        Evaluation surfaceVolumeFlux =
-                Toolbox::template decay<UpEval>(fs.invB(phaseIdx))
-                * extQuants.volumeFlux(phaseIdx);
+        if (blackoilConserveSurfaceVolume)
+            flux[conti0EqIdx + activeCompIdx] += surfaceVolumeFlux;
+        else
+            flux[conti0EqIdx + activeCompIdx] += surfaceVolumeFlux*FluidSystem::referenceDensity(phaseIdx, pvtRegionIdx);
 
-        flux[conti0EqIdx + compIdx] +=
-                surfaceVolumeFlux;
+        if (phaseIdx == oilPhaseIdx) {
+            // dissolved gas (in the oil phase).
+            if (FluidSystem::enableDissolvedGas()) {
+                const auto& Rs = Opm::BlackOil::getRs_<FluidSystem, FluidState, UpEval>(upFs, pvtRegionIdx);
 
-        // dissolved gas (in the oil phase).
-        if (phaseIdx == oilPhaseIdx && FluidSystem::enableDissolvedGas()) {
-            flux[conti0EqIdx + Indices::canonicalToActiveComponentIndex(gasCompIdx)] +=
-                    Toolbox::template decay<UpEval>(fs.Rs())
-                    * surfaceVolumeFlux;
-
+                unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(gasCompIdx);
+                if (blackoilConserveSurfaceVolume)
+                    flux[conti0EqIdx + activeGasCompIdx] += Rs*surfaceVolumeFlux;
+                else
+                    flux[conti0EqIdx + activeGasCompIdx] += Rs*surfaceVolumeFlux*FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+            }
         }
+        else if (phaseIdx == gasPhaseIdx) {
+            // vaporized oil (in the gas phase).
+            if (FluidSystem::enableVaporizedOil()) {
+                const auto& Rv = Opm::BlackOil::getRv_<FluidSystem, FluidState, UpEval>(upFs, pvtRegionIdx);
 
-        // vaporized oil (in the gas phase).
-        if (phaseIdx == gasPhaseIdx && FluidSystem::enableVaporizedOil()) {
-            flux[conti0EqIdx + Indices::canonicalToActiveComponentIndex(oilCompIdx)] +=
-                    Toolbox::template decay<UpEval>(fs.Rv())
-                    * surfaceVolumeFlux;
-
+                unsigned activeOilCompIdx = Indices::canonicalToActiveComponentIndex(oilCompIdx);
+                if (blackoilConserveSurfaceVolume)
+                    flux[conti0EqIdx + activeOilCompIdx] += Rv*surfaceVolumeFlux;
+                else
+                    flux[conti0EqIdx + activeOilCompIdx] += Rv*surfaceVolumeFlux*FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+            }
         }
     }
 
+    /*!
+     * \brief Helper function to convert the mass-related parts of a Dune::FieldVector
+     *        that stores conservation quantities in terms of "surface-volume" to the
+     *        conservation quantities used by the model.
+     *
+     * Depending on the value of the BlackoilConserveSurfaceVolume property, the model
+     * either conserves mass by means of "surface volume" of the components or mass
+     * directly. In the former case, this method is a no-op; in the latter, the values
+     * passed are multiplied by their respective pure component's density at surface
+     * conditions.
+     */
+    template <class Scalar>
+    static void adaptMassConservationQuantities_(Dune::FieldVector<Scalar, numEq>& container, unsigned pvtRegionIdx)
+    {
+        if (blackoilConserveSurfaceVolume)
+            return;
+
+        // convert "surface volume" to mass. this is complicated a bit by the fact that
+        // not all phases are necessarily enabled. (we here assume that if a fluid phase
+        // is disabled, its respective "main" component is not considered as well.)
+
+        if (waterEnabled) {
+            unsigned activeWaterCompIdx = Indices::canonicalToActiveComponentIndex(waterCompIdx);
+            container[conti0EqIdx + activeWaterCompIdx] *=
+                FluidSystem::referenceDensity(waterPhaseIdx, pvtRegionIdx);
+        }
+
+        if (gasEnabled) {
+            unsigned activeGasCompIdx = Indices::canonicalToActiveComponentIndex(gasCompIdx);
+            container[conti0EqIdx + activeGasCompIdx] *=
+                FluidSystem::referenceDensity(gasPhaseIdx, pvtRegionIdx);
+        }
+
+        if (oilEnabled) {
+            unsigned activeOilCompIdx = Indices::canonicalToActiveComponentIndex(oilCompIdx);
+            container[conti0EqIdx + activeOilCompIdx] *=
+                FluidSystem::referenceDensity(oilPhaseIdx, pvtRegionIdx);
+        }
+    }
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -188,7 +188,7 @@ public:
 
         // scale the source term of the energy equation
         if (enableEnergy) {
-            static const Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+            static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
             source[Indices::contiEnergyEqIdx] *= alpha;
         }
     }

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -132,9 +132,21 @@ SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
 SET_BOOL_PROP(BlackOilModel, EnableTemperature, false);
 SET_BOOL_PROP(BlackOilModel, EnableEnergy, false);
 
+//! by default, scale the energy equation by the inverse of the energy required to heat
+//! up one kg of water by 30 Kelvin. If we conserve surface volumes, this must be divided
+//! by the weight of one cubic meter of water. This is required to make the "dumb" linear
+//! solvers that do not weight the components of the solutions do the right thing.
 //! by default, don't scale the energy equation, i.e. assume that a reasonable linear
 //! solver is used. (Not scaling it makes debugging quite a bit easier.)
-SET_SCALAR_PROP(BlackOilModel, BlackOilEnergyScalingFactor, 1.0);
+SET_PROP(BlackOilModel, BlackOilEnergyScalingFactor)
+{
+private:
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume) ? 1000.0 : 1.0;
+
+public:
+    static constexpr Scalar value = 1.0/(30*4184.0*alpha);
+};
 
 // by default, ebos formulates the conservation equations in terms of mass not surface
 // volumes

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -71,6 +71,7 @@ NEW_TYPE_TAG(BlackOilModel, INHERITS_FROM(MultiPhaseBaseModel,
                                           VtkBlackOil,
                                           VtkBlackOilSolvent,
                                           VtkBlackOilPolymer,
+                                          VtkBlackOilEnergy,
                                           VtkComposition));
 
 //! Set the local residual function

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -120,10 +120,16 @@ public:
     typedef Opm::FluidSystems::BlackOil<Scalar> type;
 };
 
-// by default, the ECL solvent module is disabled
+// by default, all ECL extension modules are disabled
 SET_BOOL_PROP(BlackOilModel, EnableSolvent, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
-// by default, ebos formulates the conservation equations in terms of mass not surface volumes
+
+//! By default, the blackoil model is isothermal and does not conserve energy
+SET_BOOL_PROP(BlackOilModel, EnableTemperature, false);
+SET_BOOL_PROP(BlackOilModel, EnableEnergy, false);
+
+// by default, ebos formulates the conservation equations in terms of mass not surface
+// volumes
 SET_BOOL_PROP(BlackOilModel, BlackoilConserveSurfaceVolume, false);
 } // namespace Properties
 

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -107,7 +107,10 @@ SET_TYPE_PROP(BlackOilModel, FluxModule, Ewoms::BlackOilDarcyFluxModule<TypeTag>
 
 //! The indices required by the model
 SET_TYPE_PROP(BlackOilModel, Indices,
-              Ewoms::BlackOilIndices<GET_PROP_VALUE(TypeTag, EnableSolvent)?1:0, GET_PROP_VALUE(TypeTag, EnablePolymer)?1:0, /*PVOffset=*/0>);
+              Ewoms::BlackOilIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
+                                     GET_PROP_VALUE(TypeTag, EnablePolymer),
+                                     GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                     /*PVOffset=*/0>);
 
 //! Set the fluid system to the black-oil fluid system by default
 SET_PROP(BlackOilModel, FluidSystem)

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -147,8 +147,12 @@ protected:
                                  PrimaryVariables& nextValue,
                                  const PrimaryVariables& currentValue,
                                  const EqVector& update,
-                                 const EqVector& currentResidual OPM_UNUSED)
+                                 const EqVector& currentResidual)
     {
+        currentValue.checkDefined();
+        Opm::Valgrind::CheckDefined(update);
+        Opm::Valgrind::CheckDefined(currentResidual);
+
         for (unsigned eqIdx = 0; eqIdx < numEq; ++eqIdx) {
             // calculate the update of the current primary variable. For the
             // black-oil model we limit the pressure and saturation updates, but do
@@ -181,6 +185,8 @@ protected:
         // switch the new primary variables to something which is physically meaningful
         if (nextValue.adaptPrimaryVariables(this->problem(), globalDofIdx))
             ++ numPriVarsSwitched_;
+
+        nextValue.checkDefined();
     }
 
 private:

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -369,9 +369,9 @@ public:
             if (compositionSwitchEnabled)
                 Sg = (*this)[Indices::compositionSwitchIdx];
 
-            Scalar So = 1.0 - Sw - Sg - solventSaturation();
+            Scalar So = 1.0 - Sw - Sg - solventSaturation_();
 
-            Scalar So2 = 1.0 - Sw - solventSaturation();
+            Scalar So2 = 1.0 - Sw - solventSaturation_();
             if (Sg < -eps && So2 > 0.0 && FluidSystem::enableDissolvedGas()) {
                 // the hydrocarbon gas phase disappeared and some oil phase is left,
                 // i.e., switch the primary variables to { Sw, po, Rs }.
@@ -397,7 +397,7 @@ public:
                 return true;
             }
 
-            Scalar Sg2 = 1.0 - Sw - solventSaturation();
+            Scalar Sg2 = 1.0 - Sw - solventSaturation_();
             if (So < -eps && Sg2 > 0.0 && FluidSystem::enableVaporizedOil()) {
                 // the oil phase disappeared and some hydrocarbon gas phase is still
                 // present, i.e., switch the primary variables to { Sw, pg, Rv }.
@@ -407,7 +407,7 @@ public:
                 // pressure, i.e. we must determine capillary pressure
                 Scalar pC[numPhases] = { 0.0 };
                 const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
-                computeCapillaryPressures_(pC, /*So=*/0.0, Sg2 + solventSaturation(), Sw, matParams);
+                computeCapillaryPressures_(pC, /*So=*/0.0, Sg2 + solventSaturation_(), Sw, matParams);
                 Scalar pg = po + (pC[gasPhaseIdx] - pC[oilPhaseIdx]);
 
                 // we start at the Rv value that corresponds to that of oil-saturated
@@ -452,7 +452,7 @@ public:
             // than what saturated oil can hold.
             Scalar T = asImp_().temperature_();
             Scalar po = (*this)[Indices::pressureSwitchIdx];
-            Scalar So = 1.0 - Sw - solventSaturation();
+            Scalar So = 1.0 - Sw - solventSaturation_();
             Scalar SoMax = std::max(So, problem.maxOilSaturation(globalDofIdx));
             Scalar RsMax = problem.maxGasDissolutionFactor(globalDofIdx);
             Scalar RsSat =
@@ -479,7 +479,7 @@ public:
             assert(compositionSwitchEnabled);
 
             Scalar pg = (*this)[Indices::pressureSwitchIdx];
-            Scalar Sg = 1.0 - Sw - solventSaturation();
+            Scalar Sg = 1.0 - Sw - solventSaturation_();
 
             // special case for cells with almost only water
             if (Sw >= thresholdWaterFilledCell) {
@@ -490,7 +490,7 @@ public:
                 const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
                 computeCapillaryPressures_(pC,
                                            /*So=*/0.0,
-                                           /*Sg=*/Sg + solventSaturation(),
+                                           /*Sg=*/Sg + solventSaturation_(),
                                            Sw,
                                            matParams);
                 Scalar po = pg + (pC[oilPhaseIdx] - pC[gasPhaseIdx]);
@@ -528,7 +528,7 @@ public:
                 const MaterialLawParams& matParams = problem.materialLawParams(globalDofIdx);
                 computeCapillaryPressures_(pC,
                                            /*So=*/0.0,
-                                           /*Sg=*/Sg + solventSaturation(),
+                                           /*Sg=*/Sg + solventSaturation_(),
                                            Sw,
                                            matParams);
                 Scalar po = pg + (pC[oilPhaseIdx] - pC[gasPhaseIdx]);
@@ -563,7 +563,7 @@ private:
     const Implementation& asImp_() const
     { return *static_cast<const Implementation*>(this); }
 
-    Scalar solventSaturation() const
+    Scalar solventSaturation_() const
     {
         if (!enableSolvent)
             return 0.0;
@@ -571,7 +571,7 @@ private:
         return (*this)[Indices::solventSaturationIdx];
     }
 
-    Scalar polymerConcentration() const
+    Scalar polymerConcentration_() const
     {
         if (!enablePolymer)
             return 0.0;

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -321,6 +321,8 @@ public:
             if( compositionSwitchEnabled )
                 (*this)[compositionSwitchIdx] = Rv;
         }
+
+        checkDefined();
     }
 
     /*!
@@ -554,6 +556,26 @@ public:
             (*this)[i] = value;
 
         return *this;
+    }
+
+    /*!
+     * \brief Instruct valgrind to check the definedness of all attributes of this class.
+     *
+     * We cannot simply check the definedness of the whole object because there might be
+     * "alignedness holes" in the memory layout which are caused by the pseudo primary
+     * variables.
+     */
+    void checkDefined() const
+    {
+#ifndef NDEBUG
+        // check the "real" primary variables
+        for (unsigned i = 0; i < this->size(); ++i)
+            Opm::Valgrind::CheckDefined((*this)[i]);
+
+        // check the "pseudo" primary variables
+        Opm::Valgrind::CheckDefined(primaryVarsMeaning_);
+        Opm::Valgrind::CheckDefined(pvtRegionIdx_);
+#endif // NDEBUG
     }
 
 private:

--- a/ewoms/models/blackoil/blackoilproblem.hh
+++ b/ewoms/models/blackoil/blackoilproblem.hh
@@ -140,6 +140,15 @@ public:
                                  unsigned timeIdx OPM_UNUSED) const
     { return 1e5; }
 
+    /*!
+     * \brief Returns the reference temperature
+     *
+     * This is only relevant for temperature dependent quantities, in particular those
+     * needed by the module for energy conservation.
+     */
+    Scalar referenceTemperature() const
+    { return 273.15 + 15.56; /* [K] */ }
+
 private:
     //! Returns the implementation of the problem (i.e. static polymorphism)
     Implementation& asImp_()

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -50,6 +50,16 @@ NEW_PROP_TAG(EnableSolvent);
 NEW_PROP_TAG(EnablePolymer);
 //! Enable surface volume scaling
 NEW_PROP_TAG(BlackoilConserveSurfaceVolume);
+
+//! Allow the spatial and temporal domains to exhibit non-constant temperature
+//! in the black-oil model
+NEW_PROP_TAG(EnableTemperature);
+
+//! Enable the ECL-blackoil extension for energy conservation
+//!
+//! Setting this property to true implies EnableTemperature.
+NEW_PROP_TAG(EnableEnergy);
+
 }} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -60,6 +60,15 @@ NEW_PROP_TAG(EnableTemperature);
 //! Setting this property to true implies EnableTemperature.
 NEW_PROP_TAG(EnableEnergy);
 
+//! The relative weight of the residual of the energy equation compared to the mass
+//! residuals
+//!
+//! this is basically a hack to work around the limitation that the convergence criterion
+//! of unmodified dune-istl linear solvers cannot weight the individual equations. if the
+//! energy equation is not scaled, its absolute value is normally several orders of
+//! magnitude larger than that of the mass balance equations
+NEW_PROP_TAG(BlackOilEnergyScalingFactor);
+
 }} // namespace Properties, Ewoms
 
 #endif

--- a/ewoms/models/blackoil/blackoilratevector.hh
+++ b/ewoms/models/blackoil/blackoilratevector.hh
@@ -89,26 +89,42 @@ public:
     /*!
      * \copydoc ImmiscibleRateVector::setMassRate
      */
-    void setMassRate(const ParentType& value)
+    void setMassRate(const ParentType& value, unsigned pvtRegionIdx = 0)
     {
         ParentType::operator=(value);
 
-        if (enableEnergy)
-            (*this)[contiEnergyEqIdx] *=
-                GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+        // convert to "surface volume" if requested
+        if (GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume)) {
+            (*this)[FluidSystem::gasCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIdx);
+            (*this)[FluidSystem::oilCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::oilPhaseIdx, pvtRegionIdx);
+            (*this)[FluidSystem::waterCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::waterPhaseIdx, pvtRegionIdx);
+        }
     }
 
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate
      */
-    void setMolarRate(const ParentType& value)
+    void setMolarRate(const ParentType& value, unsigned pvtRegionIdx = 0)
     {
         // first, assign molar rates
         ParentType::operator=(value);
 
         // then, convert them to mass rates
         for (unsigned compIdx = 0; compIdx < numComponents; ++compIdx)
-            (*this)[conti0EqIdx + compIdx] *= FluidSystem::molarMass(compIdx);
+            (*this)[conti0EqIdx + compIdx] *= FluidSystem::molarMass(compIdx, pvtRegionIdx);
+
+        // convert to "surface volume" if requested
+        if (GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume)) {
+            (*this)[FluidSystem::gasCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::gasPhaseIdx, pvtRegionIdx);
+            (*this)[FluidSystem::oilCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::oilPhaseIdx, pvtRegionIdx);
+            (*this)[FluidSystem::waterCompIdx] /=
+                FluidSystem::referenceDensity(FluidSystem::waterPhaseIdx, pvtRegionIdx);
+        }
     }
 
     /*!

--- a/ewoms/models/blackoil/blackoilratevector.hh
+++ b/ewoms/models/blackoil/blackoilratevector.hh
@@ -59,6 +59,8 @@ class BlackOilRateVector
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
     enum { conti0EqIdx = Indices::conti0EqIdx };
+    enum { contiEnergyEqIdx = Indices::contiEnergyEqIdx };
+    enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldVector<Evaluation, numEq> ParentType;
@@ -88,7 +90,13 @@ public:
      * \copydoc ImmiscibleRateVector::setMassRate
      */
     void setMassRate(const ParentType& value)
-    { ParentType::operator=(value); }
+    {
+        ParentType::operator=(value);
+
+        if (enableEnergy)
+            (*this)[contiEnergyEqIdx] *=
+                GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
+    }
 
     /*!
      * \copydoc ImmiscibleRateVector::setMolarRate

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -37,36 +37,49 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned numPolymersV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
+template <bool enableSolventV, bool enablePolymerV, bool enableEnergyV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
 struct BlackOilTwoPhaseIndices
 {
-
     //! Is phase enabled or not
-    static const bool oilEnabled = disabledCanonicalCompIdx==0? false:true;
-    static const bool waterEnabled = disabledCanonicalCompIdx==1? false:true;
-    static const bool gasEnabled = disabledCanonicalCompIdx==2? false:true;
+    static const bool oilEnabled = (disabledCanonicalCompIdx != 0);
+    static const bool waterEnabled = (disabledCanonicalCompIdx != 1);
+    static const bool gasEnabled = (disabledCanonicalCompIdx != 2);
 
-    //! Number of phases active at all times
+    //! Are solvents involved?
+    static const bool enableSolvent = enableSolventV;
+
+    //! Are polymers involved?
+    static const bool enablePolymer = enablePolymerV;
+
+    //! Shall energy be conserved?
+    static const bool enableEnergy = enableEnergyV;
+
+private:
+    //! Number of solvent components to be considered
+    static const int numSolvents_ = enableSolvent ? 1 : 0;
+
+    //! Number of polymer components to be considered
+    static const int numPolymers_ = enablePolymer ? 1 : 0;
+
+    //! Number of energy equations to be considered
+    static const int numEnergy_ = enableEnergy ? 1 : 0;
+
+public:
+    //! The number of fluid phases
     static const int numPhases = 2;
 
-    //! Number of solvent components considered
-    static const int numSolvents = numSolventsV;
-
-    //! Number of polymer components considered
-    static const int numPolymers = numPolymersV;
-
     //! The number of equations
-    static const int numEq = numPhases + numSolvents + numPolymers;
+    static const int numEq = numPhases + numSolvents_ + numPolymers_ + numEnergy_;
 
     //////////////////////////////
     // Primary variable indices
     //////////////////////////////
 
     //! The index of the water saturation. For two-phase oil gas models this is disabled.
-    static const int waterSaturationIdx  = waterEnabled ? PVOffset + 0: -10000;
+    static const int waterSaturationIdx  = waterEnabled ? PVOffset + 0 : -10000;
 
     //! Index of the oil pressure in a vector of primary variables
-    static const int pressureSwitchIdx  = PVOffset + 1;
+    static const int pressureSwitchIdx  = waterEnabled ? PVOffset + 1 : PVOffset + 0;
 
     /*!
      * \brief Index of the switching variable which determines the composition of the
@@ -74,20 +87,24 @@ struct BlackOilTwoPhaseIndices
      *
      * \note For two-phase water oil models this is disabled.
      */
-    static const int compositionSwitchIdx = gasEnabled ? PVOffset + 0: -10000;
+    static const int compositionSwitchIdx = gasEnabled ? PVOffset + 1 : -10000;
 
     //! Index of the primary variable for the first solvent
-    static const int solventSaturationIdx  = PVOffset + numPhases;
+    static const int solventSaturationIdx =
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
 
     //! Index of the primary variable for the first polymer
-    static const int polymerConcentrationIdx  = solventSaturationIdx + numSolvents;
+    static const int polymerConcentrationIdx =
+        enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
 
-    // numSolvents-1 primary variables follow
-
+    //! Index of the primary variable for temperature
+    static const int temperatureIdx  =
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
 
     //////////////////////
     // Equation indices
     //////////////////////
+
     //! \brief returns the index of "active" component
     static unsigned canonicalToActiveComponentIndex(unsigned compIdx)
     {
@@ -127,15 +144,19 @@ struct BlackOilTwoPhaseIndices
 
     //! Index of the continuity equation of the first phase
     static const int conti0EqIdx = PVOffset + 0;
-    // two continuity equations follow
+    // one continuity equation follows
 
     //! Index of the continuity equation for the first solvent component
-    static const int contiSolventEqIdx = PVOffset + numPhases - 1 + numSolvents;
+    static const int contiSolventEqIdx =
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
 
     //! Index of the continuity equation for the first polymer component
-    static const int contiPolymerEqIdx = contiSolventEqIdx + numPolymers;
-    // numSolvents-1 continuity equations follow
+    static const int contiPolymerEqIdx =
+        enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
 
+    //! Index of the continuity equation for energy
+    static const int contiEnergyEqIdx =
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : -1000;
 };
 
 } // namespace Ewoms


### PR DESCRIPTION
this implements an energy conservation extension for the black-oil model. It requires some small downstream mop-up because the indices class expects an additional template argument which specifies if energy is enabled or not.

I've verified that the performance of `flow` for norne does not change with this. Further testing is highly appreciated, though.

