### PR TITLE
removing the completions in inactive cells after createGrid() in eclbasegridmanager

### DIFF
--- a/ebos/eclalugridmanager.hh
+++ b/ebos/eclalugridmanager.hh
@@ -196,6 +196,11 @@ protected:
             new CartesianIndexMapper(*grid_, cartesianDimension_, cartesianCellId_);
     }
 
+    void filterCompletions_()
+    {
+        // not handling the removal of completions for this type of grid yet.
+    }
+
     Grid* grid_;
     EquilGrid* equilGrid_;
     std::vector<int> cartesianCellId_;

--- a/ebos/eclbasegridmanager.hh
+++ b/ebos/eclbasegridmanager.hh
@@ -194,6 +194,7 @@ public:
         }
 
         asImp_().createGrids_();
+        asImp_().filterCompletions_();
         asImp_().finalizeInit_();
     }
 
@@ -216,6 +217,10 @@ public:
     { return *eclState_; }
 
     const Opm::Schedule& schedule() const {
+        return *schedule_;
+    }
+
+    Opm::Schedule& schedule() {
         return *schedule_;
     }
 
@@ -316,7 +321,7 @@ private:
     static Opm::Deck* externalDeck_;
     static Opm::EclipseState* externalEclState_;
     static Opm::Schedule* externalSchedule_;
-    static Opm::SummaryConfig* externalSummaryConfig_; 
+    static Opm::SummaryConfig* externalSummaryConfig_;
     std::unique_ptr<Opm::Deck> internalDeck_;
     std::unique_ptr<Opm::EclipseState> internalEclState_;
     std::unique_ptr<Opm::Schedule> internalSchedule_;

--- a/ebos/eclcpgridmanager.hh
+++ b/ebos/eclcpgridmanager.hh
@@ -31,6 +31,7 @@
 #include "ecltransmissibility.hh"
 
 #include <dune/grid/CpGrid.hpp>
+#include <dune/grid/cpgrid/GridHelpers.hpp>
 
 #include <dune/grid/common/mcmgmapper.hh>
 
@@ -255,6 +256,16 @@ protected:
         equilCartesianIndexMapper_ = new CartesianIndexMapper(*equilGrid_);
 
         globalTrans_ = nullptr;
+    }
+
+    // removing some completions located in inactive grid cells
+    void filterCompletions_()
+    {
+        assert(grid_);
+        Grid grid = *grid_;
+        grid.switchToGlobalView();
+        const auto eclipseGrid = Opm::UgGridHelpers::createEclipseGrid(grid, this->eclState().getInputGrid());
+        this->schedule().filterCompletions(eclipseGrid);
     }
 
     Grid* grid_;

--- a/ebos/eclpolyhedralgridmanager.hh
+++ b/ebos/eclpolyhedralgridmanager.hh
@@ -151,6 +151,11 @@ protected:
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);
     }
 
+    void filterCompletions_()
+    {
+        // not handling the removal of completions for this type of grid yet.
+    }
+
     GridPointer grid_;
     CartesianIndexMapperPointer cartesianIndexMapper_;
 };


### PR DESCRIPTION
reason is that we need to remove some completions in the Well in the Schedule due to processed grid in opm-simulators. 