### PR TITLE
rename the "grid manager" to "vanguard"

### DIFF
--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::EclAluGridManager
+ * \copydoc Ewoms::EclAluGridVanguard
  */
-#ifndef EWOMS_ECL_ALU_GRID_MANAGER_HH
-#define EWOMS_ECL_ALU_GRID_MANAGER_HH
+#ifndef EWOMS_ECL_ALU_GRID_VANGUARD_HH
+#define EWOMS_ECL_ALU_GRID_VANGUARD_HH
 
-#include "eclbasegridmanager.hh"
+#include "eclbasevanguard.hh"
 #include "alucartesianindexmapper.hh"
 
 #include <dune/alugrid/grid.hh>
@@ -36,15 +36,15 @@
 
 namespace Ewoms {
 template <class TypeTag>
-class EclAluGridManager;
+class EclAluGridVanguard;
 
 namespace Properties {
-NEW_TYPE_TAG(EclAluGridManager, INHERITS_FROM(EclBaseGridManager));
+NEW_TYPE_TAG(EclAluGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 // declare the properties
-SET_TYPE_PROP(EclAluGridManager, GridManager, Ewoms::EclAluGridManager<TypeTag>);
-SET_TYPE_PROP(EclAluGridManager, Grid,  Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>);
-SET_TYPE_PROP(EclAluGridManager, EquilGrid, Dune::CpGrid);
+SET_TYPE_PROP(EclAluGridVanguard, Vanguard, Ewoms::EclAluGridVanguard<TypeTag>);
+SET_TYPE_PROP(EclAluGridVanguard, Grid,  Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>);
+SET_TYPE_PROP(EclAluGridVanguard, EquilGrid, Dune::CpGrid);
 } // namespace Properties
 
 /*!
@@ -55,10 +55,10 @@ SET_TYPE_PROP(EclAluGridManager, EquilGrid, Dune::CpGrid);
  * This class uses Dune::ALUGrid as the simulation grid.
  */
 template <class TypeTag>
-class EclAluGridManager : public EclBaseGridManager<TypeTag>
+class EclAluGridVanguard : public EclBaseVanguard<TypeTag>
 {
-    friend class EclBaseGridManager<TypeTag>;
-    typedef EclBaseGridManager<TypeTag> ParentType;
+    friend class EclBaseVanguard<TypeTag>;
+    typedef EclBaseVanguard<TypeTag> ParentType;
 
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
@@ -78,9 +78,9 @@ public:
     /*!
      * \brief Inherit the constructors from the base class.
      */
-    using EclBaseGridManager<TypeTag>::EclBaseGridManager;
+    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
 
-    ~EclAluGridManager()
+    ~EclAluGridVanguard()
     {
         delete cartesianIndexMapper_;
         delete equilCartesianIndexMapper_;

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::EclBaseGridManager
+ * \copydoc Ewoms::EclBaseVanguard
  */
-#ifndef EWOMS_ECL_BASE_GRID_MANAGER_HH
-#define EWOMS_ECL_BASE_GRID_MANAGER_HH
+#ifndef EWOMS_ECL_BASE_VANGUARD_HH
+#define EWOMS_ECL_BASE_VANGUARD_HH
 
-#include <ewoms/io/basegridmanager.hh>
+#include <ewoms/io/basevanguard.hh>
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 
@@ -50,18 +50,18 @@
 
 namespace Ewoms {
 template <class TypeTag>
-class EclBaseGridManager;
+class EclBaseVanguard;
 
 namespace Properties {
-NEW_TYPE_TAG(EclBaseGridManager);
+NEW_TYPE_TAG(EclBaseVanguard);
 
-// declare the properties required by the for the ecl grid manager
+// declare the properties required by the for the ecl simulator vanguard
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(EquilGrid);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(EclDeckFileName);
 
-SET_STRING_PROP(EclBaseGridManager, EclDeckFileName, "ECLDECK.DATA");
+SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "ECLDECK.DATA");
 } // namespace Properties
 
 /*!
@@ -70,10 +70,10 @@ SET_STRING_PROP(EclBaseGridManager, EclDeckFileName, "ECLDECK.DATA");
  * \brief Helper class for grid instantiation of ECL file-format using problems.
  */
 template <class TypeTag>
-class EclBaseGridManager : public BaseGridManager<TypeTag>
+class EclBaseVanguard : public BaseVanguard<TypeTag>
 {
-    typedef BaseGridManager<TypeTag> ParentType;
-    typedef typename GET_PROP_TYPE(TypeTag, GridManager) Implementation;
+    typedef BaseVanguard<TypeTag> ParentType;
+    typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Implementation;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
 
@@ -86,7 +86,7 @@ protected:
 
 public:
     /*!
-     * \brief Register all run-time parameters for the grid manager.
+     * \brief Register the common run-time parameters for all ECL simulator vanguards.
      */
     static void registerParameters()
     {
@@ -96,13 +96,13 @@ public:
 
     /*!
      * \brief Set the Opm::EclipseState and the Opm::Deck object which ought to be used
-     *        when the grid manager is instantiated.
+     *        when the simulator vanguard is instantiated.
      *
      * This is basically an optimization: In cases where the ECL input deck must be
      * examined to decide which simulator ought to be used, this avoids having to parse
      * the input twice. When this method is used, the caller is responsible for lifetime
      * management of these two objects, i.e., they are not allowed to be deleted as long
-     * as the grid manager object is alive.
+     * as the simulator vanguard object is alive.
      */
     static void setExternalDeck(Opm::Deck* deck, Opm::EclipseState* eclState, Opm::Schedule* schedule, Opm::SummaryConfig* summaryConfig)
     {
@@ -118,7 +118,7 @@ public:
      * This is the file format used by the commercial ECLiPSE simulator. Usually it uses
      * a cornerpoint description of the grid.
      */
-    EclBaseGridManager(Simulator& simulator)
+    EclBaseVanguard(Simulator& simulator)
         : ParentType(simulator)
     {
         int myRank = 0;
@@ -336,16 +336,16 @@ private:
 };
 
 template <class TypeTag>
-Opm::Deck* EclBaseGridManager<TypeTag>::externalDeck_ = nullptr;
+Opm::Deck* EclBaseVanguard<TypeTag>::externalDeck_ = nullptr;
 
 template <class TypeTag>
-Opm::EclipseState* EclBaseGridManager<TypeTag>::externalEclState_;
+Opm::EclipseState* EclBaseVanguard<TypeTag>::externalEclState_;
 
 template <class TypeTag>
-Opm::Schedule* EclBaseGridManager<TypeTag>::externalSchedule_ = nullptr;
+Opm::Schedule* EclBaseVanguard<TypeTag>::externalSchedule_ = nullptr;
 
 template <class TypeTag>
-Opm::SummaryConfig* EclBaseGridManager<TypeTag>::externalSummaryConfig_ = nullptr;
+Opm::SummaryConfig* EclBaseVanguard<TypeTag>::externalSummaryConfig_ = nullptr;
 
 
 } // namespace Ewoms

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::EclCpGridManager
+ * \copydoc Ewoms::EclCpGridVanguard
  */
-#ifndef EWOMS_ECL_CP_GRID_MANAGER_HH
-#define EWOMS_ECL_CP_GRID_MANAGER_HH
+#ifndef EWOMS_ECL_CP_GRID_VANGUARD_HH
+#define EWOMS_ECL_CP_GRID_VANGUARD_HH
 
-#include "eclbasegridmanager.hh"
+#include "eclbasevanguard.hh"
 #include "ecltransmissibility.hh"
 
 #include <dune/grid/CpGrid.hpp>
@@ -39,18 +39,18 @@
 
 namespace Ewoms {
 template <class TypeTag>
-class EclCpGridManager;
+class EclCpGridVanguard;
 
 namespace Properties {
-NEW_TYPE_TAG(EclCpGridManager, INHERITS_FROM(EclBaseGridManager));
+NEW_TYPE_TAG(EclCpGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 NEW_PROP_TAG(ExportGlobalTransmissibility);
 
 // declare the properties
-SET_TYPE_PROP(EclCpGridManager, GridManager, Ewoms::EclCpGridManager<TypeTag>);
-SET_TYPE_PROP(EclCpGridManager, Grid, Dune::CpGrid);
-SET_TYPE_PROP(EclCpGridManager, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
-SET_BOOL_PROP(EclCpGridManager, ExportGlobalTransmissibility, false);
+SET_TYPE_PROP(EclCpGridVanguard, Vanguard, Ewoms::EclCpGridVanguard<TypeTag>);
+SET_TYPE_PROP(EclCpGridVanguard, Grid, Dune::CpGrid);
+SET_TYPE_PROP(EclCpGridVanguard, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
+SET_BOOL_PROP(EclCpGridVanguard, ExportGlobalTransmissibility, false);
 } // namespace Properties
 
 /*!
@@ -61,10 +61,10 @@ SET_BOOL_PROP(EclCpGridManager, ExportGlobalTransmissibility, false);
  * This class uses Dune::CpGrid as the simulation grid.
  */
 template <class TypeTag>
-class EclCpGridManager : public EclBaseGridManager<TypeTag>
+class EclCpGridVanguard : public EclBaseVanguard<TypeTag>
 {
-    friend class EclBaseGridManager<TypeTag>;
-    typedef EclBaseGridManager<TypeTag> ParentType;
+    friend class EclBaseVanguard<TypeTag>;
+    typedef EclBaseVanguard<TypeTag> ParentType;
 
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, ElementMapper) ElementMapper;
@@ -81,9 +81,9 @@ public:
     /*!
      * \brief Inherit the constructors from the base class.
      */
-    using EclBaseGridManager<TypeTag>::EclBaseGridManager;
+    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
 
-    ~EclCpGridManager()
+    ~EclCpGridVanguard()
     {
         delete cartesianIndexMapper_;
         delete equilCartesianIndexMapper_;

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -87,21 +87,21 @@ public:
                         EclMaterialLawManager& materialLawManager)
         : simulator_(simulator)
     {
-        const auto& gridManager = simulator.gridManager();
+        const auto& vanguard = simulator.vanguard();
 
-        unsigned numElems = gridManager.grid().size(0);
-        unsigned numCartesianElems = gridManager.cartesianSize();
+        unsigned numElems = vanguard.grid().size(0);
+        unsigned numCartesianElems = vanguard.cartesianSize();
         typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
 
         EQUIL::DeckDependent::InitialStateComputer<TypeTag> initialState(materialLawManager,
-                                                                         gridManager.eclState(),
-                                                                         gridManager.grid(),
+                                                                         vanguard.eclState(),
+                                                                         vanguard.grid(),
                                                                          simulator.problem().gravity()[dimWorld - 1]);
 
         // copy the result into the array of initial fluid states
         initialFluidStates_.resize(numCartesianElems);
         for (unsigned int elemIdx = 0; elemIdx < numElems; ++elemIdx) {
-            unsigned cartesianElemIdx = gridManager.cartesianIndex(elemIdx);
+            unsigned cartesianElemIdx = vanguard.cartesianIndex(elemIdx);
             auto& fluidState = initialFluidStates_[cartesianElemIdx];
 
             // get the PVT region index of the current element
@@ -147,9 +147,9 @@ public:
      */
     const ScalarFluidState& initialFluidState(unsigned elemIdx) const
     {
-        const auto& gridManager = simulator_.gridManager();
+        const auto& vanguard = simulator_.vanguard();
 
-        unsigned cartesianElemIdx = gridManager.cartesianIndex(elemIdx);
+        unsigned cartesianElemIdx = vanguard.cartesianIndex(elemIdx);
         return initialFluidStates_[cartesianElemIdx];
     }
 

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -22,26 +22,26 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::EclPolyhedralGridManager
+ * \copydoc Ewoms::EclPolyhedralGridVanguard
  */
-#ifndef EWOMS_ECL_POLYHEDRAL_GRID_MANAGER_HH
-#define EWOMS_ECL_POLYHEDRAL_GRID_MANAGER_HH
+#ifndef EWOMS_ECL_POLYHEDRAL_GRID_VANGUARD_HH
+#define EWOMS_ECL_POLYHEDRAL_GRID_VANGUARD_HH
 
-#include "eclbasegridmanager.hh"
+#include "eclbasevanguard.hh"
 
 #include <dune/grid/polyhedralgrid.hh>
 
 namespace Ewoms {
 template <class TypeTag>
-class EclPolyhedralGridManager;
+class EclPolyhedralGridVanguard;
 
 namespace Properties {
-NEW_TYPE_TAG(EclPolyhedralGridManager, INHERITS_FROM(EclBaseGridManager));
+NEW_TYPE_TAG(EclPolyhedralGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 // declare the properties
-SET_TYPE_PROP(EclPolyhedralGridManager, GridManager, Ewoms::EclPolyhedralGridManager<TypeTag>);
-SET_TYPE_PROP(EclPolyhedralGridManager, Grid, Dune::PolyhedralGrid<3, 3>);
-SET_TYPE_PROP(EclPolyhedralGridManager, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
+SET_TYPE_PROP(EclPolyhedralGridVanguard, Vanguard, Ewoms::EclPolyhedralGridVanguard<TypeTag>);
+SET_TYPE_PROP(EclPolyhedralGridVanguard, Grid, Dune::PolyhedralGrid<3, 3>);
+SET_TYPE_PROP(EclPolyhedralGridVanguard, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
 } // namespace Properties
 
 /*!
@@ -52,10 +52,10 @@ SET_TYPE_PROP(EclPolyhedralGridManager, EquilGrid, typename GET_PROP_TYPE(TypeTa
  * This class uses Dune::PolyhedralGrid as the simulation grid.
  */
 template <class TypeTag>
-class EclPolyhedralGridManager : public EclBaseGridManager<TypeTag>
+class EclPolyhedralGridVanguard : public EclBaseVanguard<TypeTag>
 {
-    friend class EclBaseGridManager<TypeTag>;
-    typedef EclBaseGridManager<TypeTag> ParentType;
+    friend class EclBaseVanguard<TypeTag>;
+    typedef EclBaseVanguard<TypeTag> ParentType;
 
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
@@ -75,9 +75,9 @@ public:
     /*!
      * \brief Inherit the constructors from the base class.
      */
-    using EclBaseGridManager<TypeTag>::EclBaseGridManager;
+    using EclBaseVanguard<TypeTag>::EclBaseVanguard;
 
-    ~EclPolyhedralGridManager()
+    ~EclPolyhedralGridVanguard()
     {
         delete cartesianIndexMapper_;
         delete grid_;

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -101,8 +101,8 @@ public:
         // sorry!
         assert(simulator_.model().numGridDof() == numElements);
 
-        const auto& gridManager = simulator_.gridManager();
-        const auto& eclState = gridManager.eclState();
+        const auto& vanguard = simulator_.vanguard();
+        const auto& eclState = vanguard.eclState();
         const auto& simConfig = eclState.getSimulationConfig();
 
         enableThresholdPressure_ = simConfig.hasThresholdPressure();
@@ -125,7 +125,7 @@ public:
             eclState.get3DProperties().getIntGridProperty("EQLNUM").getData();
         elemEquilRegion_.resize(numElements, 0);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
-            int cartElemIdx = gridManager.cartesianIndex(elemIdx);
+            int cartElemIdx = vanguard.cartesianIndex(elemIdx);
 
             // ECL uses Fortran-style indices but we want C-style ones!
             elemEquilRegion_[elemIdx] = equilRegionData[cartElemIdx] - 1;
@@ -161,8 +161,8 @@ private:
     // compute the defaults of the threshold pressures using the initial condition
     void computeDefaultThresholdPressures_()
     {
-        const auto& gridManager = simulator_.gridManager();
-        const auto& gridView = gridManager.gridView();
+        const auto& vanguard = simulator_.vanguard();
+        const auto& gridView = vanguard.gridView();
 
         typedef Opm::MathToolbox<Evaluation> Toolbox;
         // loop over the whole grid and compute the maximum gravity adjusted pressure
@@ -233,10 +233,10 @@ private:
     // THPRES keyword.
     void applyExplicitThresholdPressures_()
     {
-        const auto& gridManager = simulator_.gridManager();
-        const auto& gridView = gridManager.gridView();
+        const auto& vanguard = simulator_.vanguard();
+        const auto& gridView = vanguard.gridView();
         const auto& elementMapper = simulator_.model().elementMapper();
-        const auto& eclState = simulator_.gridManager().eclState();
+        const auto& eclState = simulator_.vanguard().eclState();
         const Opm::SimulationConfig& simConfig = eclState.getSimulationConfig();
         const auto& thpres = simConfig.getThresholdPressure();
 

--- a/ewoms/common/basicproperties.hh
+++ b/ewoms/common/basicproperties.hh
@@ -32,7 +32,7 @@
 
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
-#include <ewoms/io/dgfgridmanager.hh>
+#include <ewoms/io/dgfvanguard.hh>
 
 #include <ewoms/aux/compatibility.hh>
 
@@ -73,8 +73,8 @@ NEW_PROP_TAG(ParameterTree);
 //! Property which defines the group that is queried for parameters by default
 NEW_PROP_TAG(ModelParameterGroup);
 
-//! Property which provides a GridManager (manages grids)
-NEW_PROP_TAG(GridManager);
+//! Property which provides a Vanguard (manages grids)
+NEW_PROP_TAG(Vanguard);
 
 NEW_PROP_TAG(GridView);
 
@@ -82,7 +82,7 @@ NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(GridPart);
 #endif
 
-//! Property which tells the GridManager how often the grid should be refined
+//! Property which tells the Vanguard how often the grid should be refined
 //! after creation.
 NEW_PROP_TAG(GridGlobalRefinements);
 
@@ -140,8 +140,8 @@ SET_PROP(NumericModel, ParameterTree)
 //! use the global group as default for the model's parameter group
 SET_STRING_PROP(NumericModel, ModelParameterGroup, "");
 
-//! Use the DgfGridManager by default
-SET_TYPE_PROP(NumericModel, GridManager, Ewoms::DgfGridManager<TypeTag>);
+//! Use the DgfVanguard by default
+SET_TYPE_PROP(NumericModel, Vanguard, Ewoms::DgfVanguard<TypeTag>);
 
 //! Set a value for the GridFile property
 SET_STRING_PROP(NumericModel, GridFile, "");

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -45,11 +45,10 @@
 #include <string>
 #include <memory>
 
-
 namespace Ewoms {
 namespace Properties {
 NEW_PROP_TAG(Scalar);
-NEW_PROP_TAG(GridManager);
+NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(Model);
 NEW_PROP_TAG(Problem);
@@ -75,7 +74,7 @@ template <class TypeTag>
 class Simulator
 {
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+    typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
@@ -116,12 +115,12 @@ public:
         finished_ = false;
 
         if (verbose_)
-            std::cout << "Allocating the grid\n" << std::flush;
-        gridManager_.reset(new GridManager(*this));
+            std::cout << "Instantiating the vanguard\n" << std::flush;
+        vanguard_.reset(new Vanguard(*this));
 
         if (verbose_)
-            std::cout << "Distributing the grid\n" << std::flush;
-        gridManager_->loadBalance();
+            std::cout << "Distributing the vanguard data\n" << std::flush;
+        vanguard_->loadBalance();
 
         if (verbose_)
             std::cout << "Allocating the model\n" << std::flush;
@@ -160,7 +159,7 @@ public:
                              "A file with a list of predetermined time step sizes (one "
                              "time step per line)");
 
-        GridManager::registerParameters();
+        Vanguard::registerParameters();
         Model::registerParameters();
         Problem::registerParameters();
     }
@@ -168,20 +167,20 @@ public:
     /*!
      * \brief Return a reference to the grid manager of simulation
      */
-    GridManager& gridManager()
-    { return *gridManager_; }
+    Vanguard& vanguard()
+    { return *vanguard_; }
 
     /*!
      * \brief Return a reference to the grid manager of simulation
      */
-    const GridManager& gridManager() const
-    { return *gridManager_; }
+    const Vanguard& vanguard() const
+    { return *vanguard_; }
 
     /*!
      * \brief Return the grid view for which the simulation is done
      */
     const GridView& gridView() const
-    { return gridManager_->gridView(); }
+    { return vanguard_->gridView(); }
 
     /*!
      * \brief Return the physical model used in the simulation
@@ -847,7 +846,7 @@ public:
     }
 
 private:
-    std::unique_ptr<GridManager> gridManager_;
+    std::unique_ptr<Vanguard> vanguard_;
     std::unique_ptr<Model> model_;
     std::unique_ptr<Problem> problem_;
 

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -378,7 +378,7 @@ public:
         , localLinearizer_(ThreadManager::maxThreads())
         , linearizer_(new Linearizer())
 #if HAVE_DUNE_FEM
-        , space_( simulator.gridManager().gridPart() )
+        , space_( simulator.vanguard().gridPart() )
 #else
         , space_( asImp_().numGridDof() )
 #endif
@@ -1723,7 +1723,7 @@ public:
             restrictProlong_.reset(
                 new RestrictProlong( DiscreteFunctionRestrictProlong(*(solution_[/*timeIdx=*/ 0] )),
                                      simulator_.problem().restrictProlongOperator() ) );
-            adaptationManager_.reset( new AdaptationManager( simulator_.gridManager().grid(), *restrictProlong_ ) );
+            adaptationManager_.reset( new AdaptationManager( simulator_.vanguard().grid(), *restrictProlong_ ) );
         }
         return *adaptationManager_;
     }

--- a/ewoms/io/basevanguard.hh
+++ b/ewoms/io/basevanguard.hh
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::BaseGridManager
+ * \copydoc Ewoms::BaseVanguard
  */
-#ifndef EWOMS_BASE_GRID_MANAGER_HH
-#define EWOMS_BASE_GRID_MANAGER_HH
+#ifndef EWOMS_BASE_VANGUARD_HH
+#define EWOMS_BASE_VANGUARD_HH
 
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
@@ -42,7 +42,7 @@
 namespace Ewoms {
 namespace Properties {
 NEW_PROP_TAG(Grid);
-NEW_PROP_TAG(GridManager);
+NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(GridPart);
 NEW_PROP_TAG(GridViewLevel);
@@ -52,26 +52,26 @@ NEW_PROP_TAG(Simulator);
 } // namespace Properties
 
 /*!
- * \brief Provides the base class for most (all?) grid managers.
+ * \brief Provides the base class for most (all?) simulator vanguards.
  */
 template <class TypeTag>
-class BaseGridManager
+class BaseVanguard
 {
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
-    typedef typename GET_PROP_TYPE(TypeTag, GridManager) Implementation;
+    typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Implementation;
 
 #if HAVE_DUNE_FEM
     typedef typename GET_PROP_TYPE(TypeTag, GridPart) GridPart;
 #endif
 
 public:
-    BaseGridManager(Simulator& simulator)
+    BaseVanguard(Simulator& simulator)
         : simulator_(simulator)
     {}
 
-    BaseGridManager(const BaseGridManager&) = delete;
+    BaseVanguard(const BaseVanguard&) = delete;
 
     /*!
      * \brief Returns a reference to the grid view to be used.

--- a/ewoms/io/dgfvanguard.hh
+++ b/ewoms/io/dgfvanguard.hh
@@ -22,16 +22,16 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::DgfGridManager
+ * \copydoc Ewoms::DgfVanguard
  */
-#ifndef EWOMS_DGF_GRID_MANAGER_HH
-#define EWOMS_DGF_GRID_MANAGER_HH
+#ifndef EWOMS_DGF_GRID_VANGUARD_HH
+#define EWOMS_DGF_GRID_VANGUARD_HH
 
 #include <dune/grid/io/file/dgfparser/dgfparser.hh>
 #include <dune/grid/common/mcmgmapper.hh>
 #include <ewoms/models/discretefracture/fracturemapper.hh>
 
-#include <ewoms/io/basegridmanager.hh>
+#include <ewoms/io/basevanguard.hh>
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 
@@ -43,19 +43,20 @@ namespace Ewoms {
 namespace Properties {
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(GridFile);
-NEW_PROP_TAG(GridManager);
+NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridGlobalRefinements);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Simulator);
 } // namespace Properties
 
 /*!
- * \brief Provides a grid manager which reads Dune Grid Format (DGF) files
+ * \brief Provides a simulator vanguard which creates a grid by parsing a Dune Grid
+ *        Format (DGF) file.
  */
 template <class TypeTag>
-class DgfGridManager : public BaseGridManager<TypeTag>
+class DgfVanguard : public BaseVanguard<TypeTag>
 {
-    typedef BaseGridManager<TypeTag> ParentType;
+    typedef BaseVanguard<TypeTag> ParentType;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
@@ -65,7 +66,7 @@ class DgfGridManager : public BaseGridManager<TypeTag>
 
 public:
     /*!
-     * \brief Register all run-time parameters for the grid manager.
+     * \brief Register all run-time parameters for the DGF simulator vanguard.
      */
     static void registerParameters()
     {
@@ -79,7 +80,7 @@ public:
     /*!
      * \brief Load the grid from the file.
      */
-    DgfGridManager(Simulator& simulator)
+    DgfVanguard(Simulator& simulator)
         : ParentType(simulator)
     {
         const std::string dgfFileName = EWOMS_GET_PARAM(TypeTag, std::string, GridFile);

--- a/ewoms/io/structuredgridvanguard.hh
+++ b/ewoms/io/structuredgridvanguard.hh
@@ -22,12 +22,12 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::StructuredGridManager
+ * \copydoc Ewoms::StructuredGridVanguard
  */
-#ifndef EWOMS_STRUCTURED_GRID_MANAGER_HH
-#define EWOMS_STRUCTURED_GRID_MANAGER_HH
+#ifndef EWOMS_STRUCTURED_GRID_VANGUARD_HH
+#define EWOMS_STRUCTURED_GRID_VANGUARD_HH
 
-#include <ewoms/io/basegridmanager.hh>
+#include <ewoms/io/basevanguard.hh>
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 
@@ -48,12 +48,12 @@
 namespace Ewoms {
 
 template <class TypeTag>
-class StructuredGridManager;
+class StructuredGridVanguard;
 
 namespace Properties {
-NEW_TYPE_TAG(StructuredGridManager);
+NEW_TYPE_TAG(StructuredGridVanguard);
 
-// declare the properties required by the for the lens grid manager
+// declare the properties required by the for the structured grid simulator vanguard
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(Scalar);
 
@@ -74,14 +74,14 @@ static const int dim = 2;
 static const int dim = GRIDDIM;
 #endif
 
-// set the Grid and GridManager properties
+// set the Grid and Vanguard properties
 #if HAVE_DUNE_ALUGRID
-SET_TYPE_PROP(StructuredGridManager, Grid, Dune::ALUGrid< dim, dim, Dune::cube, Dune::nonconforming >);
+SET_TYPE_PROP(StructuredGridVanguard, Grid, Dune::ALUGrid< dim, dim, Dune::cube, Dune::nonconforming >);
 #else
-SET_TYPE_PROP(StructuredGridManager, Grid, Dune::YaspGrid< dim >);
+SET_TYPE_PROP(StructuredGridVanguard, Grid, Dune::YaspGrid< dim >);
 #endif
 
-SET_TYPE_PROP(StructuredGridManager, GridManager, Ewoms::StructuredGridManager<TypeTag>);
+SET_TYPE_PROP(StructuredGridVanguard, Vanguard, Ewoms::StructuredGridVanguard<TypeTag>);
 } // namespace Properties
 
 /*!
@@ -90,9 +90,9 @@ SET_TYPE_PROP(StructuredGridManager, GridManager, Ewoms::StructuredGridManager<T
  * \brief Helper class for grid instantiation of the lens problem.
  */
 template <class TypeTag>
-class StructuredGridManager : public BaseGridManager<TypeTag>
+class StructuredGridVanguard : public BaseVanguard<TypeTag>
 {
-    typedef BaseGridManager<TypeTag> ParentType;
+    typedef BaseVanguard<TypeTag> ParentType;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, Grid) Grid;
@@ -103,7 +103,7 @@ class StructuredGridManager : public BaseGridManager<TypeTag>
 
 public:
     /*!
-     * \brief Register all run-time parameters for the grid manager.
+     * \brief Register all run-time parameters for the structured grid simulator vanguard.
      */
     static void registerParameters()
     {
@@ -131,7 +131,7 @@ public:
     /*!
      * \brief Create the grid for the lens problem
      */
-    StructuredGridManager(Simulator& simulator)
+    StructuredGridVanguard(Simulator& simulator)
         : ParentType(simulator)
     {
         Dune::FieldVector<int, dim> cellRes;

--- a/ewoms/io/vtkdiscretefracturemodule.hh
+++ b/ewoms/io/vtkdiscretefracturemodule.hh
@@ -45,7 +45,7 @@ namespace Properties {
 NEW_TYPE_TAG(VtkDiscreteFracture);
 
 // create the property tags needed for the multi phase module
-NEW_PROP_TAG(GridManager);
+NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(VtkWriteFractureSaturations);
 NEW_PROP_TAG(VtkWriteFractureMobilities);
 NEW_PROP_TAG(VtkWriteFractureRelativePermeabilities);
@@ -89,7 +89,7 @@ class VtkDiscreteFractureModule : public BaseOutputModule<TypeTag>
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
     typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
 
-    typedef typename GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+    typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
 
@@ -177,7 +177,7 @@ public:
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
 
-        const auto& fractureMapper = elemCtx.simulator().gridManager().fractureMapper();
+        const auto& fractureMapper = elemCtx.simulator().vanguard().fractureMapper();
 
         for (unsigned i = 0; i < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++i) {
             unsigned I = elemCtx.globalSpaceIndex(i, /*timeIdx=*/0);

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -240,7 +240,7 @@ protected:
             amg_.reset();
 
         int verbosity = 0;
-        if (this->simulator_.gridManager().gridView().comm().rank() == 0)
+        if (this->simulator_.vanguard().gridView().comm().rank() == 0)
             verbosity = EWOMS_GET_PARAM(TypeTag, int, LinearSolverVerbosity);
 
         typedef typename Dune::Amg::SmootherTraits<ParallelSmoother>::Arguments SmootherArgs;

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -291,7 +291,7 @@ protected:
     void prepare_(const Matrix& M)
     {
         // if grid has changed the sequence number has changed too
-        int curSeqNum = simulator_.gridManager().gridSequenceNumber();
+        int curSeqNum = simulator_.vanguard().gridSequenceNumber();
         if( gridSequenceNumber_ == curSeqNum && overlappingMatrix_)
             // the grid has not changed since the overlappingMatrix_has been created, so
             // there's noting to do

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -61,7 +61,7 @@ template <class TypeTag>
 class BlackOilModel;
 
 template <class TypeTag>
-class EclGridManager;
+class EclVanguard;
 }
 
 namespace Ewoms {

--- a/ewoms/models/common/multiphasebaseproblem.hh
+++ b/ewoms/models/common/multiphasebaseproblem.hh
@@ -316,8 +316,8 @@ public:
 
         unsigned numMarked = 0;
         ElementContext elemCtx( this->simulator() );
-        auto gridView = this->simulator().gridManager().gridView();
-        auto& grid = this->simulator().gridManager().grid();
+        auto gridView = this->simulator().vanguard().gridView();
+        auto& grid = this->simulator().vanguard().grid();
         auto elemIt = gridView.template begin</*codim=*/0, Dune::Interior_Partition>();
         auto elemEndIt = gridView.template end</*codim=*/0, Dune::Interior_Partition>();
         for (; elemIt != elemEndIt; ++elemIt)
@@ -357,7 +357,7 @@ public:
         }
 
         // get global sum so that every proc is on the same page
-        numMarked = this->simulator().gridManager().grid().comm().sum( numMarked );
+        numMarked = this->simulator().vanguard().grid().comm().sum( numMarked );
 
         return numMarked;
     }

--- a/tests/problems/diffusionproblem.hh
+++ b/tests/problems/diffusionproblem.hh
@@ -30,7 +30,7 @@
 
 #include <ewoms/models/ncp/ncpproperties.hh>
 
-#include <ewoms/io/cubegridmanager.hh>
+#include <ewoms/io/cubegridvanguard.hh>
 
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
 #include <opm/material/fluidmatrixinteractions/MaterialTraits.hpp>
@@ -60,8 +60,8 @@ NEW_TYPE_TAG(DiffusionBaseProblem);
 // Set the grid implementation to be used
 SET_TYPE_PROP(DiffusionBaseProblem, Grid, Dune::YaspGrid</*dim=*/1>);
 
-// set the GridManager property
-SET_TYPE_PROP(DiffusionBaseProblem, GridManager, Ewoms::CubeGridManager<TypeTag>);
+// set the Vanguard property
+SET_TYPE_PROP(DiffusionBaseProblem, Vanguard, Ewoms::CubeGridVanguard<TypeTag>);
 
 // Set the problem property
 SET_TYPE_PROP(DiffusionBaseProblem, Problem, Ewoms::DiffusionProblem<TypeTag>);

--- a/tests/problems/fingerproblem.hh
+++ b/tests/problems/fingerproblem.hh
@@ -28,7 +28,7 @@
 #ifndef EWOMS_FINGER_PROBLEM_HH
 #define EWOMS_FINGER_PROBLEM_HH
 
-#include <ewoms/io/structuredgridmanager.hh>
+#include <ewoms/io/structuredgridvanguard.hh>
 
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
@@ -61,7 +61,7 @@ template <class TypeTag>
 class FingerProblem;
 
 namespace Properties {
-NEW_TYPE_TAG(FingerBaseProblem, INHERITS_FROM(StructuredGridManager));
+NEW_TYPE_TAG(FingerBaseProblem, INHERITS_FROM(StructuredGridVanguard));
 
 #if HAVE_DUNE_ALUGRID
 // use dune-alugrid if available
@@ -219,7 +219,7 @@ public:
      */
     FingerProblem(Simulator& simulator)
         : ParentType(simulator),
-          materialParams_( simulator.gridManager().grid(), codim )
+          materialParams_( simulator.vanguard().grid(), codim )
     {
     }
 

--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -38,7 +38,7 @@
 #endif
 
 #include <ewoms/models/discretefracture/discretefracturemodel.hh>
-#include <ewoms/io/dgfgridmanager.hh>
+#include <ewoms/io/dgfvanguard.hh>
 
 #include <opm/material/fluidmatrixinteractions/RegularizedBrooksCorey.hpp>
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
@@ -75,8 +75,8 @@ SET_TYPE_PROP(
     FractureProblem, Grid,
     Dune::ALUGrid</*dim=*/2, /*dimWorld=*/2, Dune::simplex, Dune::nonconforming>);
 
-// Set the GridManager property
-SET_TYPE_PROP(FractureProblem, GridManager, Ewoms::DgfGridManager<TypeTag>);
+// Set the Vanguard property
+SET_TYPE_PROP(FractureProblem, Vanguard, Ewoms::DgfVanguard<TypeTag>);
 
 // Set the problem property
 SET_TYPE_PROP(FractureProblem, Problem, Ewoms::FractureProblem<TypeTag>);
@@ -398,7 +398,7 @@ public:
      * \brief Returns the object representating the fracture topology.
      */
     const FractureMapper& fractureMapper() const
-    { return this->simulator().gridManager().fractureMapper(); }
+    { return this->simulator().vanguard().fractureMapper(); }
 
     /*!
      * \brief Returns the width of the fracture.

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -28,7 +28,7 @@
 #ifndef EWOMS_LENS_PROBLEM_HH
 #define EWOMS_LENS_PROBLEM_HH
 
-#include <ewoms/io/structuredgridmanager.hh>
+#include <ewoms/io/structuredgridvanguard.hh>
 #include <ewoms/models/immiscible/immiscibleproperties.hh>
 #include <ewoms/disc/common/fvbaseadlocallinearizer.hh>
 
@@ -55,7 +55,7 @@ template <class TypeTag>
 class LensProblem;
 
 namespace Properties {
-NEW_TYPE_TAG(LensBaseProblem, INHERITS_FROM(StructuredGridManager));
+NEW_TYPE_TAG(LensBaseProblem, INHERITS_FROM(StructuredGridVanguard));
 
 // declare the properties specific for the lens problem
 NEW_PROP_TAG(LensLowerLeftX);

--- a/tests/problems/powerinjectionproblem.hh
+++ b/tests/problems/powerinjectionproblem.hh
@@ -29,7 +29,7 @@
 #define EWOMS_POWER_INJECTION_PROBLEM_HH
 
 #include <ewoms/models/immiscible/immisciblemodel.hh>
-#include <ewoms/io/cubegridmanager.hh>
+#include <ewoms/io/cubegridvanguard.hh>
 
 #include <opm/material/fluidmatrixinteractions/RegularizedVanGenuchten.hpp>
 #include <opm/material/fluidmatrixinteractions/LinearMaterial.hpp>
@@ -64,9 +64,9 @@ NEW_TYPE_TAG(PowerInjectionBaseProblem);
 // Set the grid implementation to be used
 SET_TYPE_PROP(PowerInjectionBaseProblem, Grid, Dune::YaspGrid</*dim=*/1>);
 
-// set the GridManager property
-SET_TYPE_PROP(PowerInjectionBaseProblem, GridManager,
-              Ewoms::CubeGridManager<TypeTag>);
+// set the Vanguard property
+SET_TYPE_PROP(PowerInjectionBaseProblem, Vanguard,
+              Ewoms::CubeGridVanguard<TypeTag>);
 
 // Set the problem property
 SET_TYPE_PROP(PowerInjectionBaseProblem, Problem,

--- a/tests/test_ecl_output.cpp
+++ b/tests/test_ecl_output.cpp
@@ -115,10 +115,10 @@ void test_summary()
     const std::string casename = "summary_deck_non_constant_porosity";
 
     auto simulator = initSimulator<TypeTag>(filename.data());
-    typedef typename GET_PROP_TYPE(TypeTag, GridManager) GridManager;
+    typedef typename GET_PROP_TYPE(TypeTag, Vanguard) Vanguard;
     typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef Ewoms::CollectDataToIORank< GridManager > CollectDataToIORankType;
-    CollectDataToIORankType collectToIORank(simulator->gridManager());
+    typedef Ewoms::CollectDataToIORank< Vanguard > CollectDataToIORankType;
+    CollectDataToIORankType collectToIORank(simulator->vanguard());
     Ewoms::EclOutputBlackOilModule<TypeTag> eclOutputModule(*simulator, collectToIORank);
 
     typedef Ewoms::EclWriter<TypeTag> EclWriterType;

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -45,7 +45,7 @@
 
 // For the DUNE grid
 #include <dune/grid/yaspgrid.hh> /*@\label{tutorial1:include-grid-manager}@*/
-#include <ewoms/io/cubegridmanager.hh> /*@\label{tutorial1:include-grid-manager}@*/
+#include <ewoms/io/cubegridvanguard.hh> /*@\label{tutorial1:include-grid-manager}@*/
 
 // For Dune::FieldMatrix
 #include <dune/common/fmatrix.hh>
@@ -72,7 +72,7 @@ SET_TYPE_PROP(Tutorial1Problem, Problem,
 
 // Set grid and the grid manager to be used
 SET_TYPE_PROP(Tutorial1Problem, Grid, Dune::YaspGrid</*dim=*/2>); /*@\label{tutorial1:set-grid}@*/
-SET_TYPE_PROP(Tutorial1Problem, GridManager, Ewoms::CubeGridManager<TypeTag>); /*@\label{tutorial1:set-grid-manager}@*/
+SET_TYPE_PROP(Tutorial1Problem, Vanguard, Ewoms::CubeGridVanguard<TypeTag>); /*@\label{tutorial1:set-grid-manager}@*/
 
 // Set the wetting phase /*@\label{tutorial1:2p-system-start}@*/
 SET_TYPE_PROP(Tutorial1Problem,


### PR DESCRIPTION
IMO the term "vanguard" expresses better what these classes are supposed to do: level the ground for the cavalry. Normally this simply means to create and distribute a grid object, but it can become quite a bit more complicated, as exemplified by the vanguard classes of ebos.

this PR needs a pretty trivial mop-up patch for opm-simulators.