### PR TITLE
fixing polymerConcentrationIdx in blackoiltwophaseindices

### DIFF
--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -80,7 +80,7 @@ struct BlackOilTwoPhaseIndices
     static const int solventSaturationIdx  = PVOffset + numPhases;
 
     //! Index of the primary variable for the first polymer
-    static const int polymerConcentrationIdx  = solventSaturationIdx + numPolymers;
+    static const int polymerConcentrationIdx  = solventSaturationIdx + numSolvents;
 
     // numSolvents-1 primary variables follow
 


### PR DESCRIPTION
It is intended to making the oil water polymer simulation (OPM/opm-simulators#1416) work. 

The approach is suggested by @totto82 