### PR TITLE
fix a few "unused variable" warnings that occur on more uncommon compilers

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -457,7 +457,7 @@ public:
                 try {
                     bubblePointPressure_[globalDofIdx] = Opm::getValue(FluidSystem::bubblePointPressure(fs, intQuants.pvtRegionIndex()));
                 }
-                catch (const Opm::NumericalIssue& e) {
+                catch (const Opm::NumericalIssue&) {
                     const auto globalIdx = elemCtx.simulator().vanguard().grid().globalCell()[globalDofIdx];
                     failedCellsPb_.push_back(globalIdx);
                 }
@@ -467,7 +467,7 @@ public:
                 try {
                     dewPointPressure_[globalDofIdx] = Opm::getValue(FluidSystem::dewPointPressure(fs, intQuants.pvtRegionIndex()));
                 }
-                catch (const Opm::NumericalIssue& e) {
+                catch (const Opm::NumericalIssue&) {
                     const auto globalIdx = elemCtx.simulator().vanguard().grid().globalCell()[globalDofIdx];
                     failedCellsPd_.push_back(globalIdx);
                 }

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -763,7 +763,7 @@ protected:
                 try {
                     eclWell->setRadius(elemCtx, dofIdx, 0.5*completion->getDiameter());
                 }
-                catch (const std::logic_error& e)
+                catch (const std::logic_error&)
                 {}
 
                 // overwrite the automatically computed effective

--- a/tests/test_quadrature.cc
+++ b/tests/test_quadrature.cc
@@ -296,7 +296,6 @@ void testQuadrature()
 {
     std::cout << "testing SCV quadrature...\n";
 
-    std::bitset<dim> isPeriodic(false);
     std::array<int, dim> cellRes;
 
     std::fill(cellRes.begin(), cellRes.end(), 10);


### PR DESCRIPTION
i.e. on ICC. the compiler is right in producing warnings here, though.