### PR TITLE
Fix dune master

### DIFF
--- a/ebos/alucartesianindexmapper.hh
+++ b/ebos/alucartesianindexmapper.hh
@@ -225,7 +225,7 @@ namespace Ewoms
               coords[ 0 ] = gc ;
           }
           else
-            throw std::invalid_argument("cartesianCoordinate not implemented for dimension " << dimension );
+              throw std::invalid_argument("cartesianCoordinate not implemented for dimension " + std::to_string(dimension) );
         }
 
         template <class GridView>

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -39,6 +39,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <opm/material/common/Exceptions.hpp>
+#include <opm/material/common/Unused.hpp>
 
 #include <dune/grid/common/mcmgmapper.hh>
 

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -29,6 +29,8 @@
 
 #include "eclwriter.hh"
 
+#include <ewoms/models/blackoil/blackoilproperties.hh>
+
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 
@@ -44,6 +46,7 @@
 #include <opm/output/eclipse/EclipseIO.hpp>
 #endif
 
+#include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <dune/common/fvector.hh>
 
@@ -649,7 +652,7 @@ public:
     }
 
     void addRftDataToWells(Opm::data::Wells& wellDatas, size_t reportStepNum)
-    {            
+    {
         for ( const auto& well : simulator_.vanguard().schedule().getWells( reportStepNum )) {
 
             // don't bother with wells not on this process

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -39,18 +39,14 @@
 #include <opm/output/eclipse/EclipseIO.hpp>
 #endif
 
+#include <opm/grid/GridHelpers.hpp>
+
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/Exceptions.hpp>
-
-#include <boost/algorithm/string.hpp>
 
 #include <list>
 #include <utility>
 #include <string>
-#include <limits>
-#include <sstream>
-#include <fstream>
-#include <type_traits>
 
 namespace Ewoms {
 namespace Properties {
@@ -60,6 +56,9 @@ NEW_PROP_TAG(EclOutputDoublePrecision);
 
 template <class TypeTag>
 class EclWriter;
+
+template <class TypeTag>
+class EclOutputBlackOilModule;
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ewoms/linear/overlappingbcrsmatrix.hh
+++ b/ewoms/linear/overlappingbcrsmatrix.hh
@@ -89,6 +89,13 @@ public:
         build_(nativeMatrix);
     }
 
+    // this constructor is required to make the class compatible with the SeqILU class of
+    // Dune >= 2.7.
+    OverlappingBCRSMatrix(size_t numRows,
+                          size_t numCols,
+                          typename BCRSMatrix::BuildMode buildMode)
+    { throw std::logic_error("OverlappingBCRSMatrix objects cannot be build from scratch!"); }
+
     ~OverlappingBCRSMatrix()
     {
         if (overlap_.use_count() == 0)

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -35,6 +35,8 @@
 #include <dune/istl/paamg/pinfo.hh>
 #include <dune/istl/owneroverlapcopy.hh>
 
+#include <dune/common/version.hh>
+
 #include <iostream>
 
 namespace Ewoms {
@@ -94,8 +96,12 @@ class ParallelAmgBackend : public ParallelBaseBackend<TypeTag>
     typedef Dune::SeqSOR<Matrix, Vector, Vector> SequentialSmoother;
 // typedef Dune::SeqSSOR<Matrix,Vector,Vector> SequentialSmoother;
 // typedef Dune::SeqJac<Matrix,Vector,Vector> SequentialSmoother;
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2,7)
+// typedef Dune::SeqILU<Matrix,Vector,Vector> SequentialSmoother;
+#else
 // typedef Dune::SeqILU0<Matrix,Vector,Vector> SequentialSmoother;
 // typedef Dune::SeqILUn<Matrix,Vector,Vector> SequentialSmoother;
+#endif
 
 #if HAVE_MPI
     typedef Dune::OwnerOverlapCopyCommunication<Ewoms::Linear::Index>

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -482,9 +482,15 @@ SET_PROP(ParallelBaseLinearSolver, OverlappingLinearOperator)
                                                OverlappingVector> type;
 };
 
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2,7)
+SET_TYPE_PROP(ParallelBaseLinearSolver,
+              PreconditionerWrapper,
+              Ewoms::Linear::PreconditionerWrapperILU<TypeTag>);
+#else
 SET_TYPE_PROP(ParallelBaseLinearSolver,
               PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
+#endif
 
 //! set the default overlap size to 2
 SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverOverlapSize, 2);

--- a/ewoms/linear/parallelistlbackend.hh
+++ b/ewoms/linear/parallelistlbackend.hh
@@ -30,6 +30,8 @@
 #include "parallelbasebackend.hh"
 #include "istlsolverwrappers.hh"
 
+#include <dune/common/version.hh>
+
 namespace Ewoms {
 namespace Properties {
 NEW_TYPE_TAG(ParallelIstlLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
@@ -149,9 +151,15 @@ SET_TYPE_PROP(ParallelIstlLinearSolver,
               LinearSolverWrapper,
               Ewoms::Linear::SolverWrapperBiCGStab<TypeTag>);
 
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2,7)
+SET_TYPE_PROP(ParallelIstlLinearSolver,
+              PreconditionerWrapper,
+              Ewoms::Linear::PreconditionerWrapperILU<TypeTag>);
+#else
 SET_TYPE_PROP(ParallelIstlLinearSolver,
               PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILU0<TypeTag>);
+#endif
 
 //! set the GMRes restart parameter to 10 by default
 SET_INT_PROP(ParallelIstlLinearSolver, GMResRestart, 10);

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -235,16 +235,6 @@ public:
     }
 
     /*!
-     * \copydoc FvBaseDiscretization::finishInit
-     */
-    void finishInit()
-    {
-        ParentType::finishInit();
-
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-35);
-    }
-
-    /*!
      * \copydoc FvBaseDiscretization::name
      */
     static std::string name()

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -443,9 +443,6 @@ public:
                 * Toolbox::template decay<LhsEval>(fs.invB(waterPhaseIdx))
                 * Toolbox::template decay<LhsEval>(intQuants.porosity());
 
-        // avoid singular matrix if no water is present.
-        surfaceVolumeWater = Opm::max(surfaceVolumeWater, 1e-10);
-
         // polymer in water phase
         storage[contiPolymerEqIdx] += surfaceVolumeWater
                 * Toolbox::template decay<LhsEval>(intQuants.polymerConcentration())

--- a/ewoms/models/ncp/ncpnewtonmethod.hh
+++ b/ewoms/models/ncp/ncpnewtonmethod.hh
@@ -68,9 +68,7 @@ public:
      * \copydoc FvBaseNewtonMethod::FvBaseNewtonMethod(Problem& )
      */
     NcpNewtonMethod(Simulator& simulator) : ParentType(simulator)
-    {
-        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1e-35);
-    }
+    {}
 
 protected:
     friend ParentType;

--- a/tests/problems/waterairproblem.hh
+++ b/tests/problems/waterairproblem.hh
@@ -131,8 +131,13 @@ SET_STRING_PROP(WaterAirBaseProblem, GridFile, "./data/waterair.dgf");
 SET_TAG_PROP(WaterAirBaseProblem, LinearSolverSplice, ParallelIstlLinearSolver);
 SET_TYPE_PROP(WaterAirBaseProblem, LinearSolverWrapper,
               Ewoms::Linear::SolverWrapperRestartedGMRes<TypeTag>);
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2,7)
+SET_TYPE_PROP(WaterAirBaseProblem, PreconditionerWrapper,
+              Ewoms::Linear::PreconditionerWrapperILU<TypeTag>);
+#else
 SET_TYPE_PROP(WaterAirBaseProblem, PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILUn<TypeTag>);
+#endif
 SET_INT_PROP(WaterAirBaseProblem, PreconditionerOrder, 2);
 } // namespace Properties
 } // namespace Ewoms


### PR DESCRIPTION
This fixes the build on the latest master version of Dune  (i.e., what is most likely to become Dune 2.7). Probably this needs to be revised when Dune 2.7 gets released, but the changes are beneficial on their own and they're also not very complicated.