### PR TITLE
always define an index for the energy equation

### DIFF
--- a/ewoms/models/common/energymodule.hh
+++ b/ewoms/models/common/energymodule.hh
@@ -506,6 +506,12 @@ struct EnergyIndices;
 template <unsigned PVOffset>
 struct EnergyIndices<PVOffset, /*enableEnergy=*/false>
 {
+    //! The index of the primary variable representing temperature
+    enum { temperatureIdx = -1000 };
+
+    //! The index of the equation representing the conservation of energy
+    enum { energyEqIdx = -1000 };
+
 protected:
     enum { numEq_ = 0 };
 };


### PR DESCRIPTION
... even if energy conservation is disabled. The rationale is to allow  to allow constructs like

```
if (enableEnergy)
  rate[energyEqIdx] = 123.456;
```

on the flipside, this approach leads to runtime errors if the guard is forgotten and energy is disabled. That said, these errors are most likely going to be segmentation faults and should be quite easily to spot and to fix.