### PR TITLE
write the VTK output asynchronously by default for sequential simulations

### DIFF
--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -230,6 +230,11 @@ SET_BOOL_PROP(FvBaseDiscretization, EnableGridAdaptation, false);
 //! Enable the VTK output by default
 SET_BOOL_PROP(FvBaseDiscretization, EnableVtkOutput, true);
 
+//! By default, write the VTK output to asynchronously to disk
+//!
+//! This has only an effect if EnableVtkOutput is true
+SET_BOOL_PROP(FvBaseDiscretization, EnableAsyncVtkOutput, true);
+
 //! Set the format of the VTK output to ASCII by default
 SET_INT_PROP(FvBaseDiscretization, VtkOutputFormat, Dune::VTK::ascii);
 

--- a/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
+++ b/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
@@ -94,7 +94,7 @@ public:
         ++ iteration_;
         if (!vtkMultiWriter_)
             vtkMultiWriter_ =
-                new VtkMultiWriter(newtonMethod_.problem().gridView(), "convergence");
+                new VtkMultiWriter(/*async=*/false, newtonMethod_.problem().gridView(), "convergence");
         vtkMultiWriter_->beginWrite(timeStepIdx_ + iteration_ / 100.0);
     }
 

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -136,8 +136,12 @@ public:
             boundingBoxMax_[i] = gridView_.comm().max(boundingBoxMax_[i]);
         }
 
-        if (enableVtkOutput_())
-            defaultVtkWriter_ = new VtkMultiWriter(gridView_, asImp_().name());
+        if (enableVtkOutput_()) {
+            bool asyncVtkOutput =
+                simulator_.gridView().comm().size() == 1 &&
+                EWOMS_GET_PARAM(TypeTag, bool, EnableAsyncVtkOutput);
+            defaultVtkWriter_ = new VtkMultiWriter(asyncVtkOutput, gridView_, asImp_().name());
+        }
     }
 
     ~FvBaseProblem()
@@ -157,6 +161,8 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, MaxTimeStepDivisions,
                              "The maximum number of divisions by two of the timestep size "
                              "before the simulation bails out");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAsyncVtkOutput,
+                             "Dispatch a separate thread to write the VTK output");
     }
 
     /*!

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -190,6 +190,17 @@ NEW_PROP_TAG(EnableGridAdaptation);
 NEW_PROP_TAG(EnableVtkOutput);
 
 /*!
+ * \brief Determines if the VTK output is written to disk asynchronously
+ *
+ * I.e. written to disk using a separate thread. This has only an effect if
+ * EnableVtkOutput is true and if the simulation is run sequentially. The reasons for
+ * this not being used for MPI-parallel simulations are that Dune's VTK output code does
+ * not support multi-threaded multi-process VTK output and even if it would, the result
+ * would be slower than when using synchronous output.
+ */
+NEW_PROP_TAG(EnableAsyncVtkOutput);
+
+/*!
  * \brief Specify the format the VTK output is written to disk
  *
  * Possible values are:

--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -138,7 +138,7 @@ public:
         runnerMutex_.lock();
 
         threads_.resize(numWorkers);
-        for (int i = 0; i < numWorkers; ++i)
+        for (unsigned i = 0; i < numWorkers; ++i)
             // create a worker thread
             threads_[i].reset(new std::thread(startWorkerThread_, this));
     }


### PR DESCRIPTION
`Dune::VTKWriter` seems to be on the rather slow side, so threaded output writing leads to a sizeable speedup for the VTK format. For situations where an extra thread is not desireable, asynchronous VTK
output can be disabled using the `--enable-async-vtk-output=false` command-line parameter.

The main complication of this is that `Dune::VTKWriter` cannot be used in conjunction with MPI-parallel simulations because there are unnecessary calls to `MPI_barrier()` in `Dune::VTKWriter::pwrite()`
which lead to all kinds of fun since multiple threads are doing uncoordinated MPI calls in that case. (This is because the main thread needs to call MPI functions during e.g. the linear solver.) That said,
for the MPI-parallel simulations which I've tested, there was no speedup either, so asynchronous output is simply disabled for the MPI case.