### PR TITLE
disable asynchronous output for the ECL output test

### DIFF
--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -79,6 +79,7 @@ namespace Ewoms {
 namespace Properties {
 NEW_TYPE_TAG(TestEclOutputTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem));
 SET_BOOL_PROP(TestEclOutputTypeTag, EnableGravity, false);
+SET_BOOL_PROP(TestEclOutputTypeTag, EnableAsyncEclOutput, false);
 }}
 
 static const int day = 24 * 60 * 60;


### PR DESCRIPTION
this lead to non-deterministic crashes deep inside libecl. My cursory hypotheses are that this test makes the assumption that the output is written synchronously (it tries to read back the results from disk immediately) and/or that libecl is not threadsafe.