### PR TITLE
use Opm::isfinite() instead of std::isfinite(Opm::value())

### DIFF
--- a/ewoms/disc/common/fvbaselocalresidual.hh
+++ b/ewoms/disc/common/fvbaselocalresidual.hh
@@ -425,7 +425,7 @@ protected:
         size_t numDof = elemCtx.numDof(/*timeIdx=*/0);
         for (unsigned i=0; i < numDof; i++) {
             for (unsigned j = 0; j < numEq; ++ j) {
-                assert(std::isfinite(Toolbox::value(residual[i][j])));
+                assert(Opm::isfinite(residual[i][j]));
                 Opm::Valgrind::CheckDefined(residual[i][j]);
             }
         }

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -339,14 +339,14 @@ public:
             if (!FluidSystem::phaseIsActive(phaseIdx))
                 continue;
 
-            assert(std::isfinite(Toolbox::value(fluidState_.density(phaseIdx))));
-            assert(std::isfinite(Toolbox::value(fluidState_.saturation(phaseIdx))));
-            assert(std::isfinite(Toolbox::value(fluidState_.temperature(phaseIdx))));
-            assert(std::isfinite(Toolbox::value(fluidState_.pressure(phaseIdx))));
-            assert(std::isfinite(Toolbox::value(fluidState_.invB(phaseIdx))));
+            assert(Opm::isfinite(fluidState_.density(phaseIdx)));
+            assert(Opm::isfinite(fluidState_.saturation(phaseIdx)));
+            assert(Opm::isfinite(fluidState_.temperature(phaseIdx)));
+            assert(Opm::isfinite(fluidState_.pressure(phaseIdx)));
+            assert(Opm::isfinite(fluidState_.invB(phaseIdx)));
         }
-        assert(std::isfinite(Toolbox::value(fluidState_.Rs())));
-        assert(std::isfinite(Toolbox::value(fluidState_.Rv())));
+        assert(Opm::isfinite(fluidState_.Rs()));
+        assert(Opm::isfinite(fluidState_.Rv()));
 #endif
     }
 

--- a/ewoms/models/common/darcyfluxmodule.hh
+++ b/ewoms/models/common/darcyfluxmodule.hh
@@ -283,7 +283,7 @@ protected:
                     potentialGrad_[phaseIdx][dimIdx] += f[dimIdx];
 
                 for (unsigned dimIdx = 0; dimIdx < potentialGrad_[phaseIdx].size(); ++dimIdx) {
-                    if (!std::isfinite(Toolbox::value(potentialGrad_[phaseIdx][dimIdx]))) {
+                    if (!Opm::isfinite(potentialGrad_[phaseIdx][dimIdx])) {
                         throw Opm::NumericalIssue("Non-finite potential gradient for phase '"
                                                     +std::string(FluidSystem::phaseName(phaseIdx))+"'");
                     }
@@ -404,7 +404,7 @@ protected:
 
                 Opm::Valgrind::CheckDefined(potentialGrad_[phaseIdx]);
                 for (unsigned dimIdx = 0; dimIdx < potentialGrad_[phaseIdx].size(); ++dimIdx) {
-                    if (!std::isfinite(Toolbox::value(potentialGrad_[phaseIdx][dimIdx]))) {
+                    if (!Opm::isfinite(potentialGrad_[phaseIdx][dimIdx])) {
                         throw Opm::NumericalIssue("Non finite potential gradient for phase '"
                                                     +std::string(FluidSystem::phaseName(phaseIdx))+"'");
                     }
@@ -515,7 +515,7 @@ protected:
     void calculateFilterVelocity_(unsigned phaseIdx)
     {
 #ifndef NDEBUG
-        assert(std::isfinite(Toolbox::value(mobility_[phaseIdx])));
+        assert(Opm::isfinite(mobility_[phaseIdx]));
         for (unsigned i = 0; i < K_.M(); ++ i)
             for (unsigned j = 0; j < K_.N(); ++ j)
                 assert(std::isfinite(K_[i][j]));
@@ -526,7 +526,7 @@ protected:
 
 #ifndef NDEBUG
         for (unsigned i = 0; i < filterVelocity_[phaseIdx].size(); ++ i)
-            assert(std::isfinite(Toolbox::value(filterVelocity_[phaseIdx][i])));
+            assert(Opm::isfinite(filterVelocity_[phaseIdx][i]));
 #endif
     }
 


### PR DESCRIPTION
besides being briefer, this also ensures that derivatives are finite.