### PR TITLE
ebos fix and compiler workaround

### DIFF
--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -385,6 +385,30 @@ namespace Properties {
 
 /*!
  * \ingroup Properties
+ * \brief This macro provides the boiler plate code to declare a static constant member
+ *        outside of a property definition.
+ *
+ * This macro is fairly low-level and there should rarely be a need to use it.
+ */
+#define PROP_STATIC_CONST_MEMBER_DEFINITION_PREFIX_(EffTypeTagName, PropTagName) \
+    template <class TypeTag>                                            \
+    const typename Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::type \
+    Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>
+
+/*!
+ * \ingroup Properties
+ * \brief This macro provides the boiler plate code to declare a static member outside of
+ *        a property definition.
+ *
+ * This macro is fairly low-level and there should rarely be a need to use it.
+ */
+#define PROP_STATIC_MEMBER_DEFINITION_PREFIX_(EffTypeTagName, PropTagName) \
+    template <class TypeTag>                                            \
+    typename Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::type \
+    Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>
+
+/*!
+ * \ingroup Properties
  * \brief Set a property to a simple constant scalar value.
  *
  * The constant can be accessed by the \c value attribute. In order to
@@ -402,9 +426,7 @@ namespace Properties {
         typedef Scalar type;                                            \
         static const Scalar value;                                      \
     };                                                                  \
-    template <class TypeTag>                                            \
-    const typename Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::type \
-    Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::value(__VA_ARGS__)
+    PROP_STATIC_CONST_MEMBER_DEFINITION_PREFIX_(EffTypeTagName, PropTagName)::value(__VA_ARGS__)
 
 /*!
  * \ingroup Properties
@@ -423,9 +445,7 @@ namespace Properties {
         typedef std::string type;                                       \
         static const std::string value;                                 \
     };                                                                  \
-    template <class TypeTag>                                            \
-    const typename Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::type \
-    Property<TypeTag, TTAG(EffTypeTagName), PTAG(PropTagName)>::value(__VA_ARGS__)
+    PROP_STATIC_CONST_MEMBER_DEFINITION_PREFIX_(EffTypeTagName, PropTagName)::value(__VA_ARGS__)
 
 /*!
  * \ingroup Properties

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -169,9 +169,7 @@ public:
         // add the internal energy of the rock
         const auto& uRock = Opm::decay<LhsEval>(intQuants.rockInternalEnergy());
         storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
-
-        static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
-        storage[contiEnergyEqIdx] *= alpha;
+        storage[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
     }
 
     static void computeFlux(RateVector& flux,
@@ -199,9 +197,7 @@ public:
 
         // diffusive energy flux
         flux[contiEnergyEqIdx] += extQuants.energyFlux();
-
-        static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
-        flux[contiEnergyEqIdx] *= alpha;
+        flux[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
     }
 
     template <class UpstreamEval>

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -187,10 +187,8 @@ public:
         elemCtx.problem().source(source, elemCtx, dofIdx, timeIdx);
 
         // scale the source term of the energy equation
-        if (enableEnergy) {
-            static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
-            source[Indices::contiEnergyEqIdx] *= alpha;
-        }
+        if (enableEnergy)
+            source[Indices::contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
     }
 
     /*!

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -145,8 +145,12 @@ private:
     static constexpr Scalar alpha = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume) ? 1000.0 : 1.0;
 
 public:
-    static constexpr Scalar value = 1.0/(30*4184.0*alpha);
+    typedef Scalar type;
+    static const Scalar value;
 };
+
+PROP_STATIC_CONST_MEMBER_DEFINITION_PREFIX_(BlackOilModel, BlackOilEnergyScalingFactor)
+    ::value = 1.0/(30*4184.0*alpha);
 
 // by default, ebos formulates the conservation equations in terms of mass not surface
 // volumes


### PR DESCRIPTION
this PR contains two relative straight-forward changes: the first is a work around for a likely `constexpr` related compiler bug of older GCC versions, the second fixes https://github.com/OPM/opm-simulators/issues/1453. I think both should be part of the 2018.04 release.

thanks goes to @bska for finding the issue with initial temperature.