### PR TITLE
Improve tasklets

### DIFF
--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -61,6 +61,25 @@ private:
     int referenceCount_;
 };
 
+class TaskletRunner;
+
+// this class stores the thread local static attributes for the TaskletRunner class. we
+// cannot put them directly into TaskletRunner because defining static members for
+// non-template classes in headers leads the linker to choke in case multiple compile
+// units are used.
+template <class Dummy = void>
+struct TaskletRunnerHelper_
+{
+    static thread_local TaskletRunner* taskletRunner_;
+    static thread_local int workerThreadIndex_;
+};
+
+template <class Dummy>
+thread_local TaskletRunner* TaskletRunnerHelper_<Dummy>::taskletRunner_ = nullptr;
+
+template <class Dummy>
+thread_local int TaskletRunnerHelper_<Dummy>::workerThreadIndex_ = -1;
+
 /*!
  * \brief Handles where a given tasklet is run.
  *
@@ -136,7 +155,7 @@ public:
         threads_.resize(numWorkers);
         for (unsigned i = 0; i < numWorkers; ++i)
             // create a worker thread
-            threads_[i].reset(new std::thread(startWorkerThread_, this));
+            threads_[i].reset(new std::thread(startWorkerThread_, this, i));
     }
 
     /*!
@@ -157,6 +176,24 @@ public:
                 thread->join();
         }
     }
+
+    /*!
+     * \brief Returns the index of the current worker thread.
+     *
+     * If the current thread is not a worker thread, -1 is returned.
+     */
+    int workerThreadIndex() const
+    {
+        if (TaskletRunnerHelper_<void>::taskletRunner_ != this)
+            return -1;
+        return TaskletRunnerHelper_<void>::workerThreadIndex_;
+    }
+
+    /*!
+     * \brief Returns the number of worker threads for the tasklet runner.
+     */
+    int numWorkerThreads() const
+    { return threads_.size(); }
 
     /*!
      * \brief Add a new tasklet.
@@ -205,8 +242,13 @@ public:
 
 protected:
     // main function of the worker thread
-    static void startWorkerThread_(TaskletRunner* taskletRunner)
-    { taskletRunner->run_(); }
+    static void startWorkerThread_(TaskletRunner* taskletRunner, int workerThreadIndex)
+    {
+        TaskletRunnerHelper_<void>::taskletRunner_ = taskletRunner;
+        TaskletRunnerHelper_<void>::workerThreadIndex_ = workerThreadIndex;
+
+        taskletRunner->run_();
+    }
 
     //! do the work until the queue received an end tasklet
     void run_()

--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -220,7 +220,8 @@ protected:
                 [this]() -> bool
                 { return !taskletQueue_.empty(); };
 
-            workAvailableCondition_.wait(lock, /*predicate=*/workIsAvailable);
+            if (!workIsAvailable())
+                workAvailableCondition_.wait(lock, /*predicate=*/workIsAvailable);
 
             // remove tasklet from queue
             std::shared_ptr<TaskletInterface> tasklet = taskletQueue_.front();
@@ -239,10 +240,7 @@ protected:
                 // remove tasklets from the queue as soon as their reference count
                 // reaches zero, i.e. the tasklet has been run often enough.
                 taskletQueue_.pop();
-
             lock.unlock();
-            if (workIsAvailable())
-                workAvailableCondition_.notify_one();
 
             // execute tasklet
             tasklet->run();

--- a/tests/test_tasklets.cc
+++ b/tests/test_tasklets.cc
@@ -33,6 +33,8 @@
 #include <chrono>
 #include <iostream>
 
+std::mutex outputMutex;
+
 Ewoms::TaskletRunner *runner;
 
 class SleepTasklet : public Ewoms::TaskletInterface
@@ -49,7 +51,9 @@ public:
     {
         assert(0 <= runner->workerThreadIndex() && runner->workerThreadIndex() < runner->numWorkerThreads());
         std::this_thread::sleep_for(std::chrono::milliseconds(mseconds_));
+        outputMutex.lock();
         std::cout << "Sleep tasklet " << n_ << " of " << mseconds_ << " ms completed by worker thread " << runner->workerThreadIndex() << std::endl;
+        outputMutex.unlock();
     }
 
 private:


### PR DESCRIPTION
this PR adds a few minor improvements to the tasklet mechanism. in particular, the there now is the concept of a "worker thread index", which should make it relatively straight-forward to replace OpenMP by tasklets.