### PR TITLE
[bgufix][femcompat] remove operator << and operator >> for __float128

### DIFF
--- a/ebos/femcpgridcompat.hh
+++ b/ebos/femcpgridcompat.hh
@@ -97,34 +97,6 @@ namespace Dune
       }
     };
 
-    ////////////////////////////////////////////////////////////
-    //
-    //  operator << and operator >> for __float128
-    //
-    ////////////////////////////////////////////////////////////
-#if HAVE_QUAD
-    template< class Traits >
-    inline OutStreamInterface< Traits > &
-      operator<< ( OutStreamInterface< Traits >& out,
-                   const __float128 value )
-    {
-      double val = double( value );
-      out.writeDouble( val );
-      return out;
-    }
-
-    template< class Traits >
-    inline InStreamInterface< Traits > &
-      operator>> ( InStreamInterface< Traits >& in,
-                   __float128& value )
-    {
-      double val;
-      in.readDouble( val );
-      value = val;
-      return in;
-    }
-#endif
-
   } // namespace Fem
 
 } // end namespace Dune


### PR DESCRIPTION
This code has been previously moved to opm-material and accidentally came into the code from the last merged request since this section is not tested since it depends on optional thrid party modules.