### PR TITLE
Some property- and parameter system improvements

### DIFF
--- a/ebos/ebos.cc
+++ b/ebos/ebos.cc
@@ -32,10 +32,11 @@
 
 #include "eclproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(EclProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/ebos/eclalugridvanguard.hh
+++ b/ebos/eclalugridvanguard.hh
@@ -38,14 +38,20 @@ namespace Ewoms {
 template <class TypeTag>
 class EclAluGridVanguard;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(EclAluGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 // declare the properties
 SET_TYPE_PROP(EclAluGridVanguard, Vanguard, Ewoms::EclAluGridVanguard<TypeTag>);
 SET_TYPE_PROP(EclAluGridVanguard, Grid,  Dune::ALUGrid<3, 3, Dune::cube, Dune::nonconforming>);
 SET_TYPE_PROP(EclAluGridVanguard, EquilGrid, Dune::CpGrid);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -63,9 +63,11 @@ NEW_PROP_TAG(EquilGrid);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(EclDeckFileName);
 NEW_PROP_TAG(EclOutputDir);
+NEW_PROP_TAG(EclOutputInterval);
 
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "ECLDECK.DATA");
 SET_STRING_PROP(EclBaseVanguard, EclOutputDir, ".");
+SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 
 END_PROPERTIES
 
@@ -101,6 +103,8 @@ public:
                              "The name of the file which contains the ECL deck to be simulated");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, EclOutputDir,
                              "The directory to which the ECL result files are written");
+        EWOMS_REGISTER_PARAM(TypeTag, int, EclOutputInterval,
+                             "The number of report steps that ought to be skipped between two writes of ECL results");
     }
 
     /*!
@@ -226,6 +230,12 @@ public:
         // specify the directory output. This is not a very nice mechanism because
         // the eclState is supposed to be immutable here, IMO.
         ioConfig.setOutputDir(outputDir);
+
+        // Possibly override IOConfig setting for how often RESTART files should get
+        // written to disk (every N report step)
+        int outputInterval = EWOMS_GET_PARAM(TypeTag, int, EclOutputInterval);
+        if (outputInterval >= 0)
+            eclState_->getRestartConfig().overrideRestartWriteInterval(outputInterval);
 
         asImp_().createGrids_();
         asImp_().filterCompletions_();

--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -51,8 +51,10 @@
 namespace Ewoms {
 template <class TypeTag>
 class EclBaseVanguard;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(EclBaseVanguard);
 
 // declare the properties required by the for the ecl simulator vanguard
@@ -64,7 +66,10 @@ NEW_PROP_TAG(EclOutputDir);
 
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "ECLDECK.DATA");
 SET_STRING_PROP(EclBaseVanguard, EclOutputDir, ".");
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -41,8 +41,10 @@
 namespace Ewoms {
 template <class TypeTag>
 class EclCpGridVanguard;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(EclCpGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 NEW_PROP_TAG(ExportGlobalTransmissibility);
@@ -52,7 +54,10 @@ SET_TYPE_PROP(EclCpGridVanguard, Vanguard, Ewoms::EclCpGridVanguard<TypeTag>);
 SET_TYPE_PROP(EclCpGridVanguard, Grid, Dune::CpGrid);
 SET_TYPE_PROP(EclCpGridVanguard, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
 SET_BOOL_PROP(EclCpGridVanguard, ExportGlobalTransmissibility, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -37,8 +37,8 @@
 
 #include <vector>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(FluidSystem);
 NEW_PROP_TAG(GridView);
@@ -46,7 +46,10 @@ NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(MaterialLaw);
 NEW_PROP_TAG(EnableTemperature);
 NEW_PROP_TAG(EnableEnergy);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -41,10 +41,13 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(MaterialLaw);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 template <class TypeTag>
 class EclTransIntensiveQuantities;

--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -52,12 +52,15 @@
 
 #include <type_traits>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the Ecl-output
 NEW_TYPE_TAG(EclOutputBlackOil);
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 // forward declaration
 template <class TypeTag>

--- a/ebos/eclpolyhedralgridvanguard.hh
+++ b/ebos/eclpolyhedralgridvanguard.hh
@@ -34,15 +34,20 @@
 namespace Ewoms {
 template <class TypeTag>
 class EclPolyhedralGridVanguard;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(EclPolyhedralGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
 // declare the properties
 SET_TYPE_PROP(EclPolyhedralGridVanguard, Vanguard, Ewoms::EclPolyhedralGridVanguard<TypeTag>);
 SET_TYPE_PROP(EclPolyhedralGridVanguard, Grid, Dune::PolyhedralGrid<3, 3>);
 SET_TYPE_PROP(EclPolyhedralGridVanguard, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -99,8 +99,10 @@
 namespace Ewoms {
 template <class TypeTag>
 class EclProblem;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 #if EBOS_USE_ALUGRID
 NEW_TYPE_TAG(EclBaseProblem, INHERITS_FROM(EclAluGridVanguard, EclOutputBlackOil));
 #else
@@ -283,7 +285,10 @@ SET_BOOL_PROP(EclBaseProblem, EnableEnergy, false);
 
 // disable thermal flux boundaries by default
 SET_BOOL_PROP(EclBaseProblem, EnableThermalFluxBoundaries, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -49,14 +49,17 @@
 #include <vector>
 #include <unordered_map>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Evaluation);
 NEW_PROP_TAG(ElementContext);
 NEW_PROP_TAG(FluidSystem);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/ecltransmissibility.hh
+++ b/ebos/ecltransmissibility.hh
@@ -50,15 +50,18 @@
 #include <vector>
 #include <unordered_map>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(ElementMapper);
 NEW_PROP_TAG(EnableEnergy);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -50,10 +50,13 @@
 #include <string>
 #include <vector>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Grid);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup EclBlackOilSimulator

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -236,26 +236,28 @@ public:
     void restartBegin()
     {
         bool enableHysteresis = simulator_.problem().materialLawManager()->enableHysteresis();
-        std::vector<Opm::RestartKey> solution_keys {{"PRESSURE" , Opm::UnitSystem::measure::pressure},
-                                                    {"SWAT" ,     Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},
-                                                    {"SGAS" ,     Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))},
-                                                    {"TEMP" ,     Opm::UnitSystem::measure::temperature}, // always required for now
-                                                    {"RS" ,       Opm::UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas()},
-                                                    {"RV" ,       Opm::UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil()},
-                                                    {"SOMAX",     Opm::UnitSystem::measure::identity, simulator_.problem().vapparsActive()},
-                                                    {"PCSWM_OW",  Opm::UnitSystem::measure::identity, enableHysteresis},
-                                                    {"KRNSW_OW",  Opm::UnitSystem::measure::identity, enableHysteresis},
-                                                    {"PCSWM_GO",  Opm::UnitSystem::measure::identity, enableHysteresis},
-                                                    {"KRNSW_GO",  Opm::UnitSystem::measure::identity, enableHysteresis}};
+        std::vector<Opm::RestartKey> solutionKeys{
+            {"PRESSURE" , Opm::UnitSystem::measure::pressure},
+            {"SWAT" ,     Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx))},
+            {"SGAS" ,     Opm::UnitSystem::measure::identity, static_cast<bool>(FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx))},
+            {"TEMP" ,     Opm::UnitSystem::measure::temperature}, // always required for now
+            {"RS" ,       Opm::UnitSystem::measure::gas_oil_ratio, FluidSystem::enableDissolvedGas()},
+            {"RV" ,       Opm::UnitSystem::measure::oil_gas_ratio, FluidSystem::enableVaporizedOil()},
+            {"SOMAX",     Opm::UnitSystem::measure::identity, simulator_.problem().vapparsActive()},
+            {"PCSWM_OW",  Opm::UnitSystem::measure::identity, enableHysteresis},
+            {"KRNSW_OW",  Opm::UnitSystem::measure::identity, enableHysteresis},
+            {"PCSWM_GO",  Opm::UnitSystem::measure::identity, enableHysteresis},
+            {"KRNSW_GO",  Opm::UnitSystem::measure::identity, enableHysteresis}
+        };
 
-        std::vector<Opm::RestartKey> extra_keys = {{"OPMEXTRA", Opm::UnitSystem::measure::identity, false}};
+        std::vector<Opm::RestartKey> extraKeys = {{"OPMEXTRA", Opm::UnitSystem::measure::identity, false}};
 
         unsigned episodeIdx = simulator_.episodeIndex();
         const auto& gridView = simulator_.vanguard().gridView();
         unsigned numElements = gridView.size(/*codim=*/0);
         eclOutputModule_.allocBuffers(numElements, episodeIdx, /*isSubStep=*/false, /*log=*/false);
 
-        auto restartValues = eclIO_->loadRestart(solution_keys, extra_keys);
+        auto restartValues = eclIO_->loadRestart(solutionKeys, extraKeys);
         for (unsigned elemIdx = 0; elemIdx < numElements; ++elemIdx) {
             unsigned globalIdx = collectToIORank_.localIdxToGlobalIdx(elemIdx);
             eclOutputModule_.setRestart(restartValues.solution, elemIdx, globalIdx);

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -51,12 +51,15 @@
 #include <utility>
 #include <string>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(EnableEclOutput);
 NEW_PROP_TAG(EnableAsyncEclOutput);
 NEW_PROP_TAG(EclOutputDoublePrecision);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 template <class TypeTag>
 class EclWriter;

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -59,12 +59,15 @@
 #include <utility>
 #include <vector>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(FluidSystem);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /**
  * Types and routines that collectively implement a basic

--- a/ewoms/common/basicproperties.hh
+++ b/ewoms/common/basicproperties.hh
@@ -40,8 +40,8 @@
 
 #include <string>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 ///////////////////////////////////
 // Type tag definitions:
 //
@@ -185,7 +185,7 @@ SET_SCALAR_PROP(NumericModel, RestartTime, -1e35);
 //! By default, do not force any time steps
 SET_STRING_PROP(NumericModel, PredeterminedTimeStepsFile, "");
 
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -165,7 +165,10 @@ private:
 };
 } // namespace Parameters
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 // type tag which is supposed to spliced in or inherited from if the
 // parameter system is to be used
 NEW_TYPE_TAG(ParameterSystem);
@@ -214,7 +217,10 @@ private:
     }
 };
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 namespace Parameters {
 // function prototype declarations

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -130,7 +130,8 @@ struct ParamInfo
 
 // forward declaration
 template <class TypeTag, class ParamType, class PropTag>
-const ParamType get(const char *propTagName, const char *paramName,
+const ParamType get(const char *propTagName,
+                    const char *paramName,
                     bool errorIfNotRegistered = true);
 
 class ParamRegFinalizerBase_
@@ -145,7 +146,8 @@ template <class TypeTag, class ParamType, class PropTag>
 class ParamRegFinalizer_ : public ParamRegFinalizerBase_
 {
 public:
-    ParamRegFinalizer_(const std::string& paramName) : paramName_(paramName)
+    ParamRegFinalizer_(const std::string& paramName)
+        : paramName_(paramName)
     {}
 
     void retrieve()
@@ -169,8 +171,6 @@ namespace Properties {
 NEW_TYPE_TAG(ParameterSystem);
 
 NEW_PROP_TAG(ParameterMetaData);
-NEW_PROP_TAG(ParameterGroupPrefix);
-NEW_PROP_TAG(Description);
 
 
 //! Set the ParameterMetaData property
@@ -213,9 +213,6 @@ private:
         return obj;
     }
 };
-
-SET_STRING_PROP(ParameterSystem, ParameterGroupPrefix, "");
-SET_STRING_PROP(ParameterSystem, Description, "");
 
 } // namespace Properties
 
@@ -346,28 +343,28 @@ void printCompileTimeParamList_(std::ostream& os,
  * \ingroup Parameter
  * \brief Print a usage message for all run-time parameters.
  *
+ * \param helpPreamble The string that is printed after the error message and before the
+ *                     list of parameters.
+ * \param errorMsg The error message to be printed, if any
  * \param os The \c std::ostream which should be used.
- * \param progName The name of the program
  */
 template <class TypeTag>
-void printUsage(const std::string& progName, const std::string& errorMsg = "",
-                bool handleHelp = true, std::ostream& os = std::cerr)
+void printUsage(const std::string& helpPreamble,
+                const std::string& errorMsg = "",
+                std::ostream& os = std::cerr)
 {
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
-    std::string desc = GET_PROP_VALUE(TypeTag, Description);
 
     if (errorMsg != "") {
         os << errorMsg << "\n"
            << "\n";
     }
 
-    os << "Usage: " << progName << " [OPTIONS]\n";
-    if (desc != "")
-        os << desc << "\n";
+    os << helpPreamble;
     os << "\n";
     os << "Recognized options:\n";
 
-    if (handleHelp) {
+    if (!helpPreamble.empty()) {
         ParamInfo pInfo;
         pInfo.paramName = "h,--help";
         pInfo.usageString = "Print this help message and exit";
@@ -381,6 +378,19 @@ void printUsage(const std::string& progName, const std::string& errorMsg = "",
     }
 }
 
+/// \cond 0
+inline int noPositionalParameters_(std::string& errorMsg,
+                                   int argc,
+                                   const char** argv,
+                                   int paramIdx,
+                                   int posParamIdx)
+{
+    errorMsg = std::string("Illegal parameter \"")+argv[paramIdx]+"\".";
+    return 0;
+}
+
+/// \endcond
+
 /*!
  * \ingroup Parameter
  * \brief Parse the parameters provided on the command line.
@@ -391,37 +401,51 @@ void printUsage(const std::string& progName, const std::string& errorMsg = "",
  *             main() function
  * \param argv The array of strings passed by the operating system to the main()
  *             function
- * \param handleHelp Set to true if the function should deal with the -h and
- *                   --help parameters
+ * \param helpPreamble If non-empty, the --help and -h parameters will be recognized and
+ *                     the content of the string will be printed before the list of
+ *                     command line parameters
  * \return Empty string if everything worked out. Otherwise the thing that could
  *         not be read.
  */
-template <class TypeTag>
-std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp = true)
+template <class TypeTag, class PositionalArgumentCallback>
+std::string parseCommandLineOptions(int argc,
+                                    const char **argv,
+                                    const std::string& helpPreamble = "",
+                                    const PositionalArgumentCallback& posArgCallback = noPositionalParameters_)
 {
     Dune::ParameterTree& paramTree = GET_PROP(TypeTag, ParameterMetaData)::tree();
 
-    if (handleHelp) {
+    // handle the "--help" parameter
+    if (!helpPreamble.empty()) {
         for (int i = 1; i < argc; ++i) {
             if (std::string("-h") == argv[i]
                 || std::string("--help") == argv[i]) {
-                printUsage<TypeTag>(argv[0], "", handleHelp, std::cout);
+                printUsage<TypeTag>(helpPreamble, /*errorMsg=*/"", std::cout);
                 return "Help called";
             }
         }
     }
 
-    // All command line options need to start with '-'
+    int numPositionalParams = 0;
     for (int i = 1; i < argc; ++i) {
+        // All non-positional command line options need to start with '-'
         if (argv[i][0] != '-') {
-            std::ostringstream oss;
-            oss << "Command line argument " << i
-                << " (='" << argv[i] << "') is invalid.";
+            std::string errorMsg;
+            int numHandled = posArgCallback(errorMsg, argc, argv, i, numPositionalParams);
 
-            if (handleHelp)
-                printUsage<TypeTag>(argv[0], oss.str(), handleHelp, std::cerr);
+            if (numHandled < 1) {
+                std::ostringstream oss;
 
-            return oss.str();
+                if (!helpPreamble.empty())
+                    printUsage<TypeTag>(helpPreamble, errorMsg, std::cerr);
+
+                return errorMsg;
+            }
+            else {
+                ++ numPositionalParams;
+                i += numHandled - 1;
+                continue;
+            }
         }
 
         std::string paramName, paramValue;
@@ -437,9 +461,8 @@ std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp
                     << " ('" << argv[i] << "') "
                     << "is invalid because it does not start with a letter.";
 
-                if (handleHelp)
-                    printUsage<TypeTag>(argv[0], oss.str(), handleHelp,
-                                        std::cerr);
+                if (!helpPreamble.empty())
+                    printUsage<TypeTag>(helpPreamble, oss.str(), std::cerr);
 
                 return oss.str();
             }
@@ -475,9 +498,8 @@ std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp
                             << " ('" << argv[i] << "')"
                             << " is invalid (ends with a '-' character).";
 
-                        if (handleHelp)
-                            printUsage<TypeTag>(argv[0], oss.str(), handleHelp,
-                                                std::cerr);
+                        if (!helpPreamble.empty())
+                            printUsage<TypeTag>(helpPreamble, oss.str(), std::cerr);
                         return oss.str();
                     }
                     else if (s[j] == '-') {
@@ -486,23 +508,20 @@ std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp
                             << " ('" << argv[i] << "'): "
                             << "'--' in parameter name.";
 
-                        if (handleHelp)
-                            printUsage<TypeTag>(argv[0], oss.str(), handleHelp,
-                                                std::cerr);
+                        if (!helpPreamble.empty())
+                            printUsage<TypeTag>(helpPreamble, oss.str(), std::cerr);
                         return oss.str();
                     }
                     s[j] = static_cast<char>(std::toupper(s[j]));
                 }
                 else if (!std::isalnum(s[j])) {
                     std::ostringstream oss;
-                    oss << "Parameter name of argument " << i
-                        << " ('" << argv[i] << "')"
+                    oss << "Parameter name '" << argv[i] << "'"
                         << " is invalid (character '" << s[j]
                         << "' is not a letter or digit).";
 
-                    if (handleHelp)
-                        printUsage<TypeTag>(argv[0], oss.str(), handleHelp,
-                                            std::cerr);
+                    if (!helpPreamble.empty())
+                        printUsage<TypeTag>(helpPreamble, oss.str(), std::cerr);
                     return oss.str();
                 }
 
@@ -517,9 +536,8 @@ std::string parseCommandLineOptions(int argc, const char **argv, bool handleHelp
             if (argc == i + 1 || argv[i + 1][0] == '-') {
                 std::ostringstream oss;
                 oss << "No argument given for parameter '" << argv[i] << "'!";
-                if (handleHelp)
-                    printUsage<TypeTag>(argv[0], oss.str(), handleHelp,
-                                        std::cerr);
+                if (!helpPreamble.empty())
+                    printUsage<TypeTag>(helpPreamble, oss.str(), std::cerr);
                 return oss.str();
             }
 
@@ -649,7 +667,8 @@ class Param
 
 public:
     template <class ParamType, class PropTag>
-    static const ParamType get(const char *propTagName, const char *paramName,
+    static const ParamType get(const char *propTagName,
+                               const char *paramName,
                                bool errorIfNotRegistered = true)
     {
         return retrieve_<ParamType, PropTag>(propTagName,
@@ -735,23 +754,14 @@ private:
         // NewtonWriteConvergence = true
         std::string canonicalName(paramName);
 
-        std::string modelParamGroup(GET_PROP_VALUE(TypeTag,
-                                                   ParameterGroupPrefix));
-        if (modelParamGroup.size()) {
-            canonicalName.insert(0, ".");
-            canonicalName.insert(0, modelParamGroup);
-        }
-
         // retrieve actual parameter from the parameter tree
-        const ParamType defaultValue =
-            GET_PROP_VALUE_(TypeTag, PropTag);
+        const ParamType defaultValue = GET_PROP_VALUE_(TypeTag, PropTag);
         return ParamsMeta::tree().template get<ParamType>(canonicalName, defaultValue  );
     }
 };
 
 template <class TypeTag, class ParamType, class PropTag>
-const ParamType get(const char *propTagName, const char *paramName,
-                    bool errorIfNotRegistered)
+const ParamType get(const char *propTagName, const char *paramName, bool errorIfNotRegistered)
 {
     return Param<TypeTag>::template get<ParamType, PropTag>(propTagName,
                                                             paramName,

--- a/ewoms/common/propertysystem.hh
+++ b/ewoms/common/propertysystem.hh
@@ -130,6 +130,18 @@ namespace Properties {
 
 /*!
  * \ingroup Properties
+ * \brief Indicates that property definitions follow
+ */
+#define BEGIN_PROPERTIES namespace Ewoms { namespace Properties {
+
+/*!
+ * \ingroup Properties
+ * \brief Indicates that all properties have been specified (for now)
+ */
+#define END_PROPERTIES }}
+
+/*!
+ * \ingroup Properties
  * \brief Convert a type tag name to a type
  *
  * The main advantage of the type of a \c TypeTag is that it can be

--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -45,8 +45,8 @@
 #include <string>
 #include <memory>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridView);
@@ -56,7 +56,10 @@ NEW_PROP_TAG(EndTime);
 NEW_PROP_TAG(RestartTime);
 NEW_PROP_TAG(InitialTimeStepSize);
 NEW_PROP_TAG(PredeterminedTimeStepsFile);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Common

--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -68,9 +68,9 @@
 #include <mpi.h>
 #endif
 
-namespace Ewoms {
+BEGIN_PROPERTIES
+
 // forward declaration of property tags
-namespace Properties {
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(ThreadManager);
@@ -78,8 +78,9 @@ NEW_PROP_TAG(PrintProperties);
 NEW_PROP_TAG(PrintParameters);
 NEW_PROP_TAG(ParameterFile);
 NEW_PROP_TAG(Problem);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
+
 //! \cond SKIP_THIS
 
 namespace Ewoms {

--- a/ewoms/disc/common/baseauxiliarymodule.hh
+++ b/ewoms/disc/common/baseauxiliarymodule.hh
@@ -34,8 +34,8 @@
 #include <set>
 #include <vector>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(AuxModule);
 
 // declare the properties required by the for the ecl grid manager
@@ -45,7 +45,10 @@ NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(DofMapper);
 NEW_PROP_TAG(GlobalEqVector);
 NEW_PROP_TAG(JacobianMatrix);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup ModelModules

--- a/ewoms/disc/common/fvbaseadlocallinearizer.hh
+++ b/ewoms/disc/common/fvbaseadlocallinearizer.hh
@@ -44,8 +44,10 @@ namespace Ewoms {
 // forward declaration
 template<class TypeTag>
 class FvBaseAdLocalLinearizer;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 // declare the property tags required for the finite differences local linearizer
 NEW_TYPE_TAG(AutoDiffLocalLinearizer);
 
@@ -78,7 +80,9 @@ public:
     typedef Opm::DenseAd::Evaluation<Scalar, numEq> type;
 };
 
-} // namespace Properties
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FiniteVolumeDiscretizations

--- a/ewoms/disc/common/fvbaseconstraints.hh
+++ b/ewoms/disc/common/fvbaseconstraints.hh
@@ -31,10 +31,13 @@
 #include <ewoms/common/propertysystem.hh>
 #include <opm/material/common/Valgrind.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(PrimaryVariables);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FiniteVolumeDiscretizations

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -85,7 +85,10 @@ namespace Ewoms {
 template<class TypeTag>
 class FvBaseDiscretization;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 //! Set the default type for the time manager
 SET_TYPE_PROP(FvBaseDiscretization, Simulator, Ewoms::Simulator<TypeTag>);
 
@@ -266,7 +269,10 @@ SET_BOOL_PROP(FvBaseDiscretization, ExtensiveStorageTerm, false);
 // use volumetric residuals is default
 SET_BOOL_PROP(FvBaseDiscretization, UseVolumetricResidual, true);
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FiniteVolumeDiscretizations

--- a/ewoms/disc/common/fvbasefdlocallinearizer.hh
+++ b/ewoms/disc/common/fvbasefdlocallinearizer.hh
@@ -47,7 +47,10 @@ namespace Ewoms {
 template<class TypeTag>
 class FvBaseFdLocalLinearizer;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 // declare the property tags required for the finite differences local linearizer
 NEW_TYPE_TAG(FiniteDifferenceLocalLinearizer);
 
@@ -87,7 +90,10 @@ SET_INT_PROP(FiniteDifferenceLocalLinearizer, NumericDifferenceMethod, +1);
 SET_SCALAR_PROP(FiniteDifferenceLocalLinearizer,
                 BaseEpsilon,
                 std::max<Scalar>(0.9123e-10, std::numeric_limits<Scalar>::epsilon()*1.23e3));
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FiniteVolumeDiscretizations

--- a/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
+++ b/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
@@ -33,18 +33,20 @@
 
 #include <iostream>
 
-namespace Ewoms {
 //! \cond SKIP_THIS
-namespace Properties {
+BEGIN_PROPERTIES
+
 // forward declaration of the required property tags
 NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(NewtonMethod);
 NEW_PROP_TAG(SolutionVector);
 NEW_PROP_TAG(GlobalEqVector);
 NEW_PROP_TAG(VtkOutputFormat);
-} // namespace Properties
+
+END_PROPERTIES
 //! \endcond
 
+namespace Ewoms {
 /*!
  * \ingroup FiniteVolumeDiscretizations
  *

--- a/ewoms/disc/common/fvbasenewtonmethod.hh
+++ b/ewoms/disc/common/fvbasenewtonmethod.hh
@@ -42,8 +42,8 @@ template <class TypeTag>
 class FvBaseNewtonConvergenceWriter;
 } // namespace Ewoms
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! create a type tag for the Newton method of the finite-volume discretization
 NEW_TYPE_TAG(FvBaseNewtonMethod, INHERITS_FROM(NewtonMethod));
 
@@ -73,7 +73,10 @@ SET_TYPE_PROP(FvBaseNewtonMethod, NewtonMethod,
               typename GET_PROP_TYPE(TypeTag, DiscNewtonMethod));
 SET_TYPE_PROP(FvBaseNewtonMethod, NewtonConvergenceWriter,
               Ewoms::FvBaseNewtonConvergenceWriter<TypeTag>);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FiniteVolumeDiscretizations

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -166,6 +166,60 @@ public:
     }
 
     /*!
+     * \brief Returns the string that is printed before the list of command line
+     *        parameters in the help message.
+     *
+     * If the returned string is empty, no help message will be generated.
+     */
+    static std::string helpPreamble(int argc OPM_UNUSED,
+                                    const char **argv)
+    {
+        std::string desc = Implementation::briefDescription();
+        if (!desc.empty())
+            desc = desc + "\n";
+
+        return
+            "Usage: "+std::string(argv[0]) + " [OPTIONS]\n"
+            + desc;
+    }
+
+    /*!
+     * \brief Returns a human readable description of the problem for the help message
+     *
+     * The problem description is printed as part of the --help message. It is optional
+     * and should not exceed one or two lines of text.
+     */
+    static std::string briefDescription()
+    { return ""; }
+
+    // TODO (?): detailedDescription()
+
+    /*!
+     * \brief Handles positional command line parameters.
+     *
+     * Positional parameters are parameters that are not prefixed by any parameter name.
+     *
+     * \param errorMsg If the positional argument cannot be handled, this is the reason why
+     * \param argc The total number of command line parameters
+     * \param argv The string value of the command line parameters
+     * \param paramIdx The index of the positional parameter in the array of all parameters
+     * \param posParamIdx The number of the positional parameter encountered so far
+     *
+     * \return The number of array entries which ought to be skipped before processing
+     *         the next regular parameter. If this is less than 1, it indicated that the
+     *         positional parameter was invalid.
+     */
+    static int handlePositionalParameter(std::string& errorMsg,
+                                         int argc OPM_UNUSED,
+                                         const char** argv,
+                                         int paramIdx,
+                                         int posParamIdx OPM_UNUSED)
+    {
+        errorMsg = std::string("Illegal parameter \"")+argv[paramIdx]+"\".";
+        return 0;
+    }
+
+    /*!
      * \brief Called by the Ewoms::Simulator in order to initialize the problem.
      *
      * If you overload this method don't forget to call ParentType::finishInit()

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -38,8 +38,8 @@
 #include <ewoms/io/vtkprimaryvarsmodule.hh>
 #include <ewoms/linear/parallelbicgstabbackend.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for models based on the finite volume schemes
 NEW_TYPE_TAG(FvBaseDiscretization,
              INHERITS_FROM(ImplicitModel,
@@ -303,6 +303,6 @@ NEW_PROP_TAG(ExtensiveStorageTerm);
 //! \brief Specify whether to use volumetric residuals or not
 NEW_PROP_TAG(UseVolumetricResidual);
 
-}} // namespace Properties, Ewoms
+END_PROPERTIES
 
 #endif

--- a/ewoms/disc/ecfv/ecfvdiscretization.hh
+++ b/ewoms/disc/ecfv/ecfvdiscretization.hh
@@ -48,8 +48,8 @@ template <class TypeTag>
 class EcfvDiscretization;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! Set the stencil
 SET_PROP(EcfvDiscretization, Stencil)
 {
@@ -112,8 +112,7 @@ SET_BOOL_PROP(EcfvDiscretization, LinearizeNonLocalElements, true);
 //! conditions cannot occur since each matrix/vector entry is written exactly once
 SET_BOOL_PROP(EcfvDiscretization, UseLinearizationLock, false);
 
-} // namespace Properties
-} // namespace Ewoms
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/disc/ecfv/ecfvproperties.hh
+++ b/ewoms/disc/ecfv/ecfvproperties.hh
@@ -33,10 +33,11 @@
 
 #include <ewoms/common/propertysystem.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for models based on the ECFV-scheme
 NEW_TYPE_TAG(EcfvDiscretization, INHERITS_FROM(FvBaseDiscretization));
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/disc/vcfv/vcfvdiscretization.hh
+++ b/ewoms/disc/vcfv/vcfvdiscretization.hh
@@ -48,7 +48,10 @@ namespace Ewoms {
 template <class TypeTag>
 class VcfvDiscretization;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 //! Set the stencil
 SET_PROP(VcfvDiscretization, Stencil)
 {
@@ -114,7 +117,10 @@ public:
 //! of the local process' grid partition
 SET_BOOL_PROP(VcfvDiscretization, LinearizeNonLocalElements, false);
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup VcfvDiscretization

--- a/ewoms/disc/vcfv/vcfvproperties.hh
+++ b/ewoms/disc/vcfv/vcfvproperties.hh
@@ -33,14 +33,15 @@
 
 #include <ewoms/common/propertysystem.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for models based on the VCFV-scheme
 NEW_TYPE_TAG(VcfvDiscretization, INHERITS_FROM(FvBaseDiscretization));
 
 //! Use P1 finite-elements gradients instead of two-point gradients. Note that setting
 //! this property to true requires the dune-localfunctions module to be available.
 NEW_PROP_TAG(UseP1FiniteElementGradients);
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/io/baseoutputmodule.hh
+++ b/ewoms/io/baseoutputmodule.hh
@@ -44,8 +44,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // forward definition of property tags
 NEW_PROP_TAG(NumPhases);
 NEW_PROP_TAG(NumComponents);
@@ -59,7 +59,10 @@ NEW_PROP_TAG(GridView);
 NEW_PROP_TAG(ElementContext);
 NEW_PROP_TAG(FluidSystem);
 NEW_PROP_TAG(DiscBaseOutputModule);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 #if __GNUC__ || __clang__
 #pragma GCC diagnostic push

--- a/ewoms/io/basevanguard.hh
+++ b/ewoms/io/basevanguard.hh
@@ -39,8 +39,8 @@
 #include <type_traits>
 #include <memory>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridView);
@@ -49,7 +49,10 @@ NEW_PROP_TAG(GridViewLevel);
 NEW_PROP_TAG(GridFile);
 NEW_PROP_TAG(GridGlobalRefinements);
 NEW_PROP_TAG(Simulator);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \brief Provides the base class for most (all?) simulator vanguards.

--- a/ewoms/io/cubegridvanguard.hh
+++ b/ewoms/io/cubegridvanguard.hh
@@ -38,8 +38,8 @@
 
 #include <memory>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Grid);
 
@@ -52,7 +52,10 @@ NEW_PROP_TAG(CellsY);
 NEW_PROP_TAG(CellsZ);
 
 NEW_PROP_TAG(GridGlobalRefinements);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \brief Provides a simulator vanguad which creates a regular grid made of

--- a/ewoms/io/dgfvanguard.hh
+++ b/ewoms/io/dgfvanguard.hh
@@ -39,15 +39,18 @@
 #include <type_traits>
 #include <string>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Grid);
 NEW_PROP_TAG(GridFile);
 NEW_PROP_TAG(Vanguard);
 NEW_PROP_TAG(GridGlobalRefinements);
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Simulator);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \brief Provides a simulator vanguard which creates a grid by parsing a Dune Grid

--- a/ewoms/io/simplexvanguard.hh
+++ b/ewoms/io/simplexvanguard.hh
@@ -36,8 +36,8 @@
 
 #include <memory>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(Grid);
 
@@ -50,8 +50,10 @@ NEW_PROP_TAG(CellsY);
 NEW_PROP_TAG(CellsZ);
 
 NEW_PROP_TAG(GridGlobalRefinements);
-} // namespace Properties
 
+END_PROPERTIES
+
+namespace Ewoms {
 /*!
  * \brief Provides a simulator vanguard which a creates regular grid made of simplices.
  */

--- a/ewoms/io/structuredgridvanguard.hh
+++ b/ewoms/io/structuredgridvanguard.hh
@@ -50,7 +50,10 @@ namespace Ewoms {
 template <class TypeTag>
 class StructuredGridVanguard;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(StructuredGridVanguard);
 
 // declare the properties required by the for the structured grid simulator vanguard
@@ -82,7 +85,10 @@ SET_TYPE_PROP(StructuredGridVanguard, Grid, Dune::YaspGrid< dim >);
 #endif
 
 SET_TYPE_PROP(StructuredGridVanguard, Vanguard, Ewoms::StructuredGridVanguard<TypeTag>);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup TestProblems

--- a/ewoms/io/vtkblackoilenergymodule.hh
+++ b/ewoms/io/vtkblackoilenergymodule.hh
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkBlackOilEnergy);
 
@@ -58,8 +58,8 @@ SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteRockInternalEnergy, true);
 SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteTotalThermalConductivity, true);
 SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteFluidInternalEnergies, true);
 SET_BOOL_PROP(VtkBlackOilEnergy, VtkWriteFluidEnthalpies, true);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkblackoilmodule.hh
+++ b/ewoms/io/vtkblackoilmodule.hh
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkBlackOil);
 
@@ -72,8 +72,7 @@ SET_BOOL_PROP(VtkBlackOil, VtkWriteSaturationRatios, false);
 SET_BOOL_PROP(VtkBlackOil, VtkWriteSaturatedOilGasDissolutionFactor, false);
 SET_BOOL_PROP(VtkBlackOil, VtkWriteSaturatedGasOilVaporizationFactor, false);
 SET_BOOL_PROP(VtkBlackOil, VtkWritePrimaryVarsMeaning, false);
-} // namespace Properties
-} // namespace Ewoms
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkblackoilpolymermodule.hh
+++ b/ewoms/io/vtkblackoilpolymermodule.hh
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkBlackOilPolymer);
 
@@ -62,8 +62,8 @@ SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerViscosityCorrection, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWriteWaterViscosityCorrection, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerRockDensity, true);
 SET_BOOL_PROP(VtkBlackOilPolymer, VtkWritePolymerAdsorption, true);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkblackoilsolventmodule.hh
+++ b/ewoms/io/vtkblackoilsolventmodule.hh
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkBlackOilSolvent);
 
@@ -58,8 +58,8 @@ SET_BOOL_PROP(VtkBlackOilSolvent, VtkWriteSolventSaturation, true);
 SET_BOOL_PROP(VtkBlackOilSolvent, VtkWriteSolventDensity, true);
 SET_BOOL_PROP(VtkBlackOilSolvent, VtkWriteSolventViscosity, true);
 SET_BOOL_PROP(VtkBlackOilSolvent, VtkWriteSolventMobility, true);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkcompositionmodule.hh
+++ b/ewoms/io/vtkcompositionmodule.hh
@@ -35,8 +35,8 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK composition output
 NEW_TYPE_TAG(VtkComposition);
 
@@ -59,7 +59,10 @@ SET_BOOL_PROP(VtkComposition, VtkWriteTotalMoleFractions, false);
 SET_BOOL_PROP(VtkComposition, VtkWriteMolarities, false);
 SET_BOOL_PROP(VtkComposition, VtkWriteFugacities, false);
 SET_BOOL_PROP(VtkComposition, VtkWriteFugacityCoeffs, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Vtk

--- a/ewoms/io/vtkdiffusionmodule.hh
+++ b/ewoms/io/vtkdiffusionmodule.hh
@@ -37,8 +37,8 @@
 #include <opm/material/densead/Evaluation.hpp>
 #include <opm/material/densead/Math.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK output of the quantities for molecular
 // diffusion
 NEW_TYPE_TAG(VtkDiffusion);
@@ -54,8 +54,8 @@ NEW_PROP_TAG(EnableVtkOutput);
 SET_BOOL_PROP(VtkDiffusion, VtkWriteTortuosities, false);
 SET_BOOL_PROP(VtkDiffusion, VtkWriteDiffusionCoefficients, false);
 SET_BOOL_PROP(VtkDiffusion, VtkWriteEffectiveDiffusionCoefficients, false);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkdiscretefracturemodule.hh
+++ b/ewoms/io/vtkdiscretefracturemodule.hh
@@ -39,8 +39,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkDiscreteFracture);
 
@@ -65,8 +65,10 @@ SET_BOOL_PROP(VtkDiscreteFracture, VtkWriteFracturePorosity, true);
 SET_BOOL_PROP(VtkDiscreteFracture, VtkWriteFractureIntrinsicPermeabilities, false);
 SET_BOOL_PROP(VtkDiscreteFracture, VtkWriteFractureFilterVelocities, false);
 SET_BOOL_PROP(VtkDiscreteFracture, VtkWriteFractureVolumeFraction, true);
-} // namespace Properties
 
+END_PROPERTIES
+
+namespace Ewoms {
 /*!
  * \ingroup Vtk
  *

--- a/ewoms/io/vtkenergymodule.hh
+++ b/ewoms/io/vtkenergymodule.hh
@@ -35,8 +35,8 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK energy output
 NEW_TYPE_TAG(VtkEnergy);
 
@@ -53,8 +53,8 @@ SET_BOOL_PROP(VtkEnergy, VtkWriteSolidInternalEnergy, false);
 SET_BOOL_PROP(VtkEnergy, VtkWriteThermalConductivity, false);
 SET_BOOL_PROP(VtkEnergy, VtkWriteInternalEnergies, false);
 SET_BOOL_PROP(VtkEnergy, VtkWriteEnthalpies, false);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkmultiphasemodule.hh
+++ b/ewoms/io/vtkmultiphasemodule.hh
@@ -40,8 +40,8 @@
 
 #include <cstdio>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK multi-phase output
 NEW_TYPE_TAG(VtkMultiPhase);
 
@@ -75,7 +75,10 @@ SET_BOOL_PROP(VtkMultiPhase, VtkWritePorosity, true);
 SET_BOOL_PROP(VtkMultiPhase, VtkWriteIntrinsicPermeabilities, false);
 SET_BOOL_PROP(VtkMultiPhase, VtkWritePotentialGradients, false);
 SET_BOOL_PROP(VtkMultiPhase, VtkWriteFilterVelocities, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Vtk

--- a/ewoms/io/vtkphasepresencemodule.hh
+++ b/ewoms/io/vtkphasepresencemodule.hh
@@ -33,8 +33,8 @@
 #include <ewoms/common/parametersystem.hh>
 #include <ewoms/common/propertysystem.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK primary variables output
 NEW_TYPE_TAG(VtkPhasePresence);
 
@@ -44,8 +44,8 @@ NEW_PROP_TAG(VtkOutputFormat);
 NEW_PROP_TAG(EnableVtkOutput);
 
 SET_BOOL_PROP(VtkPhasePresence, VtkWritePhasePresence, false);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/io/vtkprimaryvarsmodule.hh
+++ b/ewoms/io/vtkprimaryvarsmodule.hh
@@ -33,8 +33,8 @@
 #include <ewoms/common/parametersystem.hh>
 #include <ewoms/common/propertysystem.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK primary variables output
 NEW_PROP_TAG(EnableVtkOutput);
 NEW_TYPE_TAG(VtkPrimaryVars);
@@ -49,7 +49,10 @@ NEW_PROP_TAG(EnableVtkOutput);
 SET_BOOL_PROP(VtkPrimaryVars, VtkWritePrimaryVars, false);
 SET_BOOL_PROP(VtkPrimaryVars, VtkWriteProcessRank, false);
 SET_BOOL_PROP(VtkPrimaryVars, VtkWriteDofIndex, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Vtk

--- a/ewoms/io/vtktemperaturemodule.hh
+++ b/ewoms/io/vtktemperaturemodule.hh
@@ -35,8 +35,8 @@
 
 #include <opm/material/common/MathToolbox.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // create new type tag for the VTK temperature output
 NEW_TYPE_TAG(VtkTemperature);
 
@@ -47,7 +47,10 @@ NEW_PROP_TAG(EnableVtkOutput);
 
 // set default values for what quantities to output
 SET_BOOL_PROP(VtkTemperature, VtkWriteTemperature, true);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Vtk

--- a/ewoms/linear/istlpreconditionerwrappers.hh
+++ b/ewoms/linear/istlpreconditionerwrappers.hh
@@ -50,16 +50,16 @@
 
 #include <dune/common/version.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(JacobianMatrix);
 NEW_PROP_TAG(OverlappingMatrix);
 NEW_PROP_TAG(OverlappingVector);
 NEW_PROP_TAG(PreconditionerOrder);
 NEW_PROP_TAG(PreconditionerRelaxation);
-} // namespace Properties
+END_PROPERTIES
 
+namespace Ewoms {
 namespace Linear {
 #define EWOMS_WRAP_ISTL_PRECONDITIONER(PREC_NAME, ISTL_PREC_TYPE)               \
     template <class TypeTag>                                                    \

--- a/ewoms/linear/istlsolverwrappers.hh
+++ b/ewoms/linear/istlsolverwrappers.hh
@@ -48,8 +48,8 @@
 
 #include <dune/istl/solvers.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(JacobianMatrix);
 NEW_PROP_TAG(OverlappingMatrix);
@@ -58,7 +58,10 @@ NEW_PROP_TAG(GMResRestart);
 NEW_PROP_TAG(LinearSolverTolerance);
 NEW_PROP_TAG(LinearSolverMaxIterations);
 NEW_PROP_TAG(LinearSolverVerbosity);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 namespace Linear {
 

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -43,9 +43,10 @@ namespace Ewoms {
 namespace Linear {
 template <class TypeTag>
 class ParallelAmgBackend;
-}
+}}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ParallelAmgLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
 NEW_PROP_TAG(AmgCoarsenTarget);
@@ -59,8 +60,10 @@ SET_SCALAR_PROP(ParallelAmgLinearSolver, LinearSolverMaxError, 1e7);
 
 SET_TYPE_PROP(ParallelAmgLinearSolver, LinearSolverBackend,
               Ewoms::Linear::ParallelAmgBackend<TypeTag>);
-} // namespace Properties
 
+END_PROPERTIES
+
+namespace Ewoms {
 namespace Linear {
 /*!
  * \ingroup Linear

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -47,8 +47,7 @@
 #include <memory>
 #include <iostream>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
 NEW_TYPE_TAG(ParallelBaseLinearSolver);
 
 // forward declaration of the required property tags
@@ -108,7 +107,7 @@ NEW_PROP_TAG(PreconditionerOrder);
 
 //! The relaxation factor of the preconditioner
 NEW_PROP_TAG(PreconditionerRelaxation);
-}} // namespace Properties, Ewoms
+END_PROPERTIES
 
 namespace Ewoms {
 namespace Linear {
@@ -428,8 +427,8 @@ protected:
 };
 }} // namespace Linear, Ewoms
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! make the linear solver shut up by default
 SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverVerbosity, 0);
 
@@ -497,7 +496,7 @@ SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverOverlapSize, 2);
 
 //! set the default number of maximum iterations for the linear solver
 SET_INT_PROP(ParallelBaseLinearSolver, LinearSolverMaxIterations, 1000);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/linear/parallelbicgstabbackend.hh
+++ b/ewoms/linear/parallelbicgstabbackend.hh
@@ -39,8 +39,8 @@ template <class TypeTag>
 class ParallelBiCGStabSolverBackend;
 }} // namespace Linear, Ewoms
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ParallelBiCGStabLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
 NEW_PROP_TAG(LinearSolverMaxError);
@@ -50,7 +50,8 @@ SET_TYPE_PROP(ParallelBiCGStabLinearSolver,
               Ewoms::Linear::ParallelBiCGStabSolverBackend<TypeTag>);
 
 SET_SCALAR_PROP(ParallelBiCGStabLinearSolver, LinearSolverMaxError, 1e7);
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 namespace Linear {

--- a/ewoms/linear/parallelistlbackend.hh
+++ b/ewoms/linear/parallelistlbackend.hh
@@ -32,16 +32,16 @@
 
 #include <dune/common/version.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ParallelIstlLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
 NEW_PROP_TAG(LinearSolverWrapper);
 
 //! number of iterations between solver restarts for the GMRES solver
 NEW_PROP_TAG(GMResRestart);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 namespace Linear {
@@ -141,8 +141,8 @@ protected:
 
 }} // namespace Linear, Ewoms
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 SET_TYPE_PROP(ParallelIstlLinearSolver,
               LinearSolverBackend,
               Ewoms::Linear::ParallelIstlSolverBackend<TypeTag>);
@@ -163,6 +163,7 @@ SET_TYPE_PROP(ParallelIstlLinearSolver,
 
 //! set the GMRes restart parameter to 10 by default
 SET_INT_PROP(ParallelIstlLinearSolver, GMResRestart, 10);
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/linear/superlubackend.hh
+++ b/ewoms/linear/superlubackend.hh
@@ -37,8 +37,8 @@
 #include <dune/common/fmatrix.hh>
 #include <dune/common/version.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // forward declaration of the required property tags
 NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(NumEq);
@@ -48,8 +48,8 @@ NEW_PROP_TAG(GlobalEqVector);
 NEW_PROP_TAG(LinearSolverVerbosity);
 NEW_PROP_TAG(LinearSolverBackend);
 NEW_TYPE_TAG(SuperLULinearSolver);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 namespace Linear {
@@ -173,13 +173,13 @@ public:
 } // namespace Linear
 } // namespace Ewoms
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 SET_INT_PROP(SuperLULinearSolver, LinearSolverVerbosity, 0);
 SET_TYPE_PROP(SuperLULinearSolver, LinearSolverBackend,
               Ewoms::Linear::SuperLUBackend<TypeTag>);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif // HAVE_SUPERLU
 

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -64,8 +64,8 @@ template <class TypeTag>
 class EclVanguard;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for the black-oil problems
 NEW_TYPE_TAG(BlackOilModel, INHERITS_FROM(MultiPhaseBaseModel,
                                           VtkBlackOil,
@@ -155,7 +155,10 @@ PROP_STATIC_CONST_MEMBER_DEFINITION_PREFIX_(BlackOilModel, BlackOilEnergyScaling
 // by default, ebos formulates the conservation equations in terms of mass not surface
 // volumes
 SET_BOOL_PROP(BlackOilModel, BlackoilConserveSurfaceVolume, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup BlackOilModel

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -31,8 +31,8 @@
 
 #include <ewoms/models/common/multiphasebaseproperties.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! Specifies if the simulation should write output files that are
 //! compatible with those produced by the commercial Eclipse simulator
 NEW_PROP_TAG(EnableEclipseOutput);
@@ -69,6 +69,7 @@ NEW_PROP_TAG(EnableEnergy);
 //! magnitude larger than that of the mass balance equations
 NEW_PROP_TAG(BlackOilEnergyScalingFactor);
 
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/common/darcyfluxmodule.hh
+++ b/ewoms/models/common/darcyfluxmodule.hh
@@ -42,10 +42,13 @@
 
 #include <cmath>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(MaterialLaw);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 template <class TypeTag>
 class DarcyIntensiveQuantities;

--- a/ewoms/models/common/diffusionmodule.hh
+++ b/ewoms/models/common/diffusionmodule.hh
@@ -37,10 +37,13 @@
 
 #include <dune/common/fvector.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Indices);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Diffusion

--- a/ewoms/models/common/energymodule.hh
+++ b/ewoms/models/common/energymodule.hh
@@ -40,15 +40,16 @@
 
 #include <string>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(Indices);
 NEW_PROP_TAG(EnableEnergy);
 NEW_PROP_TAG(ThermalConductionLaw);
 NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(SolidEnergyLaw);
 NEW_PROP_TAG(SolidEnergyLawParams);
-}}
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/models/common/forchheimerfluxmodule.hh
+++ b/ewoms/models/common/forchheimerfluxmodule.hh
@@ -43,10 +43,11 @@
 
 #include <cmath>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(MaterialLaw);
-}}
+
+END_PROPERTIES
 
 namespace Ewoms {
 template <class TypeTag>

--- a/ewoms/models/common/multiphasebasemodel.hh
+++ b/ewoms/models/common/multiphasebasemodel.hh
@@ -48,8 +48,8 @@ template <class TypeTag>
 class MultiPhaseBaseModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The generic type tag for problems using the immiscible multi-phase model
 NEW_TYPE_TAG(MultiPhaseBaseModel, INHERITS_FROM(VtkMultiPhase, VtkTemperature));
 
@@ -122,7 +122,10 @@ SET_TYPE_PROP(MultiPhaseBaseModel,
 //! disable gravity by default
 SET_BOOL_PROP(MultiPhaseBaseModel, EnableGravity, false);
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup MultiPhaseBaseModel

--- a/ewoms/models/common/multiphasebaseproblem.hh
+++ b/ewoms/models/common/multiphasebaseproblem.hh
@@ -41,13 +41,16 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(SolidEnergyLawParams);
 NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(EnableGravity);
 NEW_PROP_TAG(FluxModule);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup Discretization

--- a/ewoms/models/common/multiphasebaseproperties.hh
+++ b/ewoms/models/common/multiphasebaseproperties.hh
@@ -34,8 +34,8 @@
 #include <ewoms/io/vtkmultiphasemodule.hh>
 #include <ewoms/io/vtktemperaturemodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The splice to be used for the spatial discretization
 NEW_PROP_TAG(SpatialDiscretizationSplice);
 //! Number of fluid phases in the system
@@ -63,7 +63,7 @@ NEW_PROP_TAG(FluxModule);
 
 //! Returns whether gravity is considered in the problem
 NEW_PROP_TAG(EnableGravity);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/discretefracture/discretefracturemodel.hh
+++ b/ewoms/models/discretefracture/discretefracturemodel.hh
@@ -49,8 +49,8 @@ template <class TypeTag>
 class DiscreteFractureModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The generic type tag for problems using the immiscible multi-phase model
 NEW_TYPE_TAG(DiscreteFractureModel, INHERITS_FROM(ImmiscibleTwoPhaseModel, VtkDiscreteFracture));
 
@@ -89,7 +89,10 @@ SET_BOOL_PROP(DiscreteFractureModel, UseTwoPointGradients, true);
 // of freedom. This is because the fracture properties (volume, permeability, etc) are
 // specific for each...
 SET_BOOL_PROP(DiscreteFractureModel, EnableIntensiveQuantityCache, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup DiscreteFractureModel

--- a/ewoms/models/discretefracture/discretefractureproblem.hh
+++ b/ewoms/models/discretefracture/discretefractureproblem.hh
@@ -39,12 +39,15 @@
 #include <dune/common/fvector.hh>
 #include <dune/common/fmatrix.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(EnableGravity);
 NEW_PROP_TAG(FluxModule);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup DiscreteFractureModel

--- a/ewoms/models/discretefracture/discretefractureproperties.hh
+++ b/ewoms/models/discretefracture/discretefractureproperties.hh
@@ -34,9 +34,10 @@
 
 #include <ewoms/io/vtkdiscretefracturemodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(UseTwoPointGradients);
-}}
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/flash/flashmodel.hh
+++ b/ewoms/models/flash/flashmodel.hh
@@ -56,8 +56,8 @@ template <class TypeTag>
 class FlashModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for the isothermal single phase problems
 NEW_TYPE_TAG(FlashModel, INHERITS_FROM(MultiPhaseBaseModel,
                                        VtkComposition,
@@ -111,7 +111,10 @@ SET_BOOL_PROP(FlashModel, EnableDiffusion, false);
 
 //! Disable the energy equation by default
 SET_BOOL_PROP(FlashModel, EnableEnergy, false);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup FlashModel

--- a/ewoms/models/flash/flashproperties.hh
+++ b/ewoms/models/flash/flashproperties.hh
@@ -35,8 +35,8 @@
 #include <ewoms/io/vtkenergymodule.hh>
 #include <ewoms/io/vtkdiffusionmodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! Provides the thermodynamic relations
 NEW_PROP_TAG(FluidSystem);
 //! The type of the flash constraint solver
@@ -53,6 +53,7 @@ NEW_PROP_TAG(ThermalConductionLawParams);
 NEW_PROP_TAG(EnableEnergy);
 //! Enable diffusive fluxes?
 NEW_PROP_TAG(EnableDiffusion);
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/immiscible/immisciblemodel.hh
+++ b/ewoms/models/immiscible/immisciblemodel.hh
@@ -55,8 +55,8 @@ template <class TypeTag>
 class ImmiscibleModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The generic type tag for problems using the immiscible multi-phase model
 NEW_TYPE_TAG(ImmiscibleModel, INHERITS_FROM(MultiPhaseBaseModel, VtkEnergy));
 //! The type tag for single-phase immiscible problems
@@ -153,7 +153,10 @@ public:
                                               NonwettingPhase> type;
 };
 
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup ImmiscibleModel

--- a/ewoms/models/immiscible/immiscibleproperties.hh
+++ b/ewoms/models/immiscible/immiscibleproperties.hh
@@ -33,8 +33,8 @@
 #include <ewoms/models/common/multiphasebaseproperties.hh>
 #include <ewoms/io/vtkenergymodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //!The fluid systems including the information about the phases
 NEW_PROP_TAG(FluidSystem);
 //! Specify whether energy should be considered as a conservation quantity or not
@@ -52,7 +52,7 @@ NEW_PROP_TAG(NonwettingPhase);
 //! The fluid used by the model
 NEW_PROP_TAG(Fluid);
 
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/ncp/ncpmodel.hh
+++ b/ewoms/models/ncp/ncpmodel.hh
@@ -62,8 +62,8 @@ template <class TypeTag>
 class NcpModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 /*!
  * \brief Define the type tag for the compositional NCP model.
  */
@@ -117,7 +117,9 @@ SET_SCALAR_PROP(NcpModel, NcpSaturationsBaseWeight, 1.0);
 //! The unmodified weight for the fugacity primary variables
 SET_SCALAR_PROP(NcpModel, NcpFugacitiesBaseWeight, 1.0e-6);
 
-} // namespace Properties
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup NcpModel

--- a/ewoms/models/ncp/ncpproperties.hh
+++ b/ewoms/models/ncp/ncpproperties.hh
@@ -35,8 +35,8 @@
 #include <ewoms/io/vtkenergymodule.hh>
 #include <ewoms/io/vtkdiffusionmodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! Enable the energy equation?
 NEW_PROP_TAG(EnableEnergy);
 
@@ -53,7 +53,7 @@ NEW_PROP_TAG(NcpFugacitiesBaseWeight);
 //! The themodynamic constraint solver which calculates the
 //! composition of any phase given all component fugacities.
 NEW_PROP_TAG(NcpCompositionFromFugacitiesSolver);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/pvs/pvsmodel.hh
+++ b/ewoms/models/pvs/pvsmodel.hh
@@ -61,8 +61,8 @@ template <class TypeTag>
 class PvsModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for the isothermal single phase problems
 NEW_TYPE_TAG(PvsModel, INHERITS_FROM(MultiPhaseBaseModel,
                                      VtkPhasePresence,
@@ -116,7 +116,10 @@ SET_SCALAR_PROP(PvsModel, PvsSaturationsBaseWeight, 1.0);
 
 //! The basis value for the weight of the mole fraction primary variables
 SET_SCALAR_PROP(PvsModel, PvsMoleFractionsBaseWeight, 1.0);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup PvsModel

--- a/ewoms/models/pvs/pvsproperties.hh
+++ b/ewoms/models/pvs/pvsproperties.hh
@@ -38,8 +38,8 @@
 #include <ewoms/io/vtkdiffusionmodule.hh>
 #include <ewoms/io/vtkenergymodule.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! Specifies whether energy is considered as a conservation quantity or not
 NEW_PROP_TAG(EnableEnergy);
 //! Enable diffusive fluxes?
@@ -53,7 +53,7 @@ NEW_PROP_TAG(PvsPressureBaseWeight);
 NEW_PROP_TAG(PvsSaturationsBaseWeight);
 //! The basis value for the weight of the mole fraction primary variables
 NEW_PROP_TAG(PvsMoleFractionsBaseWeight);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/models/richards/richardsmodel.hh
+++ b/ewoms/models/richards/richardsmodel.hh
@@ -56,8 +56,8 @@ template <class TypeTag>
 class RichardsModel;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The type tag for problems discretized using the Richards model
 NEW_TYPE_TAG(Richards, INHERITS_FROM(MultiPhaseBaseModel));
 
@@ -166,8 +166,8 @@ public:
     typedef Opm::FluidSystems::TwoPhaseImmiscible<Scalar, WettingFluid, NonWettingFluid> type;
 };
 
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 

--- a/ewoms/models/richards/richardsproperties.hh
+++ b/ewoms/models/richards/richardsproperties.hh
@@ -32,8 +32,8 @@
 #include <ewoms/models/common/multiphasebaseproperties.hh>
 
 // \{
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 //! The fluid system used for the problem
 NEW_PROP_TAG(FluidSystem);
 
@@ -58,6 +58,7 @@ NEW_PROP_TAG(LiquidComponentIndex);
 NEW_PROP_TAG(GasComponentIndex);
 
 // \}
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 #endif

--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -57,7 +57,10 @@ class NewtonMethod;
 
 namespace Ewoms {
 // forward declaration of property tags
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 //! The type tag on which the default properties for the Newton method
 //! are attached
 NEW_TYPE_TAG(NewtonMethod);
@@ -154,8 +157,8 @@ SET_SCALAR_PROP(NewtonMethod, NewtonRawTolerance, 1e-8);
 SET_SCALAR_PROP(NewtonMethod, NewtonMaxError, 1e100);
 SET_INT_PROP(NewtonMethod, NewtonTargetIterations, 10);
 SET_INT_PROP(NewtonMethod, NewtonMaxIterations, 18);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/nonlinear/nullconvergencewriter.hh
+++ b/ewoms/nonlinear/nullconvergencewriter.hh
@@ -32,14 +32,14 @@
 
 #include <opm/material/common/Unused.hpp>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(NewtonMethod);
 
 NEW_PROP_TAG(SolutionVector);
 NEW_PROP_TAG(GlobalEqVector);
-}
-}
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/ewoms/parallel/threadmanager.hh
+++ b/ewoms/parallel/threadmanager.hh
@@ -39,10 +39,13 @@
 
 #include <dune/common/version.hh>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_PROP_TAG(ThreadsPerProcess);
-}
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \brief Simplifies multi-threaded capabilities.

--- a/tests/co2injection_flash_ecfv.cc
+++ b/tests/co2injection_flash_ecfv.cc
@@ -38,8 +38,8 @@
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionFlashEcfvProblem, INHERITS_FROM(FlashModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionFlashEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 
@@ -64,8 +64,8 @@ SET_TAG_PROP(Co2InjectionFlashEcfvProblem, LinearSolverSplice, ParallelBiCGStabL
 #else
 SET_SCALAR_PROP(Co2InjectionFlashEcfvProblem, NewtonRawTolerance, 1e-5);
 #endif
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_flash_ni_ecfv.cc
+++ b/tests/co2injection_flash_ni_ecfv.cc
@@ -35,8 +35,8 @@
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionFlashNiEcfvProblem, INHERITS_FROM(FlashModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionFlashNiEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 
@@ -63,8 +63,8 @@ SET_TAG_PROP(Co2InjectionFlashNiEcfvProblem, LinearSolverSplice, ParallelBiCGSta
 #else
 SET_SCALAR_PROP(Co2InjectionFlashNiEcfvProblem, NewtonRawTolerance, 1e-5);
 #endif
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_flash_ni_vcfv.cc
+++ b/tests/co2injection_flash_ni_vcfv.cc
@@ -35,8 +35,8 @@
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionFlashNiVcfvProblem, INHERITS_FROM(FlashModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionFlashNiVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
 
@@ -60,8 +60,8 @@ SET_TAG_PROP(Co2InjectionFlashNiVcfvProblem, LinearSolverSplice, ParallelBiCGSta
 #else
 SET_SCALAR_PROP(Co2InjectionFlashNiVcfvProblem, NewtonRawTolerance, 1e-5);
 #endif
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_flash_vcfv.cc
+++ b/tests/co2injection_flash_vcfv.cc
@@ -38,8 +38,8 @@
 #include "problems/co2injectionflash.hh"
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionFlashVcfvProblem, INHERITS_FROM(FlashModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionFlashVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
 
@@ -61,8 +61,8 @@ SET_TAG_PROP(Co2InjectionFlashVcfvProblem, LinearSolverSplice, ParallelBiCGStabL
 #else
 SET_SCALAR_PROP(Co2InjectionFlashVcfvProblem, NewtonRawTolerance, 1e-5);
 #endif
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_immiscible_ecfv.cc
+++ b/tests/co2injection_immiscible_ecfv.cc
@@ -34,14 +34,15 @@
 
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionImmiscibleEcfvProblem,
              INHERITS_FROM(ImmiscibleModel,
                            Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionImmiscibleEcfvProblem, SpatialDiscretizationSplice,
              EcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 ////////////////////////
 // the main function

--- a/tests/co2injection_immiscible_ni_ecfv.cc
+++ b/tests/co2injection_immiscible_ni_ecfv.cc
@@ -33,8 +33,8 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionImmiscibleNiEcfvProblem, INHERITS_FROM(ImmiscibleModel,
                                                                 Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionImmiscibleNiEcfvProblem, SpatialDiscretizationSplice,
@@ -44,7 +44,8 @@ SET_BOOL_PROP(Co2InjectionImmiscibleNiEcfvProblem, EnableEnergy, true);
 
 //! Use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(Co2InjectionImmiscibleNiEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 ////////////////////////
 // the main function

--- a/tests/co2injection_immiscible_ni_vcfv.cc
+++ b/tests/co2injection_immiscible_ni_vcfv.cc
@@ -33,14 +33,15 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionImmiscibleNiVcfvProblem, INHERITS_FROM(ImmiscibleModel,
                                                                 Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionImmiscibleNiVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
 
 SET_BOOL_PROP(Co2InjectionImmiscibleNiVcfvProblem, EnableEnergy, true);
-}}
+
+END_PROPERTIES
 
 ////////////////////////
 // the main function

--- a/tests/co2injection_immiscible_vcfv.cc
+++ b/tests/co2injection_immiscible_vcfv.cc
@@ -34,12 +34,13 @@
 
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionImmiscibleVcfvProblem, INHERITS_FROM(ImmiscibleModel,
                                                               Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionImmiscibleVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 ////////////////////////
 // the main function

--- a/tests/co2injection_ncp_ecfv.cc
+++ b/tests/co2injection_ncp_ecfv.cc
@@ -33,11 +33,12 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionNcpEcfvProblem, INHERITS_FROM(NcpModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionNcpEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_ncp_ni_ecfv.cc
+++ b/tests/co2injection_ncp_ni_ecfv.cc
@@ -33,15 +33,16 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionNcpNiEcfvProblem, INHERITS_FROM(NcpModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionNcpNiEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 SET_BOOL_PROP(Co2InjectionNcpNiEcfvProblem, EnableEnergy, true);
 
 //! Use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(Co2InjectionNcpNiEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_ncp_ni_vcfv.cc
+++ b/tests/co2injection_ncp_ni_vcfv.cc
@@ -33,12 +33,13 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionNcpNiVcfvProblem, INHERITS_FROM(NcpModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionNcpNiVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
 SET_BOOL_PROP(Co2InjectionNcpNiVcfvProblem, EnableEnergy, true);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_ncp_vcfv.cc
+++ b/tests/co2injection_ncp_vcfv.cc
@@ -34,11 +34,12 @@
 
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionNcpVcfvProblem, INHERITS_FROM(NcpModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionNcpVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_pvs_ecfv.cc
+++ b/tests/co2injection_pvs_ecfv.cc
@@ -33,11 +33,12 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionPvsEcfvProblem, INHERITS_FROM(PvsModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionPvsEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_pvs_ni_ecfv.cc
+++ b/tests/co2injection_pvs_ni_ecfv.cc
@@ -33,8 +33,8 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionPvsNiEcfvProblem, INHERITS_FROM(PvsModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionPvsNiEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 
@@ -42,7 +42,8 @@ SET_BOOL_PROP(Co2InjectionPvsNiEcfvProblem, EnableEnergy, true);
 
 //! Use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(Co2InjectionPvsNiEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_pvs_ni_vcfv.cc
+++ b/tests/co2injection_pvs_ni_vcfv.cc
@@ -33,13 +33,14 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionPvsNiVcfvProblem, INHERITS_FROM(PvsModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionPvsNiVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
 
 SET_BOOL_PROP(Co2InjectionPvsNiVcfvProblem, EnableEnergy, true);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/co2injection_pvs_vcfv.cc
+++ b/tests/co2injection_pvs_vcfv.cc
@@ -34,11 +34,12 @@
 
 #include "problems/co2injectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionPvsVcfvProblem, INHERITS_FROM(PvsModel, Co2InjectionBaseProblem));
 SET_TAG_PROP(Co2InjectionPvsVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/cuvette_pvs.cc
+++ b/tests/cuvette_pvs.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/cuvetteproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(CuvetteProblem, INHERITS_FROM(PvsModel, CuvetteBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/diffusion_flash.cc
+++ b/tests/diffusion_flash.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/flash/flashmodel.hh>
 #include "problems/diffusionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(DiffusionProblem, INHERITS_FROM(FlashModel, DiffusionBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/diffusion_ncp.cc
+++ b/tests/diffusion_ncp.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/ncp/ncpmodel.hh>
 #include "problems/diffusionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(DiffusionProblem, INHERITS_FROM(NcpModel, DiffusionBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/diffusion_pvs.cc
+++ b/tests/diffusion_pvs.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/diffusionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(DiffusionProblem, INHERITS_FROM(PvsModel, DiffusionBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/finger_immiscible_ecfv.cc
+++ b/tests/finger_immiscible_ecfv.cc
@@ -32,11 +32,12 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/fingerproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(FingerProblemEcfv, INHERITS_FROM(ImmiscibleTwoPhaseModel, FingerBaseProblem));
 SET_TAG_PROP(FingerProblemEcfv, SpatialDiscretizationSplice, EcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/finger_immiscible_vcfv.cc
+++ b/tests/finger_immiscible_vcfv.cc
@@ -32,11 +32,12 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/fingerproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(FingerProblemVcfv, INHERITS_FROM(ImmiscibleTwoPhaseModel, FingerBaseProblem));
 SET_TAG_PROP(FingerProblemVcfv, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/groundwater_immiscible.cc
+++ b/tests/groundwater_immiscible.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/groundwaterproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(GroundWaterProblem, INHERITS_FROM(ImmiscibleSinglePhaseModel, GroundWaterBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/infiltration_pvs.cc
+++ b/tests/infiltration_pvs.cc
@@ -31,10 +31,11 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/infiltrationproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(InfiltrationProblem, INHERITS_FROM(PvsModel, InfiltrationBaseProblem));
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/lens_immiscible_ecfv_ad.hh
+++ b/tests/lens_immiscible_ecfv_ad.hh
@@ -33,8 +33,8 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/lensproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(LensProblemEcfvAd, INHERITS_FROM(ImmiscibleTwoPhaseModel, LensBaseProblem));
 
 // use the element centered finite volume spatial discretization
@@ -45,6 +45,7 @@ SET_TAG_PROP(LensProblemEcfvAd, LocalLinearizerSplice, AutoDiffLocalLinearizer);
 
 // this problem works fine if the linear solver uses single precision scalars
 SET_TYPE_PROP(LensProblemEcfvAd, LinearSolverScalar, float);
-}}
+
+END_PROPERTIES
 
 #endif // EWOMS_LENS_IMMISCIBLE_ECFV_AD_HH

--- a/tests/lens_immiscible_vcfv_ad.cc
+++ b/tests/lens_immiscible_vcfv_ad.cc
@@ -32,8 +32,8 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/lensproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(LensProblemVcfvAd, INHERITS_FROM(ImmiscibleTwoPhaseModel, LensBaseProblem));
 
 // use automatic differentiation for this simulator
@@ -43,7 +43,8 @@ SET_TAG_PROP(LensProblemVcfvAd, LocalLinearizerSplice, AutoDiffLocalLinearizer);
 #if HAVE_DUNE_LOCALFUNCTIONS
 SET_BOOL_PROP(LensProblemVcfvAd, UseP1FiniteElementGradients, true);
 #endif
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/lens_immiscible_vcfv_fd.cc
+++ b/tests/lens_immiscible_vcfv_fd.cc
@@ -32,8 +32,8 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/lensproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(LensProblemVcfvFd, INHERITS_FROM(ImmiscibleTwoPhaseModel, LensBaseProblem));
 
 // use the finite difference methodfor this simulator
@@ -43,7 +43,8 @@ SET_TAG_PROP(LensProblemVcfvFd, LocalLinearizerSplice, FiniteDifferenceLocalLine
 #if HAVE_DUNE_LOCALFUNCTIONS
 SET_BOOL_PROP(LensProblemVcfvFd, UseP1FiniteElementGradients, true);
 #endif
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/lens_richards_ecfv.cc
+++ b/tests/lens_richards_ecfv.cc
@@ -32,14 +32,15 @@
 
 #include "problems/richardslensproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(RichardsLensEcfvProblem, INHERITS_FROM(RichardsLensProblem));
 SET_TAG_PROP(RichardsLensEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 
 //! Use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(RichardsLensEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/lens_richards_vcfv.cc
+++ b/tests/lens_richards_vcfv.cc
@@ -32,11 +32,12 @@
 
 #include "problems/richardslensproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(RichardsLensVcfvProblem, INHERITS_FROM(RichardsLensProblem));
 SET_TAG_PROP(RichardsLensVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/obstacle_immiscible.cc
+++ b/tests/obstacle_immiscible.cc
@@ -32,11 +32,11 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/obstacleproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ObstacleProblem, INHERITS_FROM(ImmiscibleModel, ObstacleBaseProblem));
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/obstacle_ncp.cc
+++ b/tests/obstacle_ncp.cc
@@ -32,11 +32,11 @@
 
 #include "problems/obstacleproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ObstacleProblem, INHERITS_FROM(NcpModel, ObstacleBaseProblem));
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/obstacle_pvs.cc
+++ b/tests/obstacle_pvs.cc
@@ -33,14 +33,14 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/obstacleproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ObstacleProblem, INHERITS_FROM(PvsModel, ObstacleBaseProblem));
 
 // Verbosity of the PVS model (0=silent, 1=medium, 2=chatty)
 SET_INT_PROP(ObstacleProblem, PvsVerbosity, 1);
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/outflow_pvs.cc
+++ b/tests/outflow_pvs.cc
@@ -31,14 +31,14 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/outflowproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(OutflowProblem, INHERITS_FROM(PvsModel, OutflowBaseProblem));
 
 // Verbosity of the PVS model (0=silent, 1=medium, 2=chatty)
 SET_INT_PROP(OutflowProblem, PvsVerbosity, 1);
-}
-}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/powerinjection_darcy_ad.cc
+++ b/tests/powerinjection_darcy_ad.cc
@@ -31,15 +31,16 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/powerinjectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(PowerInjectionDarcyAdProblem,
              INHERITS_FROM(ImmiscibleTwoPhaseModel,
                            PowerInjectionBaseProblem));
 
 SET_TYPE_PROP(PowerInjectionDarcyAdProblem, FluxModule, Ewoms::DarcyFluxModule<TypeTag>);
 SET_TAG_PROP(PowerInjectionDarcyAdProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/powerinjection_darcy_fd.cc
+++ b/tests/powerinjection_darcy_fd.cc
@@ -31,15 +31,16 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/powerinjectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(PowerInjectionDarcyFdProblem,
              INHERITS_FROM(ImmiscibleTwoPhaseModel,
                            PowerInjectionBaseProblem));
 
 SET_TYPE_PROP(PowerInjectionDarcyFdProblem, FluxModule, Ewoms::DarcyFluxModule<TypeTag>);
 SET_TAG_PROP(PowerInjectionDarcyFdProblem, LocalLinearizerSplice, FiniteDifferenceLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/powerinjection_forchheimer_ad.cc
+++ b/tests/powerinjection_forchheimer_ad.cc
@@ -31,15 +31,16 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/powerinjectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(PowerInjectionForchheimerAdProblem,
              INHERITS_FROM(ImmiscibleTwoPhaseModel,
                            PowerInjectionBaseProblem));
 
 SET_TYPE_PROP(PowerInjectionForchheimerAdProblem, FluxModule, Ewoms::ForchheimerFluxModule<TypeTag>);
 SET_TAG_PROP(PowerInjectionForchheimerAdProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/powerinjection_forchheimer_fd.cc
+++ b/tests/powerinjection_forchheimer_fd.cc
@@ -31,15 +31,16 @@
 #include <ewoms/models/immiscible/immisciblemodel.hh>
 #include "problems/powerinjectionproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(PowerInjectionForchheimerFdProblem,
              INHERITS_FROM(ImmiscibleTwoPhaseModel,
                            PowerInjectionBaseProblem));
 
 SET_TYPE_PROP(PowerInjectionForchheimerFdProblem, FluxModule, Ewoms::ForchheimerFluxModule<TypeTag>);
 SET_TAG_PROP(PowerInjectionForchheimerFdProblem, LocalLinearizerSplice, FiniteDifferenceLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/problems/co2injectionproblem.hh
+++ b/tests/problems/co2injectionproblem.hh
@@ -66,8 +66,10 @@ namespace Co2Injection {
 #include <opm/material/components/co2tables.inc>
 }
 //! \endcond
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(Co2InjectionBaseProblem);
 
 // declare the CO2 injection problem specific property tags
@@ -168,8 +170,8 @@ SET_SCALAR_PROP(Co2InjectionBaseProblem, InitialTimeStepSize, 250);
 
 // The default DGF file to load
 SET_STRING_PROP(Co2InjectionBaseProblem, GridFile, "data/co2injection.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/cuvetteproblem.hh
+++ b/tests/problems/cuvetteproblem.hh
@@ -56,8 +56,8 @@ template <class TypeTag>
 class CuvetteProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 
 // create a new type tag for the cuvette steam injection problem
 NEW_TYPE_TAG(CuvetteBaseProblem);
@@ -120,8 +120,8 @@ SET_SCALAR_PROP(CuvetteBaseProblem, InitialTimeStepSize, 1);
 
 // The default DGF file to load
 SET_STRING_PROP(CuvetteBaseProblem, GridFile, "./data/cuvette_11x4.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/diffusionproblem.hh
+++ b/tests/problems/diffusionproblem.hh
@@ -52,8 +52,7 @@ template <class TypeTag>
 class DiffusionProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(DiffusionBaseProblem);
 
@@ -116,8 +115,8 @@ SET_SCALAR_PROP(DiffusionBaseProblem, EndTime, 1e6);
 
 // The default for the initial time step size of the simulation
 SET_SCALAR_PROP(DiffusionBaseProblem, InitialTimeStepSize, 1000);
-}
-} // namespace Ewoms, Properties
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/fingerproblem.hh
+++ b/tests/problems/fingerproblem.hh
@@ -60,7 +60,10 @@ namespace Ewoms {
 template <class TypeTag>
 class FingerProblem;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(FingerBaseProblem, INHERITS_FROM(StructuredGridVanguard));
 
 #if HAVE_DUNE_ALUGRID
@@ -141,7 +144,10 @@ SET_SCALAR_PROP(FingerBaseProblem, EndTime, 215);
 
 // The default for the initial time step size of the simulation
 SET_SCALAR_PROP(FingerBaseProblem, InitialTimeStepSize, 10);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup TestProblems

--- a/tests/problems/fractureproblem.hh
+++ b/tests/problems/fractureproblem.hh
@@ -65,8 +65,8 @@ template <class TypeTag>
 class FractureProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // Create a type tag for the problem
 NEW_TYPE_TAG(FractureProblem, INHERITS_FROM(DiscreteFractureModel));
 
@@ -157,8 +157,8 @@ SET_SCALAR_PROP(FractureProblem, EndTime, 3e3);
 
 // Set the default value for the initial time step size
 SET_SCALAR_PROP(FractureProblem, InitialTimeStepSize, 100);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/groundwaterproblem.hh
+++ b/tests/problems/groundwaterproblem.hh
@@ -51,8 +51,8 @@ template <class TypeTag>
 class GroundWaterProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(GroundWaterBaseProblem);
 
 NEW_PROP_TAG(LensLowerLeftX);
@@ -106,7 +106,8 @@ SET_STRING_PROP(GroundWaterBaseProblem, GridFile, "./data/groundwater_2d.dgf");
 SET_TAG_PROP(GroundWaterBaseProblem, LinearSolverSplice, ParallelIstlLinearSolver);
 SET_TYPE_PROP(GroundWaterBaseProblem, LinearSolverWrapper,
               Ewoms::Linear::SolverWrapperConjugatedGradients<TypeTag>);
-}} // namespace Properties, Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/infiltrationproblem.hh
+++ b/tests/problems/infiltrationproblem.hh
@@ -52,8 +52,8 @@ template <class TypeTag>
 class InfiltrationProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(InfiltrationBaseProblem);
 
 // Set the grid type
@@ -103,8 +103,8 @@ SET_SCALAR_PROP(InfiltrationBaseProblem, InitialTimeStepSize, 60);
 // The default DGF file to load
 SET_STRING_PROP(InfiltrationBaseProblem, GridFile,
                 "./data/infiltration_50x3.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -53,8 +53,10 @@
 namespace Ewoms {
 template <class TypeTag>
 class LensProblem;
+}
 
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(LensBaseProblem, INHERITS_FROM(StructuredGridVanguard));
 
 // declare the properties specific for the lens problem
@@ -152,7 +154,10 @@ SET_BOOL_PROP(LensBaseProblem, EnableStorageCache, true);
 
 // enable the cache for intensive quantities by default for this problem
 SET_BOOL_PROP(LensBaseProblem, EnableIntensiveQuantityCache, true);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup TestProblems

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -303,6 +303,35 @@ public:
     }
 
     /*!
+     * \copydoc FvBaseProblem::briefDescription
+     */
+    static std::string briefDescription()
+    {
+        std::string thermal = "isothermal";
+        bool enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy);
+        if (enableEnergy)
+            thermal = "non-isothermal";
+
+        std::string deriv = "finite difference";
+        typedef typename GET_PROP_TYPE(TypeTag, LocalLinearizerSplice) LLS;
+        bool useAutoDiff = std::is_same<LLS, TTAG(AutoDiffLocalLinearizer)>::value;
+        if (useAutoDiff)
+            deriv = "automatic differentiation";
+
+        std::string disc = "vertex centered finite volume";
+        typedef typename GET_PROP_TYPE(TypeTag, Discretization) D;
+        bool useEcfv = std::is_same<D, Ewoms::EcfvDiscretization<TypeTag>>::value;
+        if (useEcfv)
+            disc = "element centered finite volume";
+
+        return std::string("")+
+            "Ground remediation problem where a dense oil infiltrates\n"+
+            "an aquifer with an embedded low-permability lens.\n" +
+            "This is the binary for the "+thermal+" variant using "+deriv+"\n"+
+            "and the "+disc+" discretization";
+    }
+
+    /*!
      * \name Soil parameters
      */
     //! \{

--- a/tests/problems/obstacleproblem.hh
+++ b/tests/problems/obstacleproblem.hh
@@ -57,8 +57,8 @@ template <class TypeTag>
 class ObstacleProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ObstacleBaseProblem);
 
 // Set the grid type
@@ -116,8 +116,8 @@ SET_SCALAR_PROP(ObstacleBaseProblem, InitialTimeStepSize, 250);
 
 // The default DGF file to load
 SET_STRING_PROP(ObstacleBaseProblem, GridFile, "./data/obstacle_24x16.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/outflowproblem.hh
+++ b/tests/problems/outflowproblem.hh
@@ -45,8 +45,8 @@ template <class TypeTag>
 class OutflowProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(OutflowBaseProblem);
 
 // Set the grid type
@@ -80,8 +80,8 @@ SET_SCALAR_PROP(OutflowBaseProblem, InitialTimeStepSize, 1);
 
 // The default DGF file to load
 SET_STRING_PROP(OutflowBaseProblem, GridFile, "./data/outflow.dgf");
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/powerinjectionproblem.hh
+++ b/tests/problems/powerinjectionproblem.hh
@@ -57,8 +57,8 @@ template <class TypeTag>
 class PowerInjectionProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(PowerInjectionBaseProblem);
 
 // Set the grid implementation to be used
@@ -135,8 +135,8 @@ SET_SCALAR_PROP(PowerInjectionBaseProblem, EndTime, 100);
 
 // The default for the initial time step size of the simulation
 SET_SCALAR_PROP(PowerInjectionBaseProblem, InitialTimeStepSize, 1e-3);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/problems/reservoirproblem.hh
+++ b/tests/problems/reservoirproblem.hh
@@ -54,7 +54,10 @@ namespace Ewoms {
 template <class TypeTag>
 class ReservoirProblem;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 
 NEW_TYPE_TAG(ReservoirBaseProblem);
 
@@ -135,7 +138,10 @@ SET_STRING_PROP(ReservoirBaseProblem, GridFile, "data/reservoir.dgf");
 
 // increase the tolerance for this problem to get larger time steps
 SET_SCALAR_PROP(ReservoirBaseProblem, NewtonRawTolerance, 1e-6);
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup TestProblems

--- a/tests/problems/richardslensproblem.hh
+++ b/tests/problems/richardslensproblem.hh
@@ -49,7 +49,10 @@ namespace Ewoms {
 template <class TypeTag>
 class RichardsLensProblem;
 
-namespace Properties {
+} // namespace Ewoms
+
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(RichardsLensProblem, INHERITS_FROM(Richards));
 
 // Use 2d YaspGrid
@@ -114,7 +117,10 @@ SET_SCALAR_PROP(RichardsLensProblem, InitialTimeStepSize, 100);
 
 // The default DGF file to load
 SET_STRING_PROP(RichardsLensProblem, GridFile, "./data/richardslens_24x16.dgf");
-} // namespace Properties
+
+END_PROPERTIES
+
+namespace Ewoms {
 
 /*!
  * \ingroup TestProblems

--- a/tests/problems/waterairproblem.hh
+++ b/tests/problems/waterairproblem.hh
@@ -58,8 +58,8 @@ template <class TypeTag>
 class WaterAirProblem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(WaterAirBaseProblem);
 
 // Set the grid type
@@ -139,8 +139,8 @@ SET_TYPE_PROP(WaterAirBaseProblem, PreconditionerWrapper,
               Ewoms::Linear::PreconditionerWrapperILUn<TypeTag>);
 #endif
 SET_INT_PROP(WaterAirBaseProblem, PreconditionerOrder, 2);
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 /*!

--- a/tests/reservoir_blackoil_ecfv.cc
+++ b/tests/reservoir_blackoil_ecfv.cc
@@ -33,8 +33,8 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/reservoirproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ReservoirBlackOilEcfvProblem, INHERITS_FROM(BlackOilModel, ReservoirBaseProblem));
 
 // Select the element centered finite volume method as spatial discretization
@@ -42,7 +42,8 @@ SET_TAG_PROP(ReservoirBlackOilEcfvProblem, SpatialDiscretizationSplice, EcfvDisc
 
 // Use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(ReservoirBlackOilEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/reservoir_blackoil_vcfv.cc
+++ b/tests/reservoir_blackoil_vcfv.cc
@@ -32,13 +32,14 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/reservoirproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ReservoirBlackOilVcfvProblem, INHERITS_FROM(BlackOilModel, ReservoirBaseProblem));
 
 // Select the vertex centered finite volume method as spatial discretization
 SET_TAG_PROP(ReservoirBlackOilVcfvProblem, SpatialDiscretizationSplice, VcfvDiscretization);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/reservoir_ncp_ecfv.cc
+++ b/tests/reservoir_ncp_ecfv.cc
@@ -32,8 +32,8 @@
 #include <ewoms/disc/ecfv/ecfvdiscretization.hh>
 #include "problems/reservoirproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ReservoirNcpEcfvProblem, INHERITS_FROM(NcpModel, ReservoirBaseProblem));
 
 // Select the element centered finite volume method as spatial discretization
@@ -41,7 +41,8 @@ SET_TAG_PROP(ReservoirNcpEcfvProblem, SpatialDiscretizationSplice, EcfvDiscretiz
 
 //! use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(ReservoirNcpEcfvProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/reservoir_ncp_vcfv.cc
+++ b/tests/reservoir_ncp_vcfv.cc
@@ -33,8 +33,8 @@
 #include <ewoms/disc/vcfv/vcfvdiscretization.hh>
 #include "problems/reservoirproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(ReservoirNcpVcfvProblem, INHERITS_FROM(NcpModel, ReservoirBaseProblem));
 
 // Select the vertex centered finite volume method as spatial discretization
@@ -48,7 +48,8 @@ SET_BOOL_PROP(ReservoirNcpVcfvProblem, EnableStorageCache, true);
 // the simulator converges better with this. (TODO: use automatic differentiation?)
 SET_SCALAR_PROP(ReservoirNcpVcfvProblem, BaseEpsilon, 1e-11);
 
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -75,12 +75,13 @@
             std::abort();                  \
     }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(TestEclOutputTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem));
 SET_BOOL_PROP(TestEclOutputTypeTag, EnableGravity, false);
 SET_BOOL_PROP(TestEclOutputTypeTag, EnableAsyncEclOutput, false);
-}}
+
+END_PROPERTIES
 
 static const int day = 24 * 60 * 60;
 

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -66,10 +66,11 @@
             std::abort();                  \
     }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(TestEquilTypeTag, INHERITS_FROM(BlackOilModel, EclBaseProblem));
-}}
+
+END_PROPERTIES
 
 template <class TypeTag>
 std::unique_ptr<typename GET_PROP_TYPE(TypeTag, Simulator)>

--- a/tests/test_propertysystem.cc
+++ b/tests/test_propertysystem.cc
@@ -35,8 +35,7 @@
 
 #include <iostream>
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
 
 ///////////////////
 // Define some hierarchy of type tags:
@@ -125,8 +124,7 @@ SET_INT_PROP(HummerH1, TopSpeed, GET_PROP_VALUE(TTAG(Pickup), TopSpeed));
 // Unmount the canon from the Hummer
 UNSET_PROP(HummerH1, CanonCaliber);
 
-} // namespace Properties
-} // namespace Ewoms
+END_PROPERTIES
 
 
 int main()

--- a/tests/waterair_pvs_ni.cc
+++ b/tests/waterair_pvs_ni.cc
@@ -31,12 +31,13 @@
 #include <ewoms/models/pvs/pvsmodel.hh>
 #include "problems/waterairproblem.hh"
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 NEW_TYPE_TAG(WaterAirProblem, INHERITS_FROM(PvsModel, WaterAirBaseProblem));
 
 SET_BOOL_PROP(WaterAirProblem, EnableEnergy, true);
-}}
+
+END_PROPERTIES
 
 int main(int argc, char **argv)
 {

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -57,8 +57,8 @@ template <class TypeTag>
 class Tutorial1Problem;
 }
 
-namespace Ewoms {
-namespace Properties {
+BEGIN_PROPERTIES
+
 // Create a new type tag for the problem
 NEW_TYPE_TAG(Tutorial1Problem, INHERITS_FROM(ImmiscibleTwoPhaseModel)); /*@\label{tutorial1:create-type-tag}@*/
 
@@ -126,8 +126,8 @@ SET_SCALAR_PROP(Tutorial1Problem, DomainSizeZ, 0.0);
 SET_INT_PROP(Tutorial1Problem, CellsX, 100);
 SET_INT_PROP(Tutorial1Problem, CellsY, 1);
 SET_INT_PROP(Tutorial1Problem, CellsZ, 1); /*@\label{tutorial1:default-params-end}@*/
-} // namespace Properties
-} // namespace Ewoms
+
+END_PROPERTIES
 
 namespace Ewoms {
 //! Tutorial problem using the "immiscible" model.


### PR DESCRIPTION
The parameter system retrieves more changes: This PR adds support for positional command line parameters and overhauls the system how the help messages are created. As a guiney pig, ebos gets support for positional parameters, and a description of is added to the help messages of ebos and the lens_* simulators.

the property system only introduces `BEGIN_PROPERTIES` and `END_PROPERTIES` macros in order to be flexible on how properties are declared in the future. Note that while this is not a very significant change in itself, converting all code to use these macros implies plenty of boiler plate changes, i.e., it is best to review the individual patches of this PR instead of the accumulated changes. (if wanted, it can also be split because it is fully bisectable.) 