### PR TITLE
parameter system: add ability to hide parameters

### DIFF
--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -88,7 +88,7 @@ namespace Ewoms {
  * \brief Announce all runtime parameters to the registry but do not specify them yet.
  */
 template <class TypeTag>
-static inline void registerAllParameters_()
+static inline void registerAllParameters_(bool finalizeRegistration = true)
 {
     typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
     typedef typename GET_PROP_TYPE(TypeTag, ThreadManager) ThreadManager;
@@ -106,7 +106,8 @@ static inline void registerAllParameters_()
     Simulator::registerParameters();
     ThreadManager::registerParameters();
 
-    EWOMS_END_PARAM_REGISTRATION(TypeTag);
+    if (finalizeRegistration)
+        EWOMS_END_PARAM_REGISTRATION(TypeTag);
 }
 
 /*!


### PR DESCRIPTION
i.e. they are still there but not mentioned in the usage message. only registered parameters can be hidden an only before the parameter registration is closed by EWOMS_END_PARAMETER_REGISTRATION.