### PR TITLE
WIP Fix thpress restart

### DIFF
--- a/ebos/eclthresholdpressure.hh
+++ b/ebos/eclthresholdpressure.hh
@@ -116,25 +116,12 @@ public:
         if (!enableThresholdPressure_)
             return;
 
-        /*
-          If this is a restart run the ThresholdPressure object will be active,
-          but it will *not* be properly initialized with numerical values. The
-          values must instead come from the THPRES vector in the restart file.
-        */
-        if (simConfig.getThresholdPressure().restart())
-            return;
-
-
         numEquilRegions_ = eclState.getTableManager().getEqldims().getNumEquilRegions();
         if (numEquilRegions_ > 0xff) {
             // make sure that the index of an equilibration region can be stored in a
             // single byte
             throw std::runtime_error("The maximum number of supported equilibration regions is 255!");
         }
-
-        // allocate the array which specifies the threshold pressures
-        thpres_.resize(numEquilRegions_*numEquilRegions_, 0.0);
-        thpresDefault_.resize(numEquilRegions_*numEquilRegions_, 0.0);
 
         // internalize the data specified using the EQLNUM keyword
         const std::vector<int>& equilRegionData =
@@ -146,6 +133,18 @@ public:
             // ECL uses Fortran-style indices but we want C-style ones!
             elemEquilRegion_[elemIdx] = equilRegionData[cartElemIdx] - 1;
         }
+
+        /*
+          If this is a restart run the ThresholdPressure object will be active,
+          but it will *not* be properly initialized with numerical values. The
+          values must instead come from the THPRES vector in the restart file.
+        */
+        if (simConfig.getThresholdPressure().restart())
+            return;
+
+        // allocate the array which specifies the threshold pressures
+        thpres_.resize(numEquilRegions_*numEquilRegions_, 0.0);
+        thpresDefault_.resize(numEquilRegions_*numEquilRegions_, 0.0);
 
         computeDefaultThresholdPressures_();
         applyExplicitThresholdPressures_();

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -253,7 +253,9 @@ public:
             {"KRNSW_GO",  Opm::UnitSystem::measure::identity, enableHysteresis}
         };
 
-        std::vector<Opm::RestartKey> extraKeys = {{"OPMEXTRA", Opm::UnitSystem::measure::identity, false}};
+        const auto& inputThpres = eclState().getSimulationConfig().getThresholdPressure();
+        std::vector<Opm::RestartKey> extraKeys = {{"OPMEXTRA", Opm::UnitSystem::measure::identity, false},
+                                                  {"THPRES", Opm::UnitSystem::measure::pressure, inputThpres.active()}};
 
         unsigned episodeIdx = simulator_.episodeIndex();
         const auto& gridView = simulator_.vanguard().gridView();
@@ -265,7 +267,6 @@ public:
             unsigned globalIdx = collectToIORank_.localIdxToGlobalIdx(elemIdx);
             eclOutputModule_.setRestart(restartValues.solution, elemIdx, globalIdx);
         }
-        const auto& inputThpres = eclState().getSimulationConfig().getThresholdPressure();
         if (inputThpres.active()) {
             Simulator& mutableSimulator = const_cast<Simulator&>(simulator_);
             auto& thpres = mutableSimulator.problem().thresholdPressure();


### PR DESCRIPTION
THPRES is read from the restart file
We no longer need to compute it from the initial conditions if defaulted.

Currently the restart of Model 2 doesn't work due to issues with THPRES input. 
This PR fixes this, but there is a slight difference in results. I have compared the
computed thpressures with the ones read from the restart file and they are identical as far as I can see. 

I will need to do some more testing to figure out whether the mis-match is related to THPRES or to something els. 