### PR TITLE
fix extra compiler warnings

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -386,10 +386,10 @@ void printUsage(const std::string& helpPreamble,
 
 /// \cond 0
 inline int noPositionalParameters_(std::string& errorMsg,
-                                   int argc,
+                                   int argc OPM_UNUSED,
                                    const char** argv,
                                    int paramIdx,
-                                   int posParamIdx)
+                                   int posParamIdx OPM_UNUSED)
 {
     errorMsg = std::string("Illegal parameter \"")+argv[paramIdx]+"\".";
     return 0;

--- a/ewoms/common/quadraturegeometries.hh
+++ b/ewoms/common/quadraturegeometries.hh
@@ -48,19 +48,19 @@ public:
     { return Dune::GeometryType(/*topologyId=*/(1 << dim) - 1, dim); }
 
     template <class CornerContainer>
-    void setCorners(const CornerContainer& corners, unsigned numCorners)
+    void setCorners(const CornerContainer& corners, unsigned nCorners)
     {
         unsigned cornerIdx;
-        for (cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx) {
+        for (cornerIdx = 0; cornerIdx < nCorners; ++cornerIdx) {
             for (unsigned j = 0; j < dim; ++j)
                 corners_[cornerIdx][j] = corners[cornerIdx][j];
         }
-        assert(cornerIdx == numCorners);
+        assert(cornerIdx == nCorners);
 
         center_ = 0;
-        for (cornerIdx = 0; cornerIdx < numCorners; ++cornerIdx)
+        for (cornerIdx = 0; cornerIdx < nCorners; ++cornerIdx)
             center_ += corners_[cornerIdx];
-        center_ /= numCorners;
+        center_ /= nCorners;
     }
 
     /*!

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -275,7 +275,7 @@ public:
      * \param timeIdx The index used for the time discretization
      */
     template <class Context>
-    void constraints(Constraints& constraints OPM_UNUSED,
+    void constraints(Constraints& constrs OPM_UNUSED,
                      const Context& context OPM_UNUSED,
                      unsigned spaceIdx OPM_UNUSED,
                      unsigned timeIdx OPM_UNUSED) const

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -430,10 +430,10 @@ public:
         }
     }
 
-    void updateEnergyQuantities_(const ElementContext& elemCtx,
-                                 unsigned dofIdx,
-                                 unsigned timeIdx,
-                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache)
+    void updateEnergyQuantities_(const ElementContext& elemCtx OPM_UNUSED,
+                                 unsigned dofIdx OPM_UNUSED,
+                                 unsigned timeIdx OPM_UNUSED,
+                                 const typename FluidSystem::template ParameterCache<Evaluation>& paramCache OPM_UNUSED)
     { }
 
     const Evaluation& rockInternalEnergy() const

--- a/ewoms/models/blackoil/blackoilsolventmodules.hh
+++ b/ewoms/models/blackoil/blackoilsolventmodules.hh
@@ -132,7 +132,6 @@ public:
         if (deck.hasKeyword("MISCIBLE")) {
             isMiscible_ = true;
 
-            unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
             unsigned numMiscRegions = 1;
 
             // misicible hydrocabon relative permeability wrt water

--- a/tests/lens_immiscible_ecfv_ad_cu1.cc
+++ b/tests/lens_immiscible_ecfv_ad_cu1.cc
@@ -38,6 +38,7 @@
 
 #include <ewoms/common/start.hh>
 
+int mainCU1(int argc, char **argv);
 int mainCU1(int argc, char **argv)
 {
     typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;

--- a/tests/problems/reservoirproblem.hh
+++ b/tests/problems/reservoirproblem.hh
@@ -551,20 +551,22 @@ public:
      * saturated with a lower pressure than the remaining reservoir.
      */
     template <class Context>
-    void constraints(Constraints& constraints, const Context& context,
-                     unsigned spaceIdx, unsigned timeIdx) const
+    void constraints(Constraints& constraintValues,
+                     const Context& context,
+                     unsigned spaceIdx,
+                     unsigned timeIdx) const
     {
         if (this->simulator().episodeIndex() == 1)
             return; // no constraints during the "settle down" episode
 
         const auto& pos = context.pos(spaceIdx, timeIdx);
         if (isInjector_(pos)) {
-            constraints.setActive(true);
-            constraints.assignNaive(injectorFluidState_);
+            constraintValues.setActive(true);
+            constraintValues.assignNaive(injectorFluidState_);
         }
         else if (isProducer_(pos)) {
-            constraints.setActive(true);
-            constraints.assignNaive(producerFluidState_);
+            constraintValues.setActive(true);
+            constraintValues.assignNaive(producerFluidState_);
         }
     }
 

--- a/tests/test_ecl_output.cc
+++ b/tests/test_ecl_output.cc
@@ -104,12 +104,14 @@ initSimulator(const char *filename)
     return std::unique_ptr<Simulator>(new Simulator);
 }
 
-ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free > readsum( const std::string& base ) {
-    return ERT::ert_unique_ptr< ecl_sum_type, ecl_sum_free >(
-            ecl_sum_fread_alloc_case( base.c_str(), ":" )
-           );
+ERT::ert_unique_ptr<ecl_sum_type, ecl_sum_free> readsum(const std::string& base);
+ERT::ert_unique_ptr<ecl_sum_type, ecl_sum_free> readsum(const std::string& base)
+{
+    return ERT::ert_unique_ptr<ecl_sum_type, ecl_sum_free>(
+            ecl_sum_fread_alloc_case(base.c_str(), ":"));
 }
 
+void test_summary();
 void test_summary()
 {
     typedef typename TTAG(TestEclOutputTypeTag) TypeTag;
@@ -176,8 +178,9 @@ void test_summary()
     CHECK_CLOSE(roip2, ecl_sum_get_general_var( resp, 1, "ROIP:2" ), 1e-3 );
 }
 
-void test_readWriteWells() {
-
+void test_readWriteWells();
+void test_readWriteWells()
+{
     using opt = Opm::data::Rates::opt;
 
     Opm::data::Rates r1, r2, rc1, rc2, rc3;
@@ -211,14 +214,14 @@ void test_readWriteWells() {
      *  the connection keys (active indices) and well names correspond to the
      *  input deck. All other entries in the well structures are arbitrary.
      */
-    w1.connections.push_back( { 88, rc1, 30.45, 123.45 } );
-    w1.connections.push_back( { 288, rc2, 33.19, 67.89 } );
+    w1.connections.push_back( { 88, rc1, 30.45, 123.45, 0.0, 0.0, 0.0 } );
+    w1.connections.push_back( { 288, rc2, 33.19, 67.89, 0.0, 0.0, 0.0 } );
 
     w2.rates = r2;
     w2.bhp = 2.34;
     w2.temperature = 4.56;
     w2.control = 2;
-    w2.connections.push_back( { 188, rc3, 36.22, 19.28 } );
+    w2.connections.push_back( { 188, rc3, 36.22, 19.28, 0.0, 0.0, 0.0 } );
 
     Opm::data::Wells wellRates;
 

--- a/tests/test_equil.cc
+++ b/tests/test_equil.cc
@@ -214,6 +214,7 @@ static Opm::EquilRecord mkEquilRecord( double datd, double datp,
     return EquilRecord( rec );
 }
 
+void test_PhasePressure();
 void test_PhasePressure()
 {
     typedef std::vector<double> PVal;
@@ -246,6 +247,7 @@ void test_PhasePressure()
     CHECK_CLOSE(ppress[1][last ] , 166.5e3 , reltol);
 }
 
+void test_CellSubset();
 void test_CellSubset()
 {
     typedef std::vector<double> PVal;
@@ -335,6 +337,7 @@ void test_CellSubset()
     CHECK_CLOSE(ppress[1][last ] , 166.5e3 , reltol);
 }
 
+void test_RegMapping();
 void test_RegMapping()
 {
     typedef std::vector<double> PVal;
@@ -422,6 +425,7 @@ void test_RegMapping()
     CHECK_CLOSE(ppress[1][last ] , 166.5e3 , reltol);
 }
 
+void test_DeckAllDead();
 void test_DeckAllDead()
 {
     typedef TTAG(TestEquilTypeTag) TypeTag;
@@ -446,6 +450,7 @@ void test_DeckAllDead()
     CHECK_CLOSE(pressures[1][last] , 1.504526940e7   , reltol);
 }
 
+void test_CapillaryInversion();
 void test_CapillaryInversion()
 {
     // Test setup.
@@ -497,6 +502,7 @@ void test_CapillaryInversion()
     }
 }
 
+void test_DeckWithCapillary();
 void test_DeckWithCapillary()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -535,6 +541,7 @@ void test_DeckWithCapillary()
     }
 }
 
+void test_DeckWithCapillaryOverlap();
 void test_DeckWithCapillaryOverlap()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -594,6 +601,7 @@ void test_DeckWithCapillaryOverlap()
     }
 }
 
+void test_DeckWithLiveOil();
 void test_DeckWithLiveOil()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -671,6 +679,7 @@ void test_DeckWithLiveOil()
     }
 }
 
+void test_DeckWithLiveGas();
 void test_DeckWithLiveGas()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -751,6 +760,7 @@ void test_DeckWithLiveGas()
     }
 }
 
+void test_DeckWithRSVDAndRVVD();
 void test_DeckWithRSVDAndRVVD()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -851,6 +861,7 @@ void test_DeckWithRSVDAndRVVD()
 }
 
 
+void test_DeckWithPBVDAndPDVD();
 void test_DeckWithPBVDAndPDVD()
 {
     typedef typename TTAG(TestEquilTypeTag) TypeTag;
@@ -941,6 +952,7 @@ void test_DeckWithPBVDAndPDVD()
     }
 }
 
+void test_DeckWithSwatinit();
 void test_DeckWithSwatinit()
 {
 #if 0

--- a/tests/test_tasklets.cc
+++ b/tests/test_tasklets.cc
@@ -62,6 +62,7 @@ private:
     int mseconds_;
 };
 
+void sleepAndPrintFunction();
 void sleepAndPrintFunction()
 {
     int ms = 100;

--- a/tutorial/tutorial1problem.hh
+++ b/tutorial/tutorial1problem.hh
@@ -269,11 +269,11 @@ public:
     //! position of the domain [kg/(m^3 * s)]. Positive values mean that
     //! mass is created.
     template <class Context>
-    void source(RateVector& source, const Context& /*context*/,
+    void source(RateVector& sourceRate, const Context& /*context*/,
                 unsigned /*spaceIdx*/, unsigned /*timeIdx*/) const
     {
-        source[contiWettingEqIdx] = 0.0;
-        source[contiNonWettingEqIdx] = 0.0;
+        sourceRate[contiWettingEqIdx] = 0.0;
+        sourceRate[contiNonWettingEqIdx] = 0.0;
     }
 
     //! Evaluates the initial value at a given position in the domain.


### PR DESCRIPTION
this is only relevant people who are masochistic enough to go beyond `-Wall`. (note that at this warning level, there is plenty of noise from Dune and other upstream dependencies.)