### PR TITLE
fix linkage of binaries that use EWOMS_HIDE_PARAM()

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -825,7 +825,7 @@ void hideParam(const char *paramName)
 {
     // make sure that a property with the parameter name exists. we cannot check if a
     // parameter exists at compile time, so this will only be caught at runtime
-    const auto& defaultValue OPM_UNUSED = GET_PROP_VALUE_(TypeTag, PropTag);
+    static const auto defaultValue OPM_UNUSED = GET_PROP_VALUE_(TypeTag, PropTag);
 
     typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
     if (!ParamsMeta::registrationOpen())


### PR DESCRIPTION
this lead to undefined symbols for binaries that use EWOMS_HIDE_PARAM() when using debugging flags on GCC. They where caused by trying to take references to the values of some properties and these values are `static const int` class attributes. Since I'm pretty sure that the c++ standard mandates that symbols for such variables must be emitted, this might constitute a GCC bug. (also, when optimizations are enabled the linker errors went away. this was probably caused by the fact that this variable was unused and the compiler thus probably killed it completely.)