### PR TITLE
simulator: provide a mutable version of Simulator::executionTimer()

### DIFF
--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -284,6 +284,8 @@ public:
      */
     const Ewoms::Timer& executionTimer() const
     { return executionTimer_; }
+    Ewoms::Timer& executionTimer()
+    { return executionTimer_; }
 
     /*!
      * \brief Returns a reference to the timer object which measures the time needed for


### PR DESCRIPTION
this allows external users like `flow` to make the execution timer return accurate timings. In `flow`'s case this is useful to implement stuff like the `TCPU` output field.