### PR TITLE
ebos: fix parallel

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -298,9 +298,9 @@ public:
                 // add missing data to global cell data
                 for (const auto& pair : localCellData_) {
                     const std::string& key = pair.first;
-                    std::size_t container_size = globalSize;
+                    std::size_t containerSize = globalSize;
                     auto OPM_OPTIM_UNUSED ret = globalCellData_.insert(key, pair.second.dim,
-                                                                       std::vector<double>(container_size),
+                                                                       std::vector<double>(containerSize),
                                                                        pair.second.target);
                     assert(ret.second);
                 }
@@ -437,9 +437,9 @@ public:
                 MessageBufferType buffer;
                 pack(0, buffer);
 
-                // pass a dummy_link to satisfy virtual class
-                const int dummy_link = -1;
-                unpack( dummy_link, buffer );
+                // pass a dummyLink to satisfy virtual class
+                int dummyLink = -1;
+                unpack(dummyLink, buffer);
             }
         }
 

--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -20,20 +20,16 @@
   module for the precise wording of the license and the list of
   copyright holders.
 */
-#ifndef EWOMS_PARALLELSERIALOUTPUT_HH
-#define EWOMS_PARALLELSERIALOUTPUT_HH
+#ifndef EWOMS_COLLECT_TO_IO_RANK_HH
+#define EWOMS_COLLECT_TO_IO_RANK_HH
 
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/data/Solution.hpp>
 #include <opm/output/data/Wells.hpp>
 
-//#if HAVE_OPM_GRID
 #include <opm/grid/common/p2pcommunicator.hh>
 #include <dune/grid/utility/persistentcontainer.hh>
 #include <dune/grid/common/gridenums.hh>
-//#else
-//#error "This header needs the opm-grid module."
-//#endif
 
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
@@ -617,5 +613,6 @@ protected:
     Opm::data::Wells globalWellData_;
 };
 
-} // end namespace Opm
+} // end namespace Ewoms
+
 #endif

--- a/ebos/eclcpgridvanguard.hh
+++ b/ebos/eclcpgridvanguard.hh
@@ -47,13 +47,10 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(EclCpGridVanguard, INHERITS_FROM(EclBaseVanguard));
 
-NEW_PROP_TAG(ExportGlobalTransmissibility);
-
 // declare the properties
 SET_TYPE_PROP(EclCpGridVanguard, Vanguard, Ewoms::EclCpGridVanguard<TypeTag>);
 SET_TYPE_PROP(EclCpGridVanguard, Grid, Dune::CpGrid);
 SET_TYPE_PROP(EclCpGridVanguard, EquilGrid, typename GET_PROP_TYPE(TypeTag, Grid));
-SET_BOOL_PROP(EclCpGridVanguard, ExportGlobalTransmissibility, false);
 
 END_PROPERTIES
 
@@ -201,17 +198,23 @@ public:
 
             delete cartesianIndexMapper_;
             cartesianIndexMapper_ = nullptr;
-
-            if (!GET_PROP_VALUE(TypeTag, ExportGlobalTransmissibility)) {
-                delete globalTrans_;
-                globalTrans_ = nullptr;
-            }
         }
 #endif
 
         cartesianIndexMapper_ = new CartesianIndexMapper(*grid_);
 
         this->updateGridView_();
+    }
+
+    /*!
+     * \brief Free the memory occupied by the global transmissibility object.
+     *
+     * After writing the initial solution, this array should not be necessary anymore.
+     */
+    void releaseGlobalTransmissibilities()
+    {
+        delete globalTrans_;
+        globalTrans_ = nullptr;
     }
 
     /*!

--- a/ebos/eclpeacemanwell.hh
+++ b/ebos/eclpeacemanwell.hh
@@ -1501,7 +1501,8 @@ protected:
         BhpEval bhpEval(bhpScalar);
         bhpEval.setDerivative(0, 1.0);
         const Scalar tolerance = 1e3*std::numeric_limits<Scalar>::epsilon();
-        for (int iterNum = 0; iterNum < 20; ++iterNum) {
+        const int maxIter = 20;
+        for (int iterNum = 0; iterNum < maxIter; ++iterNum) {
             const auto& f = wellResidual_<BhpEval>(bhpEval);
 
             if (std::abs(f.derivative(0)) < 1e-20)
@@ -1525,7 +1526,7 @@ protected:
         }
 
         throw Opm::NumericalIssue("Could not determine the bottom hole pressure of well '"+name()
-                                    +"' within 20 iterations.");
+                                  +"' within " + std::to_string(maxIter) + " iterations.");
     }
 
     template <class BhpEval>

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -558,8 +558,10 @@ public:
             maxPolymerAdsorption_.resize(numElements, 0.0);
         }
 
-        if (eclWriter_)
+        if (eclWriter_) {
             eclWriter_->writeInit();
+            this->simulator().vanguard().releaseGlobalTransmissibilities();
+        }
     }
 
     void prefetch(const Element& elem) const

--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -395,7 +395,7 @@ public:
                 }
 
                 solveTimer_.start();
-                solutionUpdate = 0;
+                solutionUpdate = 0.0;
                 linearSolver_.prepareMatrix(M);
                 bool converged = linearSolver_.solve(solutionUpdate);
                 solveTimer_.stop();

--- a/ewoms/nonlinear/newtonmethod.hh
+++ b/ewoms/nonlinear/newtonmethod.hh
@@ -598,7 +598,34 @@ protected:
      */
     void beginIteration_()
     {
-        problem().beginIteration();
+        const auto& comm = simulator_.gridView().comm();
+        bool succeeded = true;
+        try {
+            problem().beginIteration();
+        }
+        catch (const std::exception& e) {
+            succeeded = false;
+
+            std::cout << "rank " << simulator_.gridView().comm().rank()
+                      << " caught an exception while pre-processing the problem:" << e.what()
+                      << "\n"  << std::flush;
+        }
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
+        catch (const Dune::Exception& e)
+        {
+            succeeded = false;
+
+            std::cout << "rank " << simulator_.gridView().comm().rank()
+                      << " caught an exception while pre-processing the problem:" << e.what()
+                      << "\n"  << std::flush;
+        }
+#endif
+
+        succeeded = comm.min(succeeded);
+
+        if (!succeeded)
+            throw Opm::NumericalIssue("pre processing of the problem failed");
+
         lastError_ = error_;
     }
 
@@ -668,9 +695,36 @@ protected:
         // loop over the auxiliary modules and ask them to post process the solution
         // vector.
         auto& model = simulator_.model();
+        const auto& comm = simulator_.gridView().comm();
         for (unsigned i = 0; i < model.numAuxiliaryModules(); ++i) {
             auto& auxMod = *model.auxiliaryModule(i);
-            auxMod.postSolve(solutionUpdate);
+
+            bool succeeded = true;
+            try {
+                auxMod.postSolve(solutionUpdate);
+            }
+            catch (const std::exception& e) {
+                succeeded = false;
+
+                std::cout << "rank " << simulator_.gridView().comm().rank()
+                          << " caught an exception while post processing an auxiliary module:" << e.what()
+                          << "\n"  << std::flush;
+            }
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
+            catch (const Dune::Exception& e)
+            {
+                succeeded = false;
+
+                std::cout << "rank " << simulator_.gridView().comm().rank()
+                          << " caught an exception while post processing an auxiliary module:" << e.what()
+                          << "\n"  << std::flush;
+            }
+#endif
+
+            succeeded = comm.min(succeeded);
+
+            if (!succeeded)
+                throw Opm::NumericalIssue("post processing of an auxilary equation failed");
         }
     }
 
@@ -782,7 +836,34 @@ protected:
                        const SolutionVector& currentSolution  OPM_UNUSED)
     {
         ++numIterations_;
-        problem().endIteration();
+
+        const auto& comm = simulator_.gridView().comm();
+        bool succeeded = true;
+        try {
+            problem().endIteration();
+        }
+        catch (const std::exception& e) {
+            succeeded = false;
+
+            std::cout << "rank " << simulator_.gridView().comm().rank()
+                      << " caught an exception while letting the problem post-process:" << e.what()
+                      << "\n"  << std::flush;
+        }
+#if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
+        catch (const Dune::Exception& e)
+        {
+            succeeded = false;
+
+            std::cout << "rank " << simulator_.gridView().comm().rank()
+                      << " caught an exception while letting the problem post process:" << e.what()
+                      << "\n"  << std::flush;
+        }
+#endif
+
+        succeeded = comm.min(succeeded);
+
+        if (!succeeded)
+            throw Opm::NumericalIssue("post processing of the problem failed");
 
         if (asImp_().verbose_()) {
             std::cout << "Newton iteration " << numIterations_ << ""


### PR DESCRIPTION
this PR makes ebos work properly in the MPI-parallel case. if the `matrix_add_well_contributions` is not explicitly set to `true`, `flow` is completely unaffected because it currently rolls its own code when it comes to wells.

Besides the parallelization fixes, the PR contains some smaller cleanups (removal of the unused EQUIL grid, cleanup of `CollectToIORank` and the removal of the `ExportGlobalTransmissibility` properties) that have been missed during previous refactorings... (the removal of `ExportGlobalTransmissibility` requires OPM/opm-simulators#1533, but OPM/opm-simulators#1533 can be merged independently of this PR)