### PR TITLE
CollectToIORank: fix some of the const mess

### DIFF
--- a/ebos/collecttoiorank.hh
+++ b/ebos/collecttoiorank.hh
@@ -104,8 +104,8 @@ public:
         std::vector<int>& ranks_;
 
     public:
-        DistributeIndexMapping(std::vector<int>& globalIndex,
-                               std::vector<int>& distributedGlobalIndex,
+        DistributeIndexMapping(const std::vector<int>& globalIndex,
+                               const std::vector<int>& distributedGlobalIndex,
                                IndexMapType& localIndexMap,
                                IndexMapStorageType& indexMaps,
                                std::vector<int>& ranks)
@@ -279,14 +279,14 @@ public:
         const Opm::data::Solution& localCellData_;
         Opm::data::Solution& globalCellData_;
 
-        const IndexMapType& localIndexMap_;
-        const IndexMapStorageType& indexMaps_;
+        IndexMapType& localIndexMap_;
+        IndexMapStorageType& indexMaps_;
 
     public:
         PackUnPackCellData(const Opm::data::Solution& localCellData,
                            Opm::data::Solution& globalCellData,
-                           const IndexMapType& localIndexMap,
-                           const IndexMapStorageType& indexMaps,
+                           IndexMapType& localIndexMap,
+                           IndexMapStorageType& indexMaps,
                            size_t globalSize,
                            bool isIORank)
             : localCellData_(localCellData)
@@ -582,7 +582,7 @@ protected:
     IndexMapType globalCartesianIndex_;
     IndexMapType localIndexMap_;
     IndexMapStorageType indexMaps_;
-    std::vector<int>                globalRanks_;
+    std::vector<int> globalRanks_;
     Opm::data::Solution globalCellData_;
     std::map<std::pair<std::string, int>, double> globalBlockData_;
     Opm::data::Wells globalWellData_;


### PR DESCRIPTION
as noted by @blattms in his review of #346, some const qualifiers have been accidentally changed in CollectToIORank. this patch should revert them back to the state before #346.

on a more general note, while doing this patch I noticed that the `const`-ness situation in this class is (and always has been) quite messy and the code looks needlessly complicated in some places, i.e., it ought to be significantly refactored IMO.