### PR TITLE
Improve ebos ECL I/O

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -36,16 +36,10 @@
 
 #include <opm/material/common/Valgrind.hpp>
 
-#if HAVE_ECL_INPUT
 #include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#endif
-
-#if HAVE_ECL_OUTPUT
 #include <opm/output/data/Cells.hpp>
 #include <opm/output/eclipse/EclipseIO.hpp>
-#endif
-
 #include <opm/common/OpmLog/OpmLog.hpp>
 
 #include <dune/common/fvector.hh>

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -798,19 +798,19 @@ public:
      * \brief Write the requested quantities of the current solution into the output
      *        files.
      */
-    void writeOutput(bool verbose = true)
+    void writeOutput(bool isSubStep, bool verbose = true)
     {
-        Scalar t = this->simulator().time() + this->simulator().timeStepSize();
+        // use the generic code to prepare the output fields and to
+        // write the desired VTK files.
+        ParentType::writeOutput(isSubStep, verbose);
 
-        Opm::data::Wells dw;
-        if (!GET_PROP_VALUE(TypeTag, DisableWells))
-            dw = wellModel_.wellData();
+        if (!eclWriter_)
+            return;
 
-        Scalar totalSolverTime = 0.0;
-        Scalar nextstep = this->simulator().timeStepSize();
-        writeOutput(dw, t, false, totalSolverTime, nextstep, verbose);
+        eclWriter_->writeOutput(isSubStep);
     }
 
+    // this method is DEPRECATED!!!
     void writeOutput(Opm::data::Wells& dw, Scalar t, bool substep, Scalar totalSolverTime, Scalar nextstep, bool verbose = true)
     {
         // use the generic code to prepare the output fields and to

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -35,11 +35,8 @@
 #include <ewoms/io/baseoutputwriter.hh>
 #include <ewoms/parallel/tasklets.hh>
 
-#if HAVE_ECL_OUTPUT
 #include <opm/output/eclipse/EclipseIO.hpp>
 #include <opm/output/eclipse/RestartValue.hpp>
-#endif
-
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 #include <opm/grid/GridHelpers.hpp>
@@ -135,16 +132,12 @@ public:
 
     void writeInit()
     {
-#if !HAVE_ECL_OUTPUT
-        throw std::runtime_error("Eclipse output support not available in opm-common, unable to write ECL output!");
-#else
         if (collectToIORank_.isIORank()) {
             std::map<std::string, std::vector<int> > integerVectors;
             if (collectToIORank_.isParallel())
                 integerVectors.emplace("MPI_RANK", collectToIORank_.globalRanks());
             eclIO_->writeInitial(computeTrans_(), integerVectors, exportNncStructure_());
         }
-#endif
     }
 
     /*!
@@ -152,10 +145,6 @@ public:
      */
     void writeOutput(bool isSubStep)
     {
-
-#if !HAVE_ECL_INPUT
-        throw std::runtime_error("Unit support not available in opm-common.");
-#endif
         Scalar curTime = simulator_.time() + simulator_.timeStepSize();
         Scalar totalSolverTime = simulator_.executionTimer().realTimeElapsed();
         Scalar nextStepSize = simulator_.problem().nextTimeStepSize();

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -150,12 +150,18 @@ public:
     /*!
      * \brief collect and pass data and pass it to eclIO writer
      */
-    void writeOutput(Opm::data::Wells& localWellData, Scalar curTime, bool isSubStep, Scalar totalSolverTime, Scalar nextStepSize)
+    void writeOutput(bool isSubStep)
     {
 
 #if !HAVE_ECL_INPUT
         throw std::runtime_error("Unit support not available in opm-common.");
 #endif
+        Scalar curTime = simulator_.time() + simulator_.timeStepSize();
+        Scalar totalSolverTime = simulator_.executionTimer().realTimeElapsed();
+        Scalar nextStepSize = simulator_.problem().nextTimeStepSize();
+
+        // output using eclWriter if enabled
+        Opm::data::Wells localWellData = simulator_.problem().wellModel().wellData();
 
         int episodeIdx = simulator_.episodeIndex() + 1;
         const auto& gridView = simulator_.vanguard().gridView();
@@ -186,6 +192,89 @@ public:
         if (collectToIORank_.isParallel())
             collectToIORank_.collect(localCellData, eclOutputModule_.getBlockData(), localWellData);
 
+        std::map<std::string, double> miscSummaryData;
+        std::map<std::string, std::vector<double>> regionData;
+        eclOutputModule_.outputFipLog(miscSummaryData, regionData, isSubStep);
+
+        // write output on I/O rank
+        if (collectToIORank_.isIORank()) {
+            const auto& eclState = simulator_.vanguard().eclState();
+            const auto& simConfig = eclState.getSimulationConfig();
+
+            // Add TCPU
+            if (totalSolverTime != 0.0)
+                miscSummaryData["TCPU"] = totalSolverTime;
+
+            bool enableDoublePrecisionOutput = EWOMS_GET_PARAM(TypeTag, bool, EclOutputDoublePrecision);
+            const Opm::data::Solution& cellData = collectToIORank_.isParallel() ? collectToIORank_.globalCellData() : localCellData;
+            const Opm::data::Wells& wellData = collectToIORank_.isParallel() ? collectToIORank_.globalWellData() : localWellData;
+            Opm::RestartValue restartValue(cellData, wellData);
+
+            const std::map<std::pair<std::string, int>, double>& blockData
+                = collectToIORank_.isParallel()
+                ? collectToIORank_.globalBlockData()
+                : eclOutputModule_.getBlockData();
+
+            // Add suggested next timestep to extra data.
+            if (!isSubStep)
+                restartValue.addExtra("OPMEXTRA", std::vector<double>(1, nextStepSize));
+
+            if (simConfig.useThresholdPressure())
+                restartValue.addExtra("THPRES", Opm::UnitSystem::measure::pressure, simulator_.problem().thresholdPressure().data());
+
+            // first, create a tasklet to write the data for the current time step to disk
+            auto eclWriteTasklet = std::make_shared<EclWriteTasklet>(*eclIO_,
+                                                                     episodeIdx,
+                                                                     isSubStep,
+                                                                     curTime,
+                                                                     restartValue,
+                                                                     miscSummaryData,
+                                                                     regionData,
+                                                                     blockData,
+                                                                     enableDoublePrecisionOutput);
+
+            // then, make sure that the previous I/O request has been completed and the
+            // number of incomplete tasklets does not increase between time steps
+            taskletRunner_->barrier();
+
+            // finally, start a new output writing job
+            taskletRunner_->dispatch(eclWriteTasklet);
+        }
+    }
+
+    // this method is equivalent to the one above but it does not require to extract the
+    // data which ought to be written from the proper eWoms objects. this method is thus
+    // DEPRECATED!
+    void writeOutput(Opm::data::Wells& localWellData, Scalar curTime, bool isSubStep, Scalar totalSolverTime, Scalar nextStepSize)
+    {
+        int episodeIdx = simulator_.episodeIndex() + 1;
+        const auto& gridView = simulator_.vanguard().gridView();
+        int numElements = gridView.size(/*codim=*/0);
+        bool log = collectToIORank_.isIORank();
+        eclOutputModule_.allocBuffers(numElements, episodeIdx, isSubStep, log);
+
+        ElementContext elemCtx(simulator_);
+        ElementIterator elemIt = gridView.template begin</*codim=*/0>();
+        const ElementIterator& elemEndIt = gridView.template end</*codim=*/0>();
+        for (; elemIt != elemEndIt; ++elemIt) {
+            const Element& elem = *elemIt;
+            elemCtx.updatePrimaryStencil(elem);
+            elemCtx.updatePrimaryIntensiveQuantities(/*timeIdx=*/0);
+            eclOutputModule_.processElement(elemCtx);
+        }
+        eclOutputModule_.outputErrorLog();
+
+        // collect all data to I/O rank and assign to sol
+        Opm::data::Solution localCellData = {};
+        if (!isSubStep)
+            eclOutputModule_.assignToSolution(localCellData);
+
+        // add cell data to perforations for Rft output
+        if (!isSubStep)
+            eclOutputModule_.addRftDataToWells(localWellData, episodeIdx);
+
+        if (collectToIORank_.isParallel())
+            collectToIORank_.collect(localCellData, eclOutputModule_.getBlockData(), localWellData);
         std::map<std::string, double> miscSummaryData;
         std::map<std::string, std::vector<double>> regionData;
         eclOutputModule_.outputFipLog(miscSummaryData, regionData, isSubStep);


### PR DESCRIPTION
this adds a `writeOutput()` method to `EclProblem` which extracts all relevant reservoir and well data from the appropriate eWoms objects. `flow` doesn't use this, so it is unaffected.

the second patch removes the `#if HAVE_ECL_{IN,OUT}PUT` guards because `ebos` will not be useful without them. (probably it does not even compile.)