### PR TITLE
ebos: add possibility to disable the FIP output even if requested in the deck

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -51,6 +51,9 @@ BEGIN_PROPERTIES
 // create new type tag for the Ecl-output
 NEW_TYPE_TAG(EclOutputBlackOil);
 
+NEW_PROP_TAG(ForceDisableFluidInPlaceOutput);
+
+SET_BOOL_PROP(EclOutputBlackOil, ForceDisableFluidInPlaceOutput, false);
 
 END_PROPERTIES
 
@@ -126,6 +129,17 @@ public:
                 }
             }
         }
+
+        forceDisableFipOutput_ = EWOMS_GET_PARAM(TypeTag, bool, ForceDisableFluidInPlaceOutput);
+    }
+
+    /*!
+     * \brief Register all run-time parameters for the Vtk output module.
+     */
+    static void registerParameters()
+    {
+        EWOMS_REGISTER_PARAM(TypeTag, bool, ForceDisableFluidInPlaceOutput,
+                             "Do not print fluid-in-place values after each report step even if requested by the deck.");
     }
 
     /*!
@@ -1213,6 +1227,9 @@ private:
 
     void outputRegionFluidInPlace_(const ScalarBuffer& oip, const ScalarBuffer& cip, const Scalar& pav, const int reg)
     {
+        if (forceDisableFipOutput_)
+            return;
+
         const Opm::UnitSystem& units = simulator_.vanguard().eclState().getUnits();
         std::ostringstream ss;
         if (!reg) {
@@ -1277,6 +1294,7 @@ private:
 
     bool outputFipRestart_;
     bool computeFip_;
+    bool forceDisableFipOutput_;
 
     ScalarBuffer saturation_[numPhases];
     ScalarBuffer oilPressure_;

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -99,6 +99,8 @@ class EclWriter
 public:
     static void registerParameters()
     {
+        EclOutputBlackOilModule<TypeTag>::registerParameters();
+
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableAsyncEclOutput,
                              "Write the ECL-formated results in a non-blocking way (i.e., using a separate thread).");
     }


### PR DESCRIPTION
this significantly reduces the noise level of debug files if the FIP values are not of interest.

note that until OPM/opm-simulators#1512 gets merged this feature is not usable from `flow`.