### PR TITLE
fix up the more uncommon convergence criteria for the default linear solver

### DIFF
--- a/ewoms/linear/combinedcriterion.hh
+++ b/ewoms/linear/combinedcriterion.hh
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::WeightedResidualReductionCriterion
+ * \copydoc Ewoms::Linear::CombinedCriterion
  */
-#ifndef EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
-#define EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
+#ifndef EWOMS_COMBINED_CRITERION_HH
+#define EWOMS_COMBINED_CRITERION_HH
 
 #include "convergencecriterion.hh"
 

--- a/ewoms/linear/residreductioncriterion.hh
+++ b/ewoms/linear/residreductioncriterion.hh
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::ResidReductionCriterion
+ * \copydoc Ewoms::Linear::ResidReductionCriterion
  */
-#ifndef EWOMS_ISTL_RESID_REDUCTION_CRITERION_HH
-#define EWOMS_ISTL_RESID_REDUCTION_CRITERION_HH
+#ifndef EWOMS_RESID_REDUCTION_CRITERION_HH
+#define EWOMS_RESID_REDUCTION_CRITERION_HH
 
 #include "convergencecriterion.hh"
 

--- a/ewoms/linear/weightedresidreductioncriterion.hh
+++ b/ewoms/linear/weightedresidreductioncriterion.hh
@@ -22,10 +22,10 @@
 */
 /*!
  * \file
- * \copydoc Ewoms::WeightedResidualReductionCriterion
+ * \copydoc Ewoms::Linear::WeightedResidualReductionCriterion
  */
-#ifndef EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
-#define EWOMS_ISTL_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
+#ifndef EWOMS_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
+#define EWOMS_WEIGHTED_RESIDUAL_REDUCTION_CRITERION_HH
 
 #include "convergencecriterion.hh"
 
@@ -184,7 +184,9 @@ public:
     /*!
      * \copydoc ConvergenceCriterion::update(const Vector& , const Vector& )
      */
-    void update(const Vector& curSol, const Vector& curResid)
+    void update(const Vector& curSol,
+                const Vector& changeIndicator OPM_UNUSED,
+                const Vector& curResid)
     {
         lastResidualError_ = residualError_;
         updateErrors_(curSol, curResid);


### PR DESCRIPTION
some header guard macros were not adapted after copying the respective source files and ´WeightedResidualReductionCriterion::update()` was not adapted after the signature of the method changed in the base class. the practical implications of this were limited, because the affected convergence criteria are not used by default. i.e., currently they are purely used for debugging purposes.

as usual, `flow` is unaffected  by these changes. Somewhat unusually, the other binaries in eWoms also are supposed to not care...