### PR TITLE
linear: do not rescale the linear system of equations before solving

### DIFF
--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -217,8 +217,6 @@ public:
         // the values of all processes (using the assignAdd() methods)
         overlappingMatrix_->assignFromNative(M);
 
-        asImp_().rescale_();
-
         // synchronize all entries from their master processes and add entries on the
         // process border
         overlappingMatrix_->syncAdd();
@@ -322,27 +320,6 @@ protected:
         overlappingx_ = new OverlappingVector(*overlappingb_);
 
         // writeOverlapToVTK_();
-    }
-
-    void rescale_()
-    {
-        const auto& overlap = overlappingMatrix_->overlap();
-        for (unsigned domesticRowIdx = 0; domesticRowIdx < overlap.numLocal(); ++domesticRowIdx) {
-            Index nativeRowIdx = overlap.domesticToNative(static_cast<Index>(domesticRowIdx));
-            auto& row = (*overlappingMatrix_)[domesticRowIdx];
-
-            auto colIt = row.begin();
-            const auto& colEndIt = row.end();
-            for (; colIt != colEndIt; ++ colIt) {
-                auto& entry = *colIt;
-                for (unsigned i = 0; i < entry.rows; ++i)
-                    entry[i] *= simulator_.model().eqWeight(nativeRowIdx, i);
-            }
-
-            auto& rhsEntry = (*overlappingb_)[domesticRowIdx];
-            for (unsigned i = 0; i < rhsEntry.size(); ++i)
-                rhsEntry[i] *= simulator_.model().eqWeight(nativeRowIdx, i);
-        }
     }
 
     void cleanup_()


### PR DESCRIPTION
while the rescaling does not change anything mathematically, it confuses some preconditioners, in particular those which make assumptions on the semantics of a given equation.

the rescaling could either happen at model level or within a specialized linear solver backend.

`flow` is unaffected by this because it rolls its own stuff when it comes to the linear solver. the eWoms tests seem to exhibit a small performance increase on average. (most tests become faster, though some get slightly slower.)