### PR TITLE
make the "OutputDir" parameter apply universally

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -255,7 +255,7 @@ SET_BOOL_PROP(EclBaseProblem, EnableAsyncEclOutput, true);
 SET_BOOL_PROP(EclBaseProblem, EclOutputDoublePrecision, false);
 
 // The default location for the ECL output files
-SET_STRING_PROP(EclBaseProblem, EclOutputDir, ".");
+SET_STRING_PROP(EclBaseProblem, OutputDir, ".");
 
 // the cache for intensive quantities can be used for ECL problems and also yields a
 // decent speedup...
@@ -391,6 +391,12 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
     }
+
+    /*!
+     * \copydoc FvBaseProblem::prepareOutputDir
+     */
+    std::string prepareOutputDir() const
+    { return this->simulator().vanguard().eclState().getIOConfig().getOutputDir(); }
 
     /*!
      * \copydoc FvBaseProblem::handlePositionalParameter

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -226,6 +226,9 @@ SET_SCALAR_PROP(FvBaseDiscretization, MinTimeStepSize, 0.0);
 //! Disable grid adaptation by default
 SET_BOOL_PROP(FvBaseDiscretization, EnableGridAdaptation, false);
 
+//! By default, write the simulation output to the current working directory
+SET_STRING_PROP(FvBaseDiscretization, OutputDir, ".");
+
 //! Enable the VTK output by default
 SET_BOOL_PROP(FvBaseDiscretization, EnableVtkOutput, true);
 
@@ -460,6 +463,7 @@ public:
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableThermodynamicHints, "Enable thermodynamic hints");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableIntensiveQuantityCache, "Turn on caching of intensive quantities");
         EWOMS_REGISTER_PARAM(TypeTag, bool, EnableStorageCache, "Store previous storage terms and avoid re-calculating them.");
+        EWOMS_REGISTER_PARAM(TypeTag, std::string, OutputDir, "The directory to which result files are written");
     }
 
     /*!

--- a/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
+++ b/ewoms/disc/common/fvbasenewtonconvergencewriter.hh
@@ -96,7 +96,10 @@ public:
         ++ iteration_;
         if (!vtkMultiWriter_)
             vtkMultiWriter_ =
-                new VtkMultiWriter(/*async=*/false, newtonMethod_.problem().gridView(), "convergence");
+                new VtkMultiWriter(/*async=*/false,
+                                   newtonMethod_.problem().gridView(),
+                                   newtonMethod_.problem().outputDir(),
+                                   "convergence");
         vtkMultiWriter_->beginWrite(timeStepIdx_ + iteration_ / 100.0);
     }
 

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -182,6 +182,11 @@ NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(EnableGridAdaptation);
 
 /*!
+ * \brief The directory to which simulation output ought to be written to.
+ */
+NEW_PROP_TAG(OutputDir);
+
+/*!
  * \brief Global switch to enable or disable the writing of VTK output files
  *
  * If writing VTK files is disabled, then the WriteVtk$FOO options do

--- a/ewoms/io/restart.hh
+++ b/ewoms/io/restart.hh
@@ -71,12 +71,19 @@ class Restart
      */
     template <class GridView, class Scalar>
     static const std::string restartFileName_(const GridView& gridView,
+                                              const std::string& outputDir,
                                               const std::string& simName,
                                               Scalar t)
     {
+        std::string dir = outputDir;
+        if (dir == ".")
+            dir = "";
+        else if (!dir.empty() && dir.back() != '/')
+            dir += "/";
+
         int rank = gridView.comm().rank();
         std::ostringstream oss;
-        oss << simName << "_time=" << t << "_rank=" << rank << ".ers";
+        oss << dir << simName << "_time=" << t << "_rank=" << rank << ".ers";
         return oss.str();
     }
 
@@ -95,6 +102,7 @@ public:
     {
         const std::string magicCookie = magicRestartCookie_(simulator.gridView());
         fileName_ = restartFileName_(simulator.gridView(),
+                                     simulator.problem().outputDir(),
                                      simulator.problem().name(),
                                      simulator.time());
 
@@ -163,7 +171,7 @@ public:
     template <class Simulator, class Scalar>
     void deserializeBegin(Simulator& simulator, Scalar t)
     {
-        fileName_ = restartFileName_(simulator.gridView(), simulator.problem().name(), t);
+        fileName_ = restartFileName_(simulator.gridView(), simulator.problem().outputDir(), simulator.problem().name(), t);
 
         // open input file and read magic cookie
         inStream_.open(fileName_.c_str());


### PR DESCRIPTION
all disc output, i.e. VTK, restart files, ECL and -- in the future -- logfiles, goes to that directory. before this, only the ECL output could be directed to a different than the current working directory and the parameter for this was called "EclOutputDir".

note that the Dune VTK writing infrastructure makes it harder than it needs to be: suddenly Dune::VTKWriter::write() does not work in parallel anymore, but Dune::VTKWriter::pwrite() must be called with the right arguments.

this PR requires a small mop-up PR in opm-simulators.