### PR TITLE
Parameter system: Improve usage message

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -445,9 +445,9 @@ public:
     {
         if (briefDescription_.empty())
             return
-                "The Ecl-deck Black-Oil reservoir Simulator (ebos); a hydrocarbon\n"
-                "reservoir simulation program that processes ECL-formatted input\n"
-                "files which is provided by the Open Porous Media project\n"
+                "The Ecl-deck Black-Oil reservoir Simulator (ebos); a hydrocarbon "
+                "reservoir simulation program that processes ECL-formatted input "
+                "files which is provided by the Open Porous Media project "
                 "(https://opm-project.org).";
         else
             return briefDescription_;

--- a/tests/problems/lensproblem.hh
+++ b/tests/problems/lensproblem.hh
@@ -330,9 +330,9 @@ public:
             disc = "element centered finite volume";
 
         return std::string("")+
-            "Ground remediation problem where a dense oil infiltrates\n"+
-            "an aquifer with an embedded low-permability lens.\n" +
-            "This is the binary for the "+thermal+" variant using "+deriv+"\n"+
+            "Ground remediation problem where a dense oil infiltrates "+
+            "an aquifer with an embedded low-permability lens. " +
+            "This is the binary for the "+thermal+" variant using "+deriv+
             "and the "+disc+" discretization";
     }
 


### PR DESCRIPTION
This is a small epilogue to OPM/opm-simulators#1512. It prints the default values for all parameters in the usage message and on TTYs, it breaks lines nicely. (the latter is surprisingly hard to implement.)