### PR TITLE
Fix eclipse output for reordered CpGrid and add command line parameter

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -68,6 +68,8 @@ NEW_PROP_TAG(EclOutputInterval);
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 
+NEW_PROP_TAG(EnableReorderKFastest);
+SET_BOOL_PROP(EclBaseVanguard, EnableReorderKFastest, false);
 END_PROPERTIES
 
 namespace Ewoms {
@@ -102,6 +104,8 @@ public:
                              "The name of the file which contains the ECL deck to be simulated");
         EWOMS_REGISTER_PARAM(TypeTag, int, EclOutputInterval,
                              "The number of report steps that ought to be skipped between two writes of ECL results");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableReorderKFastest,
+                             "If true then k will be the fastest running index of ijk for CpGrid");
     }
 
     /*!


### PR DESCRIPTION
Companion award of OPM/opm-grid#340
The eclipse output expects the arrays in CellData to be ordered correctly, that
is local indices should be such that cartesian index i is running fastest, then
j and then k. In case the CpGrid is reordered that does not hold. Therefore we reorder
the array just before calling the eclipse IO methods.

In addition we added a command line parameter --enable-reorder-k-fastest to switch on
reordering. Default is false.