### PR TITLE
Threading fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,10 +166,10 @@ opm_add_test(waterair_pvs_ni
              TEST_ARGS --grid-global-refinements=1)
 
 opm_add_test(lens_immiscible_vcfv_ad
-             TEST_ARGS --end-time=3000 --threads-per-process=1)
+             TEST_ARGS --end-time=3000)
 
 opm_add_test(lens_immiscible_vcfv_fd
-             TEST_ARGS --end-time=3000 --threads-per-process=1)
+             TEST_ARGS --end-time=3000)
 
 opm_add_test(lens_immiscible_ecfv_ad
              TEST_ARGS --end-time=3000)
@@ -235,10 +235,10 @@ foreach(tapp co2injection_flash_ni_vcfv
   opm_add_test(${tapp})
 endforeach()
 
-opm_add_test(reservoir_blackoil_vcfv TEST_ARGS --end-time=8750000 --threads-per-process=1)
-opm_add_test(reservoir_blackoil_ecfv TEST_ARGS --end-time=8750000 --threads-per-process=1)
-opm_add_test(reservoir_ncp_vcfv TEST_ARGS --end-time=8750000 --threads-per-process=1)
-opm_add_test(reservoir_ncp_ecfv TEST_ARGS --end-time=8750000 --threads-per-process=1)
+opm_add_test(reservoir_blackoil_vcfv TEST_ARGS --end-time=8750000)
+opm_add_test(reservoir_blackoil_ecfv TEST_ARGS --end-time=8750000)
+opm_add_test(reservoir_ncp_vcfv TEST_ARGS --end-time=8750000)
+opm_add_test(reservoir_ncp_ecfv TEST_ARGS --end-time=8750000)
 
 opm_add_test(fracture_discretefracture
              CONDITION ${DUNE_ALUGRID_FOUND}
@@ -278,7 +278,7 @@ opm_add_test(lens_immiscible_vcfv_fd_parallel
              PROCESSORS 4
              CONDITION ${MPI_FOUND}
              DRIVER_ARGS --parallel-simulation=4
-             TEST_ARGS --end-time=250 --initial-time-step-size=250 --threads-per-process=1)
+             TEST_ARGS --end-time=250 --initial-time-step-size=250)
 
 opm_add_test(lens_immiscible_vcfv_ad_parallel
              EXE_NAME lens_immiscible_vcfv_ad
@@ -286,7 +286,7 @@ opm_add_test(lens_immiscible_vcfv_ad_parallel
              PROCESSORS 4
              CONDITION ${MPI_FOUND}
              DRIVER_ARGS --parallel-simulation=4
-             TEST_ARGS --end-time=250 --initial-time-step-size=250 --threads-per-process=1)
+             TEST_ARGS --end-time=250 --initial-time-step-size=250)
 
 opm_add_test(lens_immiscible_ecfv_ad_parallel
              EXE_NAME lens_immiscible_ecfv_ad

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -209,7 +209,7 @@ SET_TYPE_PROP(FvBaseDiscretization, ConstraintsContext, Ewoms::FvBaseConstraints
  * \brief The OpenMP threads manager
  */
 SET_TYPE_PROP(FvBaseDiscretization, ThreadManager, Ewoms::ThreadManager<TypeTag>);
-SET_INT_PROP(FvBaseDiscretization, ThreadsPerProcess, -1);
+SET_INT_PROP(FvBaseDiscretization, ThreadsPerProcess, 1);
 SET_BOOL_PROP(FvBaseDiscretization, UseLinearizationLock, true);
 
 /*!

--- a/ewoms/io/vtkmultiphasemodule.hh
+++ b/ewoms/io/vtkmultiphasemodule.hh
@@ -228,9 +228,9 @@ public:
 
             if (extrusionFactorOutput_()) extrusionFactor_[I] = intQuants.extrusionFactor();
             if (porosityOutput_()) porosity_[I] = Toolbox::value(intQuants.porosity());
+
             if (intrinsicPermeabilityOutput_()) {
                 const auto& K = problem.intrinsicPermeability(elemCtx, i, /*timeIdx=*/0);
-                intrinsicPermeability_[I].resize(K.rows, K.cols);
                 for (unsigned rowIdx = 0; rowIdx < K.rows; ++rowIdx)
                     for (unsigned colIdx = 0; colIdx < K.cols; ++colIdx)
                         intrinsicPermeability_[I][rowIdx][colIdx] = K[rowIdx][colIdx];

--- a/ewoms/parallel/threadmanager.hh
+++ b/ewoms/parallel/threadmanager.hh
@@ -100,12 +100,6 @@ public:
         // used in the end.
         if (numThreads_ > 0)
             omp_set_num_threads(numThreads_);
-        else {
-            if (!getenv("OMP_NUM_THREADS")) {
-                int num_core = omp_get_num_procs();
-                omp_set_num_threads(std::min(2, num_core));
-            }
-        }
 
         numThreads_ = omp_get_max_threads();
 #endif


### PR DESCRIPTION
this fixes a race condition in the VTK output code if intrinsic permeabilitiy tensors ought to be written. the reason was that Dune::DynamicMatrix::resize() is not threadsafe. now, we simply rely on the fact that the `Tensor` objects are assumed to be dim \times dim matrices by the base class anyway.

Further this PR reverts most of #370 and #371 because they break builds without OpenMP enabled and the threading mumbo-jumbo for flow is better done within opm-simulators.