### PR TITLE
move the registration of the EnableOpmRstFile to the EclBaseVanguard

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -104,6 +104,8 @@ public:
                              "The name of the file which contains the ECL deck to be simulated");
         EWOMS_REGISTER_PARAM(TypeTag, int, EclOutputInterval,
                              "The number of report steps that ought to be skipped between two writes of ECL results");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableOpmRstFile,
+                             "Include OPM-specific keywords in the ECL restart file to enable restart of OPM simulators from these files");
     }
 
     /*!

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -257,9 +257,6 @@ SET_BOOL_PROP(EclBaseProblem, EclOutputDoublePrecision, false);
 // The default location for the ECL output files
 SET_STRING_PROP(EclBaseProblem, OutputDir, ".");
 
-// Should we output OPM or ECL restart files
-SET_BOOL_PROP(EclBaseProblem, EnableOpmRstFile, false);
-
 // the cache for intensive quantities can be used for ECL problems and also yields a
 // decent speedup...
 SET_BOOL_PROP(EclBaseProblem, EnableIntensiveQuantityCache, true);
@@ -393,8 +390,6 @@ public:
                              "Tell the output writer to use double precision. Useful for 'perfect' restarts");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableOpmRstFile,
-                             "Should we include special OPM keywords to enable flow based restart");
     }
 
     /*!


### PR DESCRIPTION
before this patch the parameter was registered by the problem but not used there. Since this is quite confusing, let's move registration to where the parameter is actually used, i.e., the vanguard.

@joakim-hove: please press Green if you do not object to this.