### PR TITLE
Handle more specific exceptions first

### DIFF
--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -347,16 +347,6 @@ static inline int start(int argc, char **argv)
         }
         return 0;
     }
-    catch (std::exception& e)
-    {
-        if (myRank == 0)
-            std::cout << e.what() << ". Abort!\n" << std::flush;
-
-        std::cout << "Trying to reset TTY.\n";
-        resetTerminal_();
-
-        return 1;
-    }
 #if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
     catch (Dune::Exception& e)
     {
@@ -369,6 +359,16 @@ static inline int start(int argc, char **argv)
         return 2;
     }
 #endif
+    catch (std::exception& e)
+    {
+        if (myRank == 0)
+            std::cout << e.what() << ". Abort!\n" << std::flush;
+
+        std::cout << "Trying to reset TTY.\n";
+        resetTerminal_();
+
+        return 1;
+    }
     catch (...)
     {
         if (myRank == 0)

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -192,13 +192,6 @@ public:
             linearize_();
             succeeded = 1;
         }
-        catch (const std::exception& e)
-        {
-            std::cout << "rank " << simulator_().gridView().comm().rank()
-                      << " caught an exception while linearizing:" << e.what()
-                      << "\n"  << std::flush;
-            succeeded = 0;
-        }
 #if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,5)
         catch (const Dune::Exception& e)
         {
@@ -208,6 +201,13 @@ public:
             succeeded = 0;
         }
 #endif
+        catch (const std::exception& e)
+        {
+            std::cout << "rank " << simulator_().gridView().comm().rank()
+                      << " caught an exception while linearizing:" << e.what()
+                      << "\n"  << std::flush;
+            succeeded = 0;
+        }
         catch (...)
         {
             std::cout << "rank " << simulator_().gridView().comm().rank()


### PR DESCRIPTION
The handler for DuneException will be hidden behind the std::exception
and never be invoked. It should be moved up so that the most specific
exception is handled first.