### PR TITLE
Set default value of EnableOpmRstFile to true

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -68,7 +68,7 @@ NEW_PROP_TAG(EclOutputInterval);
 
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
-SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
+SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, true);
 
 END_PROPERTIES
 


### PR DESCRIPTION
As discussed on email the default will be to produce restart files which can be used in a flow -> flow restart.

Equinor will internally use a patched version: 