### PR TITLE
[Equinor internal]: Opm rst default false

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -72,7 +72,7 @@ NEW_PROP_TAG(IgnoreKeywords);
 SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
-SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, true);
+SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, false);
 SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 
 END_PROPERTIES


### PR DESCRIPTION
**This should not be merged, but will be used internally in *Equinor*.**

The net effect of this pr is to add the option: `--enable-opm-rst-file=false` to the `flow` command line.