### PR TITLE
Handle exceptions throw in OpenMP threads

### DIFF
--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -459,7 +459,7 @@ private:
 
         // storage to any exception that needs to be bridged out of the
         // parallel block below. initialized to null to indicate no exception
-        std::exception_ptr exc_ptr = nullptr;
+        std::exception_ptr exceptionPtr = nullptr;
 
         // relinearize the elements...
         ThreadedEntityIterator<GridView, /*codim=*/0> threadedElemIt(gridView_());
@@ -504,15 +504,15 @@ private:
 #ifdef _OPENMP
 		        std::lock_guard<std::mutex> take(this->exceptionLock);
 #endif
-		        exc_ptr = std::current_exception();
+		        exceptionPtr = std::current_exception();
 	        }
         }  // parallel block
 
-        // after reduction from the parallel block, exc_ptr will point to
+        // after reduction from the parallel block, exceptionPtr will point to
         // a valid exception if one occurred in one of the threads; rethrow
         // it here to let the outer handler take care of it properly
-        if(exc_ptr) {
-	        std::rethrow_exception(exc_ptr);
+        if(exceptionPtr) {
+	        std::rethrow_exception(exceptionPtr);
         }
 
         applyConstraintsToLinearization_();

--- a/ewoms/disc/common/fvbaselinearizer.hh
+++ b/ewoms/disc/common/fvbaselinearizer.hh
@@ -502,12 +502,9 @@ private:
 	        // numerical issue and the other one is out of memory
 	        catch(...) {
 #ifdef _OPENMP
-		        this->exceptionLock.lock();
+		        std::lock_guard<std::mutex> take(this->exceptionLock);
 #endif
 		        exc_ptr = std::current_exception();
-#ifdef _OPENMP
-		        this->exceptionLock.unlock();
-#endif
 	        }
         }  // parallel block
 

--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -226,7 +226,12 @@ public:
             // run the tasklet immediately in synchronous mode.
             while (tasklet->referenceCount() > 0) {
                 tasklet->dereference();
-                tasklet->run();
+                try {
+                    tasklet->run();
+                }
+                catch (...) {
+                    std::cerr << "ERROR: Uncaught exception when running tasklet. Trying to continue.\n";
+                }
             }
         }
         else {
@@ -317,7 +322,12 @@ protected:
             lock.unlock();
 
             // execute tasklet
-            tasklet->run();
+            try {
+                tasklet->run();
+            }
+            catch (...) {
+                std::cerr << "ERROR: Uncaught exception when running tasklet. Trying to continue.\n";
+            }
         }
     }
 

--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -32,6 +32,7 @@
 #include <thread>
 #include <queue>
 #include <mutex>
+#include <iostream>
 #include <condition_variable>
 
 namespace Ewoms {


### PR DESCRIPTION
Exceptions cannot escape from OpenMP threads to be handled at the outer
level in the master node. If an exception occurs and is not handled
within the parallel block, terminate() will be called!

This patch catches all exceptions that occurs in threads, tuck them away
and let the parallel block end normally. Afterwards one of the
exceptions are selected at random and then rethrown in single thread mode.

This implementation is perhaps the most elegant because the reduction happens in an OpenMP pragma, the cost is however that it now requires GCC 5.0 or later. We can implement the reducion explicitly with a critical section instead if that compiler requirement is not desirable; discussion in comments!