### PR TITLE
Blackoil: Prepare for 2p conditional storage of fluidstate

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -354,10 +354,7 @@ class EclProblem : public GET_PROP_TYPE(TypeTag, BaseProblem)
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
 
-    typedef Opm::BlackOilFluidState<Scalar,
-                                    FluidSystem,
-                                    enableTemperature,
-                                    enableEnergy> InitialFluidState;
+    typedef typename EclEquilInitializer<TypeTag>::ScalarFluidState InitialFluidState;
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -98,8 +98,16 @@ public:
         storage = 0.0;
 
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
-            if (!FluidSystem::phaseIsActive(phaseIdx))
+            if (!FluidSystem::phaseIsActive(phaseIdx)) {
+                if (Indices::numPhases == 3) { // add trivial equation for the pseudo phase
+                    unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
+                    if (timeIdx == 0)
+                        storage[conti0EqIdx + activeCompIdx] = Opm::variable<LhsEval>(0.0, conti0EqIdx + activeCompIdx);
+                    else
+                        storage[conti0EqIdx + activeCompIdx] = 0.0;
+                }
                 continue;
+            }
 
             unsigned activeCompIdx = Indices::canonicalToActiveComponentIndex(FluidSystem::solventComponentIndex(phaseIdx));
             LhsEval surfaceVolume =

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -270,10 +270,10 @@ public:
         typedef typename std::remove_const<ConstEvaluation>::type FsEvaluation;
         typedef typename Opm::MathToolbox<FsEvaluation> FsToolbox;
 
-        bool gasPresent = (fluidState.saturation(gasPhaseIdx) > 0.0);
-        bool oilPresent = (fluidState.saturation(oilPhaseIdx) > 0.0);
+        bool gasPresent = FluidSystem::phaseIsActive(gasPhaseIdx)?(fluidState.saturation(gasPhaseIdx) > 0.0):false;
+        bool oilPresent = FluidSystem::phaseIsActive(oilPhaseIdx)?(fluidState.saturation(oilPhaseIdx) > 0.0):false;
         static const Scalar thresholdWaterFilledCell = 1.0 - 1e-6;
-        bool onlyWater = (fluidState.saturation(waterPhaseIdx) > thresholdWaterFilledCell);
+        bool onlyWater = FluidSystem::phaseIsActive(waterPhaseIdx)?(fluidState.saturation(waterPhaseIdx) > thresholdWaterFilledCell):false;
 
         // deal with the primary variables for the energy extension
         EnergyModule::assignPrimaryVars(*this, fluidState);


### PR DESCRIPTION
Depends on OPM/opm-material#310

Gives a small (5%) speed up in the linearizer for the Olympus case. 