### PR TITLE
blackoil model: fix the equation weights

### DIFF
--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -376,16 +376,22 @@ public:
         if (globalDofIdx >= this->numGridDof())
             return 1.0;
 
+        // we do not care much about water, so it gets de-prioritized by a factor of 100
+        static constexpr Scalar waterPriority = 1e-2;
+
         if (GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume)) {
+            // Roughly convert the surface volume of the fluids from m^3 to kg. (in this
+            // context, it does not really matter if the actual densities are off by a
+            // factor of two or three.)
             switch (eqIdx) {
             case Indices::conti0EqIdx + FluidSystem::waterCompIdx:
-                return 1.0/1000.0;
+                return 1000.0*waterPriority;
 
             case Indices::conti0EqIdx + FluidSystem::gasCompIdx:
                 return 1.0;
 
             case Indices::conti0EqIdx + FluidSystem::oilCompIdx:
-                return 1.0/650.0;
+                return 650.0;
             }
         }
 
@@ -398,7 +404,9 @@ public:
         else if (EnergyModule::eqApplies(eqIdx))
             return EnergyModule::eqWeight(eqIdx);
 
-        // it is said that all kilograms are equal!
+        // it is said that all kilograms are born equal (except water)!
+        if (eqIdx == Indices::conti0EqIdx + FluidSystem::waterCompIdx)
+            return waterPriority;
         return 1.0;
     }
 


### PR DESCRIPTION
The main change is that we now care quite a bit less about water than about the hydrocarbons. Also, the equation weight was inverted when conserving fluid surface volume instead of mass, oops. Note that the tolerances for oil, gas and water are now always expressed in terms of "invalid kg per second", i.e., the tolerances for the Newton-Raphson solver probably should be changed for problems that used the black-oil model formulated in terms of surface volumes.

this is only relevant for the eWoms Newton-Raphson solver, i.e. `flow` is completely unaffected at the moment.