### PR TITLE
Use reference porosity for rock energy storage

### DIFF
--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -168,7 +168,8 @@ public:
 
         // add the internal energy of the rock
         const auto& uRock = Opm::decay<LhsEval>(intQuants.rockInternalEnergy());
-        storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
+        //storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
+        storage[contiEnergyEqIdx] += uRock;
         storage[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
     }
 

--- a/ewoms/models/blackoil/blackoilenergymodules.hh
+++ b/ewoms/models/blackoil/blackoilenergymodules.hh
@@ -167,9 +167,9 @@ public:
         }
 
         // add the internal energy of the rock
+        Scalar refPoro = intQuants.referencePorosity();
         const auto& uRock = Opm::decay<LhsEval>(intQuants.rockInternalEnergy());
-        //storage[contiEnergyEqIdx] += (1.0 - poro)*uRock;
-        storage[contiEnergyEqIdx] += uRock;
+        storage[contiEnergyEqIdx] += (1.0 - refPoro)*uRock;
         storage[contiEnergyEqIdx] *= GET_PROP_VALUE(TypeTag, BlackOilEnergyScalingFactor);
     }
 

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -316,7 +316,8 @@ public:
         }
 
         // retrieve the porosity from the problem
-        porosity_ = problem.porosity(elemCtx, dofIdx, timeIdx);
+        referencePorosity_ = problem.porosity(elemCtx, dofIdx, timeIdx);
+        porosity_ = referencePorosity_;
 
         // the porosity must be modified by the compressibility of the
         // rock...
@@ -396,6 +397,15 @@ public:
         return fluidState_.viscosity(phaseIdx)*mobility(phaseIdx);
     }
 
+    /*!
+     * \brief Returns the porosity of the rock at reference conditions.
+     *
+     * I.e., the porosity of rock which is not perturbed by pressure and temperature
+     * changes.
+     */
+    Scalar referencePorosity() const
+    { return referencePorosity_; }
+
 private:
     friend BlackOilSolventIntensiveQuantities<TypeTag>;
     friend BlackOilPolymerIntensiveQuantities<TypeTag>;
@@ -405,6 +415,7 @@ private:
     { return *static_cast<Implementation*>(this); }
 
     FluidState fluidState_;
+    Scalar referencePorosity_;
     Evaluation porosity_;
     Evaluation mobility_[numPhases];
 };


### PR DESCRIPTION
this ought to succeed #403. the difference is that porosity needs to be considered for energy storage, but compressibility as it is implemented by the blackoil model must not. as an approximation for reality we thus use the reference porosity instead of the current one.

@hnil: please press green if you agree.