### PR TITLE
Prov. localGeometry meth. for elem.-centr. discret.

### DIFF
--- a/ewoms/disc/ecfv/ecfvstencil.hh
+++ b/ewoms/disc/ecfv/ecfvstencil.hh
@@ -133,6 +133,12 @@ public:
         const LocalGeometry geometry() const
         { return element_.geometry(); }
 
+        /*!
+         * \brief Geometry of the sub-control volume relative to parent.
+         */
+        const LocalGeometry localGeometry() const
+        { return element_.geometryInFather(); }
+
     private:
         GlobalPosition centerPos_;
         Scalar volume_;


### PR DESCRIPTION
The SubControlVolume class in vertex-centered discretization has a
localGeometry method that was used in the diffusion module for free
flow boundary conditions, but there was no counterpart to this is the
Dune::Entity class, which is used for element-centered discretization.

Admittedly not knowing whether this is absolutely the same concept,
there is a geometryInFather method in the Dune::Entity class which
provides seemingly similar information.

With this patch, problems using element-centered discretizations can
thus be compiled with diffusion enabled. Testing has been minimal,
however.