### PR TITLE
simplify API of Ewoms::GenericGuard

### DIFF
--- a/ewoms/common/genericguard.hh
+++ b/ewoms/common/genericguard.hh
@@ -47,6 +47,17 @@ public:
         , isEnabled_(true)
     { }
 
+    // allow moves
+    GenericGuard(GenericGuard&& other)
+        : callback_(other.callback_)
+        , isEnabled_(other.isEnabled)
+    {
+        other.isEnabled = false;
+    }
+
+    // disable copies
+    GenericGuard(const GenericGuard& other) = delete;
+
     ~GenericGuard()
     {
         if (isEnabled_)
@@ -72,6 +83,10 @@ private:
     Callback& callback_;
     bool isEnabled_;
 };
+
+template <class Callback>
+GenericGuard<Callback> make_guard(Callback& callback)
+{ return GenericGuard<Callback>(callback); }
 
 } // namespace Ewoms
 


### PR DESCRIPTION
now it is possible to create a guard object like this:

```c++
auto guard = Ewoms::make_guard(callback);
```

where `callback` is any callable object which does not take arguments.