### PR TITLE
Avoid output of trivial fipnum regions

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -1249,6 +1249,10 @@ private:
         if (forceDisableFipOutput_)
             return;
 
+        // don't output FIPNUM report if the region has no porv.
+        if (cip[FipDataType::PoreVolume] == 0)
+            return;
+
         const Opm::UnitSystem& units = simulator_.vanguard().eclState().getUnits();
         std::ostringstream ss;
         if (!reg) {


### PR DESCRIPTION
This has annoyed me as well. 
Fix issue  OPM/opm-common#543