### PR TITLE
Allow abs. tol. in linear solver to be set by prop

### DIFF
--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -262,6 +262,9 @@ SET_BOOL_PROP(FvBaseDiscretization, EnableThermodynamicHints, false);
 // sufficient...
 SET_SCALAR_PROP(FvBaseDiscretization, LinearSolverTolerance, 1e-3);
 
+// use default initialization based on rule-of-thumb of Newton tolerance
+SET_SCALAR_PROP(FvBaseDiscretization, LinearSolverAbsTolerance, -1.);
+
 //! Set the history size of the time discretization to 2 (for implicit euler)
 SET_INT_PROP(FvBaseDiscretization, TimeDiscHistorySize, 2);
 

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -187,7 +187,11 @@ protected:
         typedef CombinedCriterion<OverlappingVector, decltype(gridView.comm())> CCC;
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        Scalar linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance() / 10.0;
+        Scalar linearSolverAbsTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance);
+        // special magic value to indicate default
+        if(linearSolverAbsTolerance == -1.) {
+	        this->simulator_.model().newtonMethod().tolerance() / 10.0;
+        }
 
         convCrit_.reset(new CCC(gridView.comm(),
                                 /*residualReductionTolerance=*/linearSolverTolerance,

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -92,6 +92,11 @@ NEW_PROP_TAG(LinearSolverOverlapSize);
 NEW_PROP_TAG(LinearSolverTolerance);
 
 /*!
+ * \brief Maximum accepted error of the norm of the residual.
+ */
+NEW_PROP_TAG(LinearSolverAbsTolerance);
+
+/*!
  * \brief Specifies the verbosity of the linear solver
  *
  * By default it is 0, i.e. it doesn't print anything. Setting this
@@ -189,6 +194,8 @@ public:
     {
         EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverTolerance,
                              "The maximum allowed error between of the linear solver");
+        EWOMS_REGISTER_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance,
+                             "The maximum accepted error of the norm of the residual");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, LinearSolverOverlapSize,
                              "The size of the algebraic overlap for the linear solver");
         EWOMS_REGISTER_PARAM(TypeTag, int, LinearSolverMaxIterations,

--- a/ewoms/linear/parallelbicgstabbackend.hh
+++ b/ewoms/linear/parallelbicgstabbackend.hh
@@ -123,7 +123,11 @@ protected:
         typedef CombinedCriterion<OverlappingVector, decltype(gridView.comm())> CCC;
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
-        Scalar linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance() / 10.0;
+        Scalar linearSolverAbsTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance);
+        // special magic value to indicate default
+        if(linearSolverAbsTolerance == -1.) {
+	        this->simulator_.model().newtonMethod().tolerance() / 10.0;
+        }
 
         convCrit_.reset(new CCC(gridView.comm(),
                                 /*residualReductionTolerance=*/linearSolverTolerance,


### PR DESCRIPTION
The magic value -1 indicates that a value based on an order less of the
Newton tolerance should be used. The special value 0. cannot be used to
signal this, as that value is already used to indicate that the
criterion should be deactivated; however there were no way of setting
this to zero before this change.

Credits belong to Tor-Harald, who realized that an over-eager
convergence check was the reason that the simulations didn't update.