### PR TITLE
fix the auto-determined absolute tolerance for the linear solver

### DIFF
--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -188,10 +188,8 @@ protected:
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
         Scalar linearSolverAbsTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance);
-        // special magic value to indicate default
-        if(linearSolverAbsTolerance == -1.) {
-	        this->simulator_.model().newtonMethod().tolerance() / 10.0;
-        }
+        if(linearSolverAbsTolerance < 0.0)
+            linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance()/100.0;
 
         convCrit_.reset(new CCC(gridView.comm(),
                                 /*residualReductionTolerance=*/linearSolverTolerance,

--- a/ewoms/linear/parallelbicgstabbackend.hh
+++ b/ewoms/linear/parallelbicgstabbackend.hh
@@ -124,10 +124,8 @@ protected:
 
         Scalar linearSolverTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverTolerance);
         Scalar linearSolverAbsTolerance = EWOMS_GET_PARAM(TypeTag, Scalar, LinearSolverAbsTolerance);
-        // special magic value to indicate default
-        if(linearSolverAbsTolerance == -1.) {
-	        this->simulator_.model().newtonMethod().tolerance() / 10.0;
-        }
+        if(linearSolverAbsTolerance < 0.0)
+            linearSolverAbsTolerance = this->simulator_.model().newtonMethod().tolerance() / 100.0;
 
         convCrit_.reset(new CCC(gridView.comm(),
                                 /*residualReductionTolerance=*/linearSolverTolerance,


### PR DESCRIPTION
this was set to -1 by default because the computed value was not used anymore after ewoms#420. The automatically computed absolute tolerance now is also tighter than it was before which hopefully reduces issues.