### PR TITLE
Ewoms pure black oil

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -397,12 +397,14 @@ public:
                 Opm::Valgrind::CheckDefined(gasFormationVolumeFactor_[globalDofIdx]);
 
             }
+            /*
             if (saturatedOilFormationVolumeFactor_.size() > 0) {
                 saturatedOilFormationVolumeFactor_[globalDofIdx] =
                     1.0/FluidSystem::template saturatedInverseFormationVolumeFactor<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);
                 Opm::Valgrind::CheckDefined(saturatedOilFormationVolumeFactor_[globalDofIdx]);
 
             }
+            */
             if (oilSaturationPressure_.size() > 0) {
                 oilSaturationPressure_[globalDofIdx] =
                     FluidSystem::template saturationPressure<FluidState, Scalar>(fs, oilPhaseIdx, pvtRegionIdx);

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -69,6 +69,7 @@
 #include <opm/material/thermal/EclThermalLawManager.hpp>
 
 #include <opm/material/fluidstates/CompositionalFluidState.hpp>
+#include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/fluidsystems/BlackOilFluidSystem.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/DryGasPvt.hpp>
 #include <opm/material/fluidsystems/blackoilpvt/WetGasPvt.hpp>
@@ -137,6 +138,9 @@ NEW_PROP_TAG(EnableThermalFluxBoundaries);
 // The class which deals with ECL aquifers
 NEW_PROP_TAG(EclAquiferModel);
 
+// the class to set fluid state
+NEW_PROP_TAG(FluidState);
+
 // Set the problem property
 SET_TYPE_PROP(EclBaseProblem, Problem, Ewoms::EclProblem<TypeTag>);
 
@@ -145,6 +149,26 @@ SET_TAG_PROP(EclBaseProblem, SpatialDiscretizationSplice, EcfvDiscretization);
 
 //! for ebos, use automatic differentiation to linearize the system of PDEs
 SET_TAG_PROP(EclBaseProblem, LocalLinearizerSplice, AutoDiffLocalLinearizer);
+
+
+SET_PROP(EclBaseProblem, FluidState)
+    {
+    private:
+      typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+      typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+      enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
+      enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
+      enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
+      enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+      typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+      typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+      static const bool compositionSwitchEnabled = Indices::gasEnabled;
+ 
+    public:
+//typedef Opm::BlackOilFluidSystemSimple<Scalar> type;
+       typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > type;
+};
+
 
 // Set the material law for fluid fluxes
 SET_PROP(EclBaseProblem, MaterialLaw)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1250,7 +1250,8 @@ public:
 
         if (useMassConservativeInitialCondition_) {
             const auto& matParams = materialLawParams(context, spaceIdx, timeIdx);
-            values.assignMassConservative(initialFluidStates_[globalDofIdx], matParams);
+            throw std::runtime_error("Mass conservative initialization disabled");            
+            //values.assignMassConservative(initialFluidStates_[globalDofIdx], matParams);
         }
         else
             values.assignNaive(initialFluidStates_[globalDofIdx]);

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -40,6 +40,9 @@
 #include <cstring>
 #include <utility>
 
+BEGIN_PROPERTIES
+NEW_PROP_TAG(FluidState);
+END_PROPERTIES
 namespace Ewoms {
 /*!
  * \ingroup BlackOilModel
@@ -68,7 +71,8 @@ class BlackOilIntensiveQuantities
     typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GET_PROP_TYPE(TypeTag, FluxModule) FluxModule;
-
+    typedef typename GET_PROP_TYPE(TypeTag, FluidState) FluidState;
+    
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
@@ -91,7 +95,8 @@ class BlackOilIntensiveQuantities
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldMatrix<Scalar, dimWorld, dimWorld> DimMatrix;
     typedef typename FluxModule::FluxIntensiveQuantities FluxIntensiveQuantities;
-    typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > FluidState;
+    //typedef Opm::BlackOilFluidState<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > FluidState;
+    //typedef FluidStateType<Evaluation, FluidSystem, enableTemperature, enableEnergy, compositionSwitchEnabled,  Indices::numPhases > FluidState; 
 
 public:
     BlackOilIntensiveQuantities()

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -530,6 +530,7 @@ protected:
 
     void registerOutputModules_()
     {
+        /*
         ParentType::registerOutputModules_();
 
         // add the VTK output modules which make sense for the blackoil model
@@ -539,6 +540,7 @@ protected:
 
         this->addOutputModule(new Ewoms::VtkBlackOilModule<TypeTag>(this->simulator_));
         this->addOutputModule(new Ewoms::VtkCompositionModule<TypeTag>(this->simulator_));
+        */
     }
 
 private:


### PR DESCRIPTION
Pull request for discussion: This changes make it posssible to to run with a black oil fluidsystem with minimal interface.

This avoid that one has to implement interface to function not needed if one only are running black oil. It should not change other tings.

A better implementation would probably be to have a compiler switch for some of the commented lines to be able to easy use the genneral vtk output functions in the future..