### PR TITLE
[bugfix][MatrixBlock] fix fallout from SparseMatrixAdapter merge for DUNE 2.4.1.

### DIFF
--- a/ewoms/linear/matrixblock.hh
+++ b/ewoms/linear/matrixblock.hh
@@ -209,9 +209,9 @@ static inline void invertMatrix(Dune::FieldMatrix<K, 4, 4>& matrix)
 template <class Scalar, int n, int m>
 class MatrixBlock : public Dune::FieldMatrix<Scalar, n, m>
 {
+public:
     typedef Dune::FieldMatrix<Scalar, n, m>  BaseType;
 
-public:
     using BaseType::operator= ;
     using BaseType::rows;
     using BaseType::cols;


### PR DESCRIPTION
This fixes compilation issues mentioned in opm-simulators#1635. 