### PR TITLE
Tasklets: Provide Additional Context For 'std::exception'

### DIFF
--- a/ewoms/parallel/tasklets.hh
+++ b/ewoms/parallel/tasklets.hh
@@ -230,8 +230,11 @@ public:
                 try {
                     tasklet->run();
                 }
+                catch (const std::exception& e) {
+                    std::cerr << "ERROR: Uncaught std::exception when running tasklet: " << e.what() << ". Trying to continue.\n";
+                }
                 catch (...) {
-                    std::cerr << "ERROR: Uncaught exception when running tasklet. Trying to continue.\n";
+                    std::cerr << "ERROR: Uncaught exception (general type) when running tasklet. Trying to continue.\n";
                 }
             }
         }
@@ -325,6 +328,9 @@ protected:
             // execute tasklet
             try {
                 tasklet->run();
+            }
+            catch (const std::exception& e) {
+                std::cerr << "ERROR: Uncaught std::exception when running tasklet: " << e.what() << ". Trying to continue.\n";
             }
             catch (...) {
                 std::cerr << "ERROR: Uncaught exception when running tasklet. Trying to continue.\n";


### PR DESCRIPTION
This commit adds an information-only exception handler for types derived from `std::exception`.  The handler prints `what()` in addition to the general notification about an exception in the case of exceptions propagating from within a `TaskletInterface::run()`.

This, in turn, is useful in tracking down the origin of a problem without running the process in a debugger.