### PR TITLE
Fix tracer code compilation for DUNE versions other than 2.6

### DIFF
--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -381,8 +381,8 @@ protected:
     bool linearSolve_(const TracerMatrix& M, TracerVector& x, TracerVector& b)
     {
 #if ! DUNE_VERSION_NEWER(DUNE_COMMON, 2,7)
-        Dune::FMatrixPrecision<LinearSolverScalar>::set_singular_limit(1.e-30);
-        Dune::FMatrixPrecision<LinearSolverScalar>::set_absolute_limit(1.e-30);
+        Dune::FMatrixPrecision<Scalar>::set_singular_limit(1.e-30);
+        Dune::FMatrixPrecision<Scalar>::set_absolute_limit(1.e-30);
 #endif
         x = 0.0;
         Scalar tolerance = 1e-2;

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -392,11 +392,15 @@ protected:
         typedef Dune::BiCGSTABSolver<TracerVector> TracerSolver;
         typedef Dune::MatrixAdapter<TracerMatrix, TracerVector , TracerVector > TracerOperator;
         typedef Dune::SeqScalarProduct< TracerVector > TracerScalarProduct ;
+#if DUNE_VERSION_NEWER(DUNE_ISTL, 2,6)
         typedef Dune::SeqILU< TracerMatrix, TracerVector, TracerVector  > TracerPreconditioner;
+#else
+        typedef Dune::SeqILUn< TracerMatrix, TracerVector, TracerVector  > TracerPreconditioner;
+#endif
 
         TracerOperator tracerOperator(M);
         TracerScalarProduct tracerScalarProduct;
-        TracerPreconditioner tracerPreconditioner(M, 1);
+        TracerPreconditioner tracerPreconditioner(M, 0, 1); // results in ILU0
 
         TracerSolver solver (tracerOperator, tracerScalarProduct,
                              tracerPreconditioner, tolerance, maxIter,


### PR DESCRIPTION
Closes #438.
Since the merge of PR #431 I experienced compile errors with DUNE versions 2.4, 2.5, and current master.
The old version do not know SeqILU (added in 2.6) and for master an undefined typedef was used