### PR TITLE
Do not log messages during getWriteRestartFile query on all procs.

### DIFF
--- a/ebos/ecloutputblackoilmodule.hh
+++ b/ebos/ecloutputblackoilmodule.hh
@@ -217,7 +217,7 @@ public:
         }
 
         // Only provide restart on restart steps
-        if (!restartConfig.getWriteRestartFile(reportStepNum) || substep)
+        if (!restartConfig.getWriteRestartFile(reportStepNum, log) || substep)
             return;
 
         // always output saturation of active phases


### PR DESCRIPTION
Previously all processes reported
"Warning: Fast restart using SAVE is not supported. Standard restart file is written instead."
in the PRT file.
Now this is done only on the master process where logging is activated.