### PR TITLE
Add parameter for (dis)enable the tracer model

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -302,6 +302,8 @@ SET_BOOL_PROP(EclBaseProblem, EnableEnergy, false);
 // disable thermal flux boundaries by default
 SET_BOOL_PROP(EclBaseProblem, EnableThermalFluxBoundaries, false);
 
+SET_BOOL_PROP(EclBaseProblem, EnableTracerModel, false);
+
 END_PROPERTIES
 
 namespace Ewoms {
@@ -400,6 +402,8 @@ public:
                              "Tell the output writer to use double precision. Useful for 'perfect' restarts");
         EWOMS_REGISTER_PARAM(TypeTag, unsigned, RestartWritingInterval,
                              "The frequencies of which time steps are serialized to disk");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EnableTracerModel,
+                             "Transport tracers found in the deck.");
     }
 
     /*!

--- a/ebos/ecltracermodel.hh
+++ b/ebos/ecltracermodel.hh
@@ -35,6 +35,11 @@
 #include <vector>
 #include <iostream>
 
+BEGIN_PROPERTIES
+
+NEW_PROP_TAG(EnableTracerModel);
+
+END_PROPERTIES
 
 namespace Ewoms {
 
@@ -75,6 +80,7 @@ public:
         : simulator_(simulator)
     { }
 
+
     /*!
      * \brief Initialize all internal data structures needed by the tracer module
      */
@@ -84,6 +90,13 @@ public:
 
         if (!deck.hasKeyword("TRACERS"))
             return; // tracer treatment is supposed to be disabled
+
+        if (!EWOMS_GET_PARAM(TypeTag, bool, EnableTracerModel))
+        {
+            std::cout << "Warning: Tracer model is disabled but the deck contatins the TRACERS keyword \n";
+            std::cout << "The tracer model must be activated by the enable-tracer-model=true "<< std::endl;
+            return; // Tracer transport must be enabled by the user
+        }
 
         if (!deck.hasKeyword("TRACER")){
             throw std::runtime_error("the deck does not contain the TRACER keyword");


### PR DESCRIPTION
The tracer model slows down the simulation time and is disabled by
default, until the performance is improved.