### PR TITLE
Extending the polymer module to handle the polymer molecular weight transport

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -93,6 +93,8 @@
 
 #include <opm/output/eclipse/EclipseIO.hpp>
 
+#include <opm/common/OpmLog/OpmLog.hpp>
+
 #include <boost/date_time.hpp>
 
 #include <set>
@@ -1298,7 +1300,7 @@ public:
 
         if (enablePolymerMW)
             values[Indices::polymerMoleWeightIdx]= polymerMoleWeight_[globalDofIdx];
-	    
+
         values.checkDefined();
     }
 
@@ -1807,8 +1809,13 @@ private:
         if (enablePolymer)
             polymerConcentration_.resize(numElems,0.0);
 
-        if (enablePolymerMW)
+        if (enablePolymerMW) {
+            const std::string msg {"Support of the RESTART for polymer molecular weight "
+                                   "is not implemented yet. The polymer weight value will be "
+                                   "zero when RESTART begins"};
+            Opm::OpmLog::warning("NO_POLYMW_RESTART", msg);
             polymerMoleWeight_.resize(numElems, 0.0);
+        }
 
         for (size_t elemIdx = 0; elemIdx < numElems; ++elemIdx) {
             auto& elemFluidState = initialFluidStates_[elemIdx];

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1121,14 +1121,13 @@ public:
     /*!
     * \brief Returns the polymer molecule weight for a given cell index
     */
+    // TODO: remove this function if not called
     Scalar polymerMolecularWeight(const unsigned elemIdx) const
     {
         if (polymerMoleWeight_.empty())
             return 0.0;
 
         return polymerMoleWeight_[elemIdx];
-        // TODO: not sure where this function will be called
-        // TODO: if not, it should be removed
     }
 
     /*!
@@ -1820,7 +1819,7 @@ private:
                  solventSaturation_[elemIdx] = eclWriter_->eclOutputModule().getSolventSaturation(elemIdx);
             if (enablePolymer)
                  polymerConcentration_[elemIdx] = eclWriter_->eclOutputModule().getPolymerConcentration(elemIdx);
-            // TODO: something need to add the polymer molecular weight related to output
+            // if we need to restart for polymer molecular weight simulation, we need to add related here
         }
 
         if (tracerModel().numTracers() > 0)

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -104,6 +104,10 @@ public:
     static const int polymerConcentrationIdx =
         enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
 
+    //! Index of the primary variable for the second polymer primary variable (molecular weight)
+    static const int polymerMoleWeightIdx =
+        numPolymers_ > 1 ? polymerConcentrationIdx + 1 : -1000;
+
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
         enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
@@ -123,6 +127,10 @@ public:
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
         enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+
+    //! Index of the continuity equation for the second polymer component (molecular weight)
+    static const int contiPolymerMWEqIdx =
+        numPolymers_ > 1 ? contiPolymerEqIdx + 1 : -1000;
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -35,7 +35,7 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <bool enableSolventV, bool enablePolymerV, bool enableEnergyV, unsigned PVOffset>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, unsigned PVOffset>
 struct BlackOilIndices
 {
     //! Number of phases active at all times
@@ -47,23 +47,23 @@ struct BlackOilIndices
     static const bool gasEnabled = true;
 
     //! Are solvents involved?
-    static const bool enableSolvent = enableSolventV;
+    static const bool enableSolvent = numSolventsV > 0;
 
     //! Are polymers involved?
-    static const bool enablePolymer = enablePolymerV;
+    static const bool enablePolymer = numPolymersV > 0;
 
     //! Shall energy be conserved?
-    static const bool enableEnergy = enableEnergyV;
+    static const bool enableEnergy = numEnergyV > 0;
 
 private:
     //! Number of solvent components to be considered
-    static const int numSolvents_ = enableSolvent ? 1 : 0;
+    static const int numSolvents_ = enableSolvent ? numSolventsV : 0;
 
     //! Number of polymer components to be considered
-    static const int numPolymers_ = enablePolymer ? 1 : 0;
+    static const int numPolymers_ = enablePolymer ? numPolymersV : 0;
 
     //! Number of energy equations to be considered
-    static const int numEnergy_ = enableEnergy ? 1 : 0;
+    static const int numEnergy_ = enableEnergy ? numEnergyV : 0;
 
 public:
     //! The number of equations

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -96,13 +96,14 @@ public:
      */
     static const int compositionSwitchIdx = PVOffset + 2;
 
+    // TODO: the following -1 thing only applies to the num*** is 1
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx =
         enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents_ : -1000;
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static const int polymerMoleWeightIdx =
@@ -126,7 +127,7 @@ public:
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+        enablePolymer > 0 ? PVOffset + numPhases + numSolvents_ : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -55,19 +55,17 @@ struct BlackOilIndices
     //! Shall energy be conserved?
     static const bool enableEnergy = numEnergyV > 0;
 
-private:
     //! Number of solvent components to be considered
-    static const int numSolvents_ = enableSolvent ? numSolventsV : 0;
+    static const int numSolvents = enableSolvent ? numSolventsV : 0;
 
     //! Number of polymer components to be considered
-    static const int numPolymers_ = enablePolymer ? numPolymersV : 0;
+    static const int numPolymers = enablePolymer ? numPolymersV : 0;
 
     //! Number of energy equations to be considered
-    static const int numEnergy_ = enableEnergy ? numEnergyV : 0;
+    static const int numEnergy = enableEnergy ? numEnergyV : 0;
 
-public:
     //! The number of equations
-    static const int numEq = numPhases + numSolvents_ + numPolymers_ + numEnergy_;
+    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy;
 
     //! \brief returns the index of "active" component
     static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
@@ -99,19 +97,19 @@ public:
     // TODO: the following -1 thing only applies to the num*** is 1
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + numPhases + numSolvents_ : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static const int polymerMoleWeightIdx =
-        numPolymers_ > 1 ? polymerConcentrationIdx + 1 : -1000;
+        numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
 
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : - 1000;
 
     ////////
     // Equation indices
@@ -123,19 +121,19 @@ public:
 
     //! Index of the continuity equation for the first solvent component
     static const int contiSolventEqIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + numPhases + numSolvents_ : -1000;
+        enablePolymer > 0 ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =
-        numPolymers_ > 1 ? contiPolymerEqIdx + 1 : -1000;
+        numPolymers > 1 ? contiPolymerEqIdx + 1 : -1000;
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : -1000;
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : -1000;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -94,10 +94,9 @@ struct BlackOilIndices
      */
     static const int compositionSwitchIdx = PVOffset + 2;
 
-    // TODO: the following -1 thing only applies to the num*** is 1
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
+        enableSolvent ? PVOffset + numPhases : -1000;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
@@ -109,7 +108,7 @@ struct BlackOilIndices
 
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : - 1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : - 1000;
 
     ////////
     // Equation indices
@@ -121,11 +120,11 @@ struct BlackOilIndices
 
     //! Index of the continuity equation for the first solvent component
     static const int contiSolventEqIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
+        enableSolvent ? PVOffset + numPhases : -1000;
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + numPhases + numSolvents : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =
@@ -133,7 +132,7 @@ struct BlackOilIndices
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : -1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -71,6 +71,7 @@ class BlackOilIntensiveQuantities
 
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
+    //  it is not used anywhere here
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
     enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -71,7 +71,6 @@ class BlackOilIntensiveQuantities
 
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
-    //  it is not used anywhere here
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
     enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -127,6 +127,8 @@ public:
 // by default, all ECL extension modules are disabled
 SET_BOOL_PROP(BlackOilModel, EnableSolvent, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
+SET_BOOL_PROP(BlackOilModel, EnablePolymerMW, false);
+
 
 //! By default, the blackoil model is isothermal and does not conserve energy
 SET_BOOL_PROP(BlackOilModel, EnableTemperature, false);

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -129,7 +129,6 @@ SET_BOOL_PROP(BlackOilModel, EnableSolvent, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymerMW, false);
 
-
 //! By default, the blackoil model is isothermal and does not conserve energy
 SET_BOOL_PROP(BlackOilModel, EnableTemperature, false);
 SET_BOOL_PROP(BlackOilModel, EnableEnergy, false);

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -254,7 +254,10 @@ protected:
                 delta *= satAlpha;
             else if (pvIdx == Indices::polymerMoleWeightIdx) {
                 const double sign = delta >= 0. ? 1. : -1.;
-                delta = sign * std::min(std::abs(delta), 5.0);
+                // maximum change of polymer molecular weight, the unit is MDa.
+                // applying this limit to stabilize the simulation. The value itself is still experimental.
+                const double maxMWChange = 100.0;
+                delta = sign * std::min(std::abs(delta), maxMWChange);
                 delta *= satAlpha;
             }
 

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -252,6 +252,11 @@ protected:
             else if (pvIdx == Indices::solventSaturationIdx)
                 // solvent saturation updates are also subject to the Appleyard chop
                 delta *= satAlpha;
+            else if (pvIdx == Indices::polymerMoleWeightIdx) {
+                const double sign = delta >= 0. ? 1. : -1.;
+                delta = sign * std::min(std::abs(delta), 5.0);
+                delta *= satAlpha;
+            }
 
             // do the actual update
             nextValue[pvIdx] = currentValue[pvIdx] - delta;
@@ -263,6 +268,13 @@ protected:
             // keep the polymer concentration above 0
             if (pvIdx == Indices::polymerConcentrationIdx)
                 nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0);
+
+            if (pvIdx == Indices::polymerMoleWeightIdx) {
+                nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0);
+                const double polymerConcentration = nextValue[Indices::polymerConcentrationIdx];
+                if (polymerConcentration < 1.e-10)
+                    nextValue[pvIdx] = 0.0;
+            }
 
         }
 

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -1140,7 +1140,8 @@ public:
             const Evaluation x = 1.e-6 * 1000. * polymerConcentration_ * intrinsicViscosity;
             // TODO: the viscosity correction is used for mobility, so it is a division correction
             waterViscosityCorrection_ = 1.0 / ( 1.0 + gamma * (x + kappa * x * x) );
-            polymerViscosityCorrection_ = waterViscosityCorrection_;
+            // In this model, the mixing parameter is not considered. We assume fully mixing always.
+            polymerViscosityCorrection_ = 1.0;
         }
 
         // adjust water mobility

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -469,7 +469,31 @@ public:
         }
     }
 
+    /*!
+    * \brief get the SKPRWAT table
+    */
+    static TabulatedTwoDFunction& getSkprwatTable(const int numTable)
+    {
+        const auto iterTable = skprwatTables_.find(numTable);
+        if (iterTable != plymwinjTables_.end()) {
+            return iterTable->second;
+        } else {
+            throw std::runtime_error(" the SKPRWAT table " + std::to_string(numTable) + " does not exist\n");
+        }
+    }
 
+    /*!
+    * \brief get the SKPRWAT table
+    */
+    static TabulatedTwoDFunction& getSkprpolyTable(const int numTable)
+    {
+        const auto iterTable = skprpolyTables_.find(numTable);
+        if (iterTable != skprpolyTables_.end()) {
+            return iterTable->second;
+        } else {
+            throw std::runtime_error(" the SKPRPOLY table " + std::to_string(numTable) + " does not exist\n");
+        }
+    }
 
     /*!
      * \brief Register all run-time parameters for the black-oil polymer module.

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -589,7 +589,7 @@ public:
                 * Toolbox::template decay<LhsEval>(intQuants.polymerRockDensity())
                 * Toolbox::template decay<LhsEval>(intQuants.polymerAdsorption());
 
-        const LhsEval accumulationPolymer = massPolymer + adsorptionPolymer;
+        LhsEval accumulationPolymer = massPolymer + adsorptionPolymer;
 
         storage[contiPolymerEqIdx] += accumulationPolymer;
 
@@ -599,6 +599,8 @@ public:
             // TODO: for the water, there is something like a minimum water saturation there
             // TODO: basically, it is multiplying the accumulation term of polymer equation by the molecular weight
             // TODO: needs to check later whether this is the good way
+            accumulationPolymer = Opm::max(accumulationPolymer, 1e-10);
+
             storage[contiPolymerMWEqIdx]  += accumulationPolymer
                                          * Toolbox::template decay<LhsEval> (intQuants.polymerMoleWeight() );
         }

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -884,14 +884,14 @@ public:
         const Scalar eps = 1e-14;
         // return 1.0 if the polymer has no effect on the water.
         if ( std::abs( (viscosityMultiplier - 1.0) ) < eps){
-            return 1.0;
+            return v0 * 0. + 1.;
         }
 
         const std::vector<Scalar>& shearEffectRefLogVelocity = plyshlogShearEffectRefLogVelocity_[pvtnumRegionIdx];
         auto v0AbsLog = Opm::log(Opm::abs(v0));
         // return 1.0 if the velocity /sharte is smaller than the first velocity entry.
         if (v0AbsLog < shearEffectRefLogVelocity[0])
-            return 1.0;
+            return v0 * 0. + 1.0;
 
         // compute shear factor from input
         // Z = (1 + (P - 1) * M(v) ) / P

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -97,6 +97,11 @@ class BlackOilPolymerModule
     static constexpr unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
     static constexpr unsigned numPhases = FluidSystem::numPhases;
 
+    struct SkprpolyTable {
+        double refConcentration;
+        TabulatedTwoDFunction table_func;
+    };
+
 public:
     enum AdsorptionBehaviour { Desorption = 1, NoDesorption = 2 };
 
@@ -485,7 +490,7 @@ public:
     /*!
     * \brief get the SKPRWAT table
     */
-    static TabulatedTwoDFunction& getSkprpolyTable(const int numTable)
+    static SkprpolyTable& getSkprpolyTable(const int numTable)
     {
         const auto iterTable = skprpolyTables_.find(numTable);
         if (iterTable != skprpolyTables_.end()) {
@@ -963,10 +968,6 @@ private:
     static std::map<int, TabulatedTwoDFunction> plymwinjTables_;
     static std::map<int, TabulatedTwoDFunction> skprwatTables_;
 
-    struct SkprpolyTable {
-        double refConcentration;
-        TabulatedTwoDFunction table;
-    };
     static std::map<int, SkprpolyTable> skprpolyTables_;
 };
 
@@ -1086,7 +1087,9 @@ public:
     {
         const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         polymerConcentration_ = priVars.makeEvaluation(polymerConcentrationIdx, timeIdx);
-        polymerMoleWeight_ = priVars.makeEvaluation(polymerMoleWeightIdx, timeIdx);
+        if (enablePolymerMW) {
+            polymerMoleWeight_ = priVars.makeEvaluation(polymerMoleWeightIdx, timeIdx);
+        }
         const Scalar cmax = PolymerModule::plymaxMaxConcentration(elemCtx, dofIdx, timeIdx);
 
         // permeability reduction due to polymer

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -333,9 +333,9 @@ public:
             for (const auto& table : plymwinjTables) {
                 const int table_number = table.first;
                 const auto& plymwinjtable = table.second;
-                const std::vector<double>& throughput = plymwinjtable.getXSamplingPoints();
-                const std::vector<double>& watervelocity = plymwinjtable.getYSamplingPoints();
-                const std::vector<std::vector<double>>& molecularweight = plymwinjtable.getTableData();
+                const std::vector<double>& throughput = plymwinjtable.getThroughputs();
+                const std::vector<double>& watervelocity = plymwinjtable.getVelocities();
+                const std::vector<std::vector<double>>& molecularweight = plymwinjtable.getMoleWeights();
                 TabulatedTwoDFunction tablefunc(throughput, watervelocity, molecularweight, true, false);
                 plymwinjTables_[table_number] = std::move(tablefunc);
             }
@@ -345,9 +345,9 @@ public:
             for (const auto& table : skprwatTables) {
                 const int table_number = table.first;
                 const auto& skprwattable = table.second;
-                const std::vector<double>& throughput = skprwattable.getXSamplingPoints();
-                const std::vector<double>& watervelocity = skprwattable.getYSamplingPoints();
-                const std::vector<std::vector<double>>& skinpressure = skprwattable.getTableData();
+                const std::vector<double>& throughput = skprwattable.getThroughputs();
+                const std::vector<double>& watervelocity = skprwattable.getVelocities();
+                const std::vector<std::vector<double>>& skinpressure = skprwattable.getSkinPressures();
                 TabulatedTwoDFunction tablefunc(throughput, watervelocity, skinpressure, true, false);
                 skprwatTables_[table_number] = std::move(tablefunc);
             }
@@ -357,9 +357,9 @@ public:
             for (const auto& table : skprpolyTables) {
                 const int table_number = table.first;
                 const auto& skprpolytable = table.second;
-                const std::vector<double>& throughput = skprpolytable.getXSamplingPoints();
-                const std::vector<double>& watervelocity = skprpolytable.getYSamplingPoints();
-                const std::vector<std::vector<double>>& skinpressure = skprpolytable.getTableData();
+                const std::vector<double>& throughput = skprpolytable.getThroughputs();
+                const std::vector<double>& watervelocity = skprpolytable.getVelocities();
+                const std::vector<std::vector<double>>& skinpressure = skprpolytable.getSkinPressures();
                 const double ref_polymer_concentration = skprpolytable.referenceConcentration();
                 SkprpolyTable tablefunc = {ref_polymer_concentration,
                                            TabulatedTwoDFunction(throughput, watervelocity, skinpressure, true, false)};

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -671,33 +671,6 @@ public:
     }
 
     /*!
-     * \brief Assign the polymer specific primary variables to a PrimaryVariables object
-     */
-    static void assignPrimaryVars(PrimaryVariables& priVars,
-                                  Scalar polymerConcentration)
-    {
-        if (!enablePolymer)
-            return;
-        // TODO: not called
-        priVars[polymerConcentrationIdx] = polymerConcentration;
-    }
-
-    /*!
-     * \brief Do a Newton-Raphson update the primary variables of the polymers.
-     */
-    static void updatePrimaryVars(PrimaryVariables& newPv,
-                                  const PrimaryVariables& oldPv,
-                                  const EqVector& delta)
-    {
-        if (!enablePolymer)
-            return;
-
-        // TODO: not called
-        // do a plain unchopped Newton update
-        newPv[polymerConcentrationIdx] = oldPv[polymerConcentrationIdx] - delta[polymerConcentrationIdx];
-    }
-
-    /*!
      * \brief Return how much a Newton-Raphson update is considered an error
      */
     static Scalar computeUpdateError(const PrimaryVariables& oldPv OPM_UNUSED,
@@ -707,16 +680,6 @@ public:
         // convergence
         // TODO: maybe this should be changed
         return static_cast<Scalar>(0.0);
-    }
-
-    /*!
-     * \brief Return how much a residual is considered an error
-     */
-    static Scalar computeResidualError(const EqVector& resid)
-    {
-        // TODO: not called
-        // do not weight the residual of polymers when it comes to convergence
-        return std::abs(Toolbox::scalarValue(resid[contiPolymerEqIdx]));
     }
 
     template <class DofEntity>
@@ -741,7 +704,6 @@ public:
         PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
         PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
 
-        // TODO: not sure how to handle here for polymer molecular weight
         instream >> priVars0[polymerConcentrationIdx];
         instream >> priVars0[polymerMoleWeightIdx];
 

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -569,7 +569,7 @@ public:
 
         const auto& fs = intQuants.fluidState();
 
-        const LhsEval surfaceVolumeWater =
+        LhsEval surfaceVolumeWater =
                 Toolbox::template decay<LhsEval>(fs.saturation(waterPhaseIdx))
                 * Toolbox::template decay<LhsEval>(fs.invB(waterPhaseIdx))
                 * Toolbox::template decay<LhsEval>(intQuants.porosity());

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -90,6 +90,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+    enum { enablePolymerMW = GET_PROP_VALUE(TypeTag, EnablePolymerMW) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
@@ -242,6 +243,8 @@ public:
         assignNaive(fsFlash);
     }
 
+    // TODO: this function is not called anywhere, so the extension for the polymer
+    // molecular weight is not done for this function
     template <class FluidState, class SolventContainer>
     void assignMassConservative(const FluidState& fluidState,
                                 const MaterialLawParams& matParams,

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -243,26 +243,6 @@ public:
         assignNaive(fsFlash);
     }
 
-    // TODO: this function is not called anywhere, so the extension for the polymer
-    // molecular weight is not done for this function
-    template <class FluidState, class SolventContainer>
-    void assignMassConservative(const FluidState& fluidState,
-                                const MaterialLawParams& matParams,
-                                Scalar solSat,
-                                bool isInEquilibrium = false)
-    {
-        assignMassConservative(fluidState, matParams, isInEquilibrium);
-
-        // set the primary variables of the solvent module
-        SolventModule::assignPrimaryVars(*this, solSat);
-
-        // set the primary variables of the polymer module
-        PolymerModule::assignPrimaryVars(*this, solSat);
-
-        // set the primary variables of the energy module
-        EnergyModule::assignPrimaryVars(*this, solSat);
-    }
-
     /*!
      * \copydoc ImmisciblePrimaryVariables::assignNaive
      */

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -48,6 +48,8 @@ NEW_PROP_TAG(SolidEnergyLawParams);
 NEW_PROP_TAG(EnableSolvent);
 //! Enable the ECL-blackoil extension for polymer.
 NEW_PROP_TAG(EnablePolymer);
+//! Enable the tracking polymer molecular weight tracking and related functionalities
+NEW_PROP_TAG(EnablePolymerMW);
 //! Enable surface volume scaling
 NEW_PROP_TAG(BlackoilConserveSurfaceVolume);
 

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -97,6 +97,10 @@ public:
     static const int polymerConcentrationIdx =
         enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
 
+    //! Index of the primary variable for the second polymer primary variable (molecular weight)
+    static const int polymerMoleWeightIdx =
+        numPolymers_ > 1 ? polymerConcentrationIdx + 1 : -1000;
+
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
         enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
@@ -153,6 +157,10 @@ public:
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
         enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+
+    //! Index of the continuity equation for the second polymer component (molecular weight)
+    static const int contiPolymerMWEqIdx =
+        numPolymers_ > 1 ? contiPolymerEqIdx + 1 : -1000;
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -54,22 +54,20 @@ struct BlackOilTwoPhaseIndices
     //! Shall energy be conserved?
     static const bool enableEnergy = numEnergyV > 0;
 
-private:
     //! Number of solvent components to be considered
-    static const int numSolvents_ = enableSolvent ? numSolventsV : 0;
+    static const int numSolvents = enableSolvent ? numSolventsV : 0;
 
     //! Number of polymer components to be considered
-    static const int numPolymers_ = enablePolymer ? numPolymersV : 0;
+    static const int numPolymers = enablePolymer ? numPolymersV : 0;
 
     //! Number of energy equations to be considered
-    static const int numEnergy_ = enableEnergy ? numEnergyV : 0;
+    static const int numEnergy = enableEnergy ? numEnergyV : 0;
 
-public:
     //! The number of fluid phases
     static const int numPhases = 2;
 
     //! The number of equations
-    static const int numEq = numPhases + numSolvents_ + numPolymers_ + numEnergy_;
+    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy;
 
     //////////////////////////////
     // Primary variable indices
@@ -92,19 +90,19 @@ public:
 
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + numPhases + numSolvents_ : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static const int polymerMoleWeightIdx =
-        numPolymers_ > 1 ? polymerConcentrationIdx + 1 : -1000;
+        numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
 
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : - 1000;
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : - 1000;
 
     //////////////////////
     // Equation indices
@@ -153,19 +151,19 @@ public:
 
     //! Index of the continuity equation for the first solvent component
     static const int contiSolventEqIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents_ : -1000;
+        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + numPhases + numSolvents_ : -1000;
+        enablePolymer > 0 ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =
-        numPolymers_ > 1 ? contiPolymerEqIdx + 1 : -1000;
+        numPolymers > 1 ? contiPolymerEqIdx + 1 : -1000;
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ + numEnergy_ : -1000;
+        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : -1000;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -37,7 +37,7 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <bool enableSolventV, bool enablePolymerV, bool enableEnergyV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
 struct BlackOilTwoPhaseIndices
 {
     //! Is phase enabled or not
@@ -46,23 +46,23 @@ struct BlackOilTwoPhaseIndices
     static const bool gasEnabled = (disabledCanonicalCompIdx != 2);
 
     //! Are solvents involved?
-    static const bool enableSolvent = enableSolventV;
+    static const bool enableSolvent = numSolventsV > 0;
 
     //! Are polymers involved?
-    static const bool enablePolymer = enablePolymerV;
+    static const bool enablePolymer = numPolymersV > 0;
 
     //! Shall energy be conserved?
-    static const bool enableEnergy = enableEnergyV;
+    static const bool enableEnergy = numEnergyV > 0;
 
 private:
     //! Number of solvent components to be considered
-    static const int numSolvents_ = enableSolvent ? 1 : 0;
+    static const int numSolvents_ = enableSolvent ? numSolventsV : 0;
 
     //! Number of polymer components to be considered
-    static const int numPolymers_ = enablePolymer ? 1 : 0;
+    static const int numPolymers_ = enablePolymer ? numPolymersV : 0;
 
     //! Number of energy equations to be considered
-    static const int numEnergy_ = enableEnergy ? 1 : 0;
+    static const int numEnergy_ = enableEnergy ? numEnergyV : 0;
 
 public:
     //! The number of fluid phases

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -87,6 +87,7 @@ public:
      *
      * \note For two-phase water oil models this is disabled.
      */
+     // TODO: the following -1 thing only applies to the num*** is 1
     static const int compositionSwitchIdx = gasEnabled ? PVOffset + 1 : -10000;
 
     //! Index of the primary variable for the first solvent
@@ -95,7 +96,7 @@ public:
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
-        enablePolymer ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents_ : -1000;
 
     //! Index of the primary variable for the second polymer primary variable (molecular weight)
     static const int polymerMoleWeightIdx =
@@ -156,7 +157,7 @@ public:
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + (numPhases-1) + numSolvents_ + numPolymers_ : -1000;
+        enablePolymer > 0 ? PVOffset + numPhases + numSolvents_ : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -85,12 +85,11 @@ struct BlackOilTwoPhaseIndices
      *
      * \note For two-phase water oil models this is disabled.
      */
-     // TODO: the following -1 thing only applies to the num*** is 1
     static const int compositionSwitchIdx = gasEnabled ? PVOffset + 1 : -10000;
 
     //! Index of the primary variable for the first solvent
     static const int solventSaturationIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
+        enableSolvent ? PVOffset + numPhases : -1000;
 
     //! Index of the primary variable for the first polymer
     static const int polymerConcentrationIdx =
@@ -102,7 +101,7 @@ struct BlackOilTwoPhaseIndices
 
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : - 1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : - 1000;
 
     //////////////////////
     // Equation indices
@@ -151,11 +150,11 @@ struct BlackOilTwoPhaseIndices
 
     //! Index of the continuity equation for the first solvent component
     static const int contiSolventEqIdx =
-        enableSolvent ? PVOffset + (numPhases-1) + numSolvents : -1000;
+        enableSolvent ? PVOffset + numPhases : -1000;
 
     //! Index of the continuity equation for the first polymer component
     static const int contiPolymerEqIdx =
-        enablePolymer > 0 ? PVOffset + numPhases + numSolvents : -1000;
+        enablePolymer ? PVOffset + numPhases + numSolvents : -1000;
 
     //! Index of the continuity equation for the second polymer component (molecular weight)
     static const int contiPolymerMWEqIdx =
@@ -163,7 +162,7 @@ struct BlackOilTwoPhaseIndices
 
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + (numPhases-1) + numSolvents + numPolymers + numEnergy : -1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
 };
 
 } // namespace Ewoms


### PR DESCRIPTION
The molecular weight will be used to evaluate the polymer viscosity based on a different viscosity model. 

This PR requires the upstream PR https://github.com/OPM/opm-material/pull/317 . 