### PR TITLE
Do not invalidate intensive quantites cache when DRSDT is activated

### DIFF
--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -713,7 +713,10 @@ public:
 
         aquiferModel_.beginEpisode();
 
-        if (doInvalidate)
+        // if drsdt and drvdt is active invalidating the intesive quantities
+        // results in wrong initial storage term. (timeIndex = 1)
+        // TODO: Explicitly store the last storage term in the endTimeStep method
+        if (doInvalidate && !drsdtActive_() && !drvdtActive_())
             this->model().invalidateIntensiveQuantitiesCache(/*timeIdx=*/0);
     }
 


### PR DESCRIPTION
DRSDT changes the solution between timesteps and thus violates
the assumption in fvbaselocalresidual.hh that the beginning of the time
step is the same as the end of the last time step.

If the intesive quantities are not updated teh DRSDT effect will not
be effective before iteration 1. This may couse convergence issues.
A proper fix would be to compute and store the accumulation term when
the time-step is over.