### PR TITLE
make it possible to explicitly compute the storage term of the previous time step

### DIFF
--- a/ewoms/disc/common/fvbaseelementcontext.hh
+++ b/ewoms/disc/common/fvbaseelementcontext.hh
@@ -405,7 +405,7 @@ public:
 #ifndef NDEBUG
         assert(0 <= dofIdx && dofIdx < numDof(timeIdx));
 
-        if (enableStorageCache_ && timeIdx != 0)
+        if (enableStorageCache_ && timeIdx != 0 && problem().recycleFirstIterationStorage())
             throw std::logic_error("If caching of the storage term is enabled, only the intensive quantities "
                                    "for the most-recent substep (i.e. time index 0) are available!");
 #endif
@@ -577,7 +577,7 @@ protected:
     void updateSingleIntQuants_(const PrimaryVariables& priVars, unsigned dofIdx, unsigned timeIdx)
     {
 #ifndef NDEBUG
-        if (enableStorageCache_ && timeIdx != 0)
+        if (enableStorageCache_ && timeIdx != 0 && problem().recycleFirstIterationStorage())
             throw std::logic_error("If caching of the storage term is enabled, only the intensive quantities "
                                    "for the most-recent substep (i.e. time index 0) are available!");
 #endif

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -181,6 +181,16 @@ public:
     }
 
     /*!
+     * \brief Return if the storage term of the first iteration is identical to the storage
+     *        term for the solution of the previous time step.
+     *
+     * This is only relevant if the storage cache is enabled and is usually the case,
+     * i.e., this method only needs to be overwritten in rare corner cases.
+     */
+    bool recycleFirstIterationStorage() const
+    { return true; }
+
+    /*!
      * \brief Determine the directory for simulation output.
      *
      * The actual problem may chose to transform the value of the OutputDir parameter and

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -205,7 +205,7 @@ public:
             // in the threephase case, gas and oil phases are potentially present, i.e.,
             // we use the compositions of the gas-saturated oil and oil-saturated gas.
             if (FluidSystem::enableDissolvedGas()) {
-                Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(globalSpaceIdx);
+                Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(timeIdx, globalSpaceIdx);
                 const Evaluation& RsSat =
                     FluidSystem::saturatedDissolutionFactor(fluidState_,
                                                             oilPhaseIdx,
@@ -217,7 +217,7 @@ public:
                 fluidState_.setRs(0.0);
 
             if (FluidSystem::enableVaporizedOil()) {
-                Scalar RvMax = elemCtx.problem().maxOilVaporizationFactor(globalSpaceIdx);
+                Scalar RvMax = elemCtx.problem().maxOilVaporizationFactor(timeIdx, globalSpaceIdx);
                 const Evaluation& RvSat =
                     FluidSystem::saturatedDissolutionFactor(fluidState_,
                                                             gasPhaseIdx,
@@ -230,7 +230,7 @@ public:
         }
         else if (priVars.primaryVarsMeaning() == PrimaryVariables::Sw_po_Rs) {
             // if the switching variable is the mole fraction of the gas component in the
-            Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(globalSpaceIdx);
+            Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(timeIdx, globalSpaceIdx);
 
             // oil phase, we can directly set the composition of the oil phase
             const auto& Rs = priVars.makeEvaluation(Indices::compositionSwitchIdx, timeIdx);
@@ -239,7 +239,7 @@ public:
             if (FluidSystem::enableVaporizedOil()) {
                 // the gas phase is not present, but we need to compute its "composition"
                 // for the gravity correction anyway
-                Scalar RvMax = elemCtx.problem().maxOilVaporizationFactor(globalSpaceIdx);
+                Scalar RvMax = elemCtx.problem().maxOilVaporizationFactor(timeIdx, globalSpaceIdx);
                 const auto& RvSat =
                     FluidSystem::saturatedDissolutionFactor(fluidState_,
                                                             gasPhaseIdx,
@@ -260,7 +260,7 @@ public:
             if (FluidSystem::enableDissolvedGas()) {
                 // the oil phase is not present, but we need to compute its "composition" for
                 // the gravity correction anyway
-                Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(globalSpaceIdx);
+                Scalar RsMax = elemCtx.problem().maxGasDissolutionFactor(timeIdx, globalSpaceIdx);
                 const auto& RsSat =
                     FluidSystem::saturatedDissolutionFactor(fluidState_,
                                                             oilPhaseIdx,

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -376,7 +376,7 @@ public:
                 Scalar po = (*this)[Indices::pressureSwitchIdx];
                 Scalar T = asImp_().temperature_();
                 Scalar SoMax = problem.maxOilSaturation(globalDofIdx);
-                Scalar RsMax = problem.maxGasDissolutionFactor(globalDofIdx);
+                Scalar RsMax = problem.maxGasDissolutionFactor(/*timeIdx=*/0, globalDofIdx);
                 Scalar RsSat = FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIdx_,
                                                                                    T,
                                                                                    po,
@@ -407,7 +407,7 @@ public:
                 // hydrocarbon gas
                 Scalar T = asImp_().temperature_();
                 Scalar SoMax = problem.maxOilSaturation(globalDofIdx);
-                Scalar RvMax = problem.maxOilVaporizationFactor(globalDofIdx);
+                Scalar RvMax = problem.maxOilVaporizationFactor(/*timeIdx=*/0, globalDofIdx);
                 Scalar RvSat =
                     FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvtRegionIdx_,
                                                                          T,
@@ -447,7 +447,7 @@ public:
             Scalar po = (*this)[Indices::pressureSwitchIdx];
             Scalar So = 1.0 - Sw - solventSaturation_();
             Scalar SoMax = std::max(So, problem.maxOilSaturation(globalDofIdx));
-            Scalar RsMax = problem.maxGasDissolutionFactor(globalDofIdx);
+            Scalar RsMax = problem.maxGasDissolutionFactor(/*timeIdx=*/0, globalDofIdx);
             Scalar RsSat =
                 FluidSystem::oilPvt().saturatedGasDissolutionFactor(pvtRegionIdx_,
                                                                     T,
@@ -504,7 +504,7 @@ public:
             // low-level PVT objects here for performance reasons.
             Scalar T = asImp_().temperature_();
             Scalar SoMax = problem.maxOilSaturation(globalDofIdx);
-            Scalar RvMax = problem.maxOilVaporizationFactor(globalDofIdx);
+            Scalar RvMax = problem.maxOilVaporizationFactor(/*timeIdx=*/0, globalDofIdx);
             Scalar RvSat =
                 FluidSystem::gasPvt().saturatedOilVaporizationFactor(pvtRegionIdx_,
                                                                      T,

--- a/ewoms/models/blackoil/blackoilproblem.hh
+++ b/ewoms/models/blackoil/blackoilproblem.hh
@@ -65,7 +65,7 @@ public:
      *
      * This is required for the DRSDT keyword.
      */
-    Scalar maxGasDissolutionFactor(unsigned globalDofIdx OPM_UNUSED) const
+    Scalar maxGasDissolutionFactor(unsigned timeIdx OPM_UNUSED, unsigned globalDofIdx OPM_UNUSED) const
     { return std::numeric_limits<Scalar>::max()/2; }
 
     /*!
@@ -74,7 +74,7 @@ public:
      *
      * This is required for the DRVDT keyword.
      */
-    Scalar maxOilVaporizationFactor(unsigned globalDofIdx OPM_UNUSED) const
+    Scalar maxOilVaporizationFactor(unsigned timeIdx OPM_UNUSED, unsigned globalDofIdx OPM_UNUSED) const
     { return std::numeric_limits<Scalar>::max()/2; }
 
     /*!


### PR DESCRIPTION
some weird hacks (hello, DR[SV]DT) cause a change of the storage term in the first Newton-Raphson iteration compared to the solution of the previous time level. In order to use the correct values, one thus must explicitly recompute the storage term for the previous time step instead of just reusing the result of the first Newton-Raphson iteration of the current time step.

This (hopefully) fixes the root issue which is papered over  by #446. I've tested this on Norne and did not notice any performance regression. decks which have DRSDT or DRVDT active at some point may yield slightly different results, so a data update might be required.
