### PR TITLE
Strict parsing

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -65,6 +65,7 @@ NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(EclDeckFileName);
 NEW_PROP_TAG(OutputDir);
 NEW_PROP_TAG(EnableOpmRstFile);
+NEW_PROP_TAG(EclStrictParsing);
 NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
 
@@ -72,6 +73,7 @@ SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, true);
+SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 
 END_PROPERTIES
 
@@ -111,6 +113,8 @@ public:
                              "Include OPM-specific keywords in the ECL restart file to enable restart of OPM simulators from these files");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, IgnoreKeywords,
                              "List of Eclipse keywords which should be ignored. As a ':' separated string.");
+        EWOMS_REGISTER_PARAM(TypeTag, bool, EclStrictParsing,
+                             "Use strict mode for parsing - all errors are collected before the applicaton exists.");
     }
 
     /*!
@@ -227,6 +231,9 @@ public:
                 offset = pos + 1;
             }
         }
+
+        if (EWOMS_GET_PARAM(TypeTag, bool , EclStrictParsing))
+            parseContext.update(Opm::InputError::DELAYED_EXIT1);
 
         if (!externalDeck_) {
             if (myRank == 0)


### PR DESCRIPTION
Add a command-line option `--strict-parsing`. If the `--strict-parsing` option is enabled we all `ParseContext` error modes are treated with the mode `DELAYED_EXIT1` - this implies that:

1. All recognized error modes are treated as fatal.
2. Parsing, and construction of `EclipseState++` objects continues all the way (unless some other failure pops up); if there are errors - all errors and warnings are dumped on `stderr` and the application stops.

The first commit comes from: #453 - which must be merged first.

**Update:** This PR is not really complete, because the `Deck` and `EclipseState` objects are assigned from external scope, so the `--strict-parsing` option must be parsed/interpreted also in opm-simulators.