### PR TITLE
fix some masochistic compiler warnings for the GCC 9 pre-release

### DIFF
--- a/ebos/eclbaseaquifermodel.hh
+++ b/ebos/eclbaseaquifermodel.hh
@@ -86,10 +86,10 @@ public:
      * \brief Add the water which enters or leaves the reservoir due to aquifiers.
      */
     template <class Context>
-    void addToSource(RateVector& rate,
-                     const Context& context,
-                     unsigned spaceIdx,
-                     unsigned timeIdx) const
+    void addToSource(RateVector& rate OPM_UNUSED,
+                     const Context& context OPM_UNUSED,
+                     unsigned spaceIdx OPM_UNUSED,
+                     unsigned timeIdx OPM_UNUSED) const
     { }
 
     /*!
@@ -122,7 +122,7 @@ public:
      *        format.
      */
     template <class Restarter>
-    void serialize(Restarter& res)
+    void serialize(Restarter& res OPM_UNUSED)
     { }
 
     /*!
@@ -130,7 +130,7 @@ public:
      *        format.
      */
     template <class Restarter>
-    void deserialize(Restarter& res)
+    void deserialize(Restarter& res OPM_UNUSED)
     { }
 
 protected:

--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -107,7 +107,6 @@ public:
 
         unsigned numElems = vanguard.grid().size(0);
         unsigned numCartesianElems = vanguard.cartesianSize();
-        typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
 
         EQUIL::DeckDependent::InitialStateComputer<TypeTag> initialState(materialLawManager,
                                                                          eclState,

--- a/ebos/eclwellmanager.hh
+++ b/ebos/eclwellmanager.hh
@@ -101,7 +101,7 @@ public:
      *
      * I.e., well positions, names etc...
      */
-    void init(const Opm::EclipseState& eclState,
+    void init(const Opm::EclipseState& eclState OPM_UNUSED,
               const Opm::Schedule& deckSchedule)
     {
         // create the wells which intersect with the current process' grid
@@ -609,7 +609,7 @@ public:
     }
 
 protected:
-    bool wellTopologyChanged_(const Opm::EclipseState& eclState,
+    bool wellTopologyChanged_(const Opm::EclipseState& eclState OPM_UNUSED,
                               const Opm::Schedule& schedule,
                               unsigned reportStepIdx) const
     {

--- a/ebos/eclwriter.hh
+++ b/ebos/eclwriter.hh
@@ -384,7 +384,6 @@ private:
         }
 
         const auto& globalGridView = globalGrid_.leafGridView();
-        typedef typename Grid::LeafGridView GridView;
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
         typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView> ElementMapper;
         ElementMapper globalElemMapper(globalGridView, Dune::mcmgElementLayout());
@@ -450,7 +449,6 @@ private:
         int ny = eclState().getInputGrid().getNY();
 
         const auto& globalGridView = globalGrid_.leafGridView();
-        typedef typename Grid::LeafGridView GridView;
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
         typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView> ElementMapper;
         ElementMapper globalElemMapper(globalGridView, Dune::mcmgElementLayout());

--- a/ebos/equil/initstateequil.hh
+++ b/ebos/equil/initstateequil.hh
@@ -713,9 +713,9 @@ phaseSaturations(const Grid& grid,
                                          /*storeSaturation=*/true,
                                          /*storeDensity=*/false,
                                          /*storeViscosity=*/false,
-                                         /*storeEnthalpy=*/false> SatOnlyFluidState;
+                                         /*storeEnthalpy=*/false> MySatOnlyFluidState;
 
-    SatOnlyFluidState fluidState;
+    MySatOnlyFluidState fluidState;
     typedef typename MaterialLawManager::MaterialLaw MaterialLaw;
 
     const bool water = FluidSystem::phaseIsActive(FluidSystem::waterPhaseIdx);
@@ -1129,7 +1129,7 @@ private:
     }
 
     template <class RMap, class MaterialLawManager>
-    void calcPressSatRsRv(const Opm::EclipseState& eclState,
+    void calcPressSatRsRv(const Opm::EclipseState& eclState OPM_UNUSED,
                           const RMap& reg,
                           const std::vector< Opm::EquilRecord >& rec,
                           MaterialLawManager& materialLawManager,

--- a/ewoms/disc/common/baseauxiliarymodule.hh
+++ b/ewoms/disc/common/baseauxiliarymodule.hh
@@ -126,7 +126,7 @@ public:
      *
      * It is intended to implement stuff like Schur complements.
      */
-    virtual void postSolve(GlobalEqVector& residual)
+    virtual void postSolve(GlobalEqVector& residual OPM_UNUSED)
     {};
 
 private:

--- a/ewoms/disc/common/fvbaseconstraints.hh
+++ b/ewoms/disc/common/fvbaseconstraints.hh
@@ -56,11 +56,13 @@ public:
     FvBaseConstraints()
     { setActive(false); }
 
+    FvBaseConstraints(const FvBaseConstraints&) = default;
+
 //! \cond SKIP
     /*!
-     * \brief Use the assignment operators from the parent type
+     * \brief Use the default assignment operator
      */
-    using ParentType::operator=;
+    FvBaseConstraints &operator=(const FvBaseConstraints&) = default;
 //! \endcond
 
     /*!

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -749,7 +749,7 @@ public:
      *
      * \param verbose Specify if a message should be printed whenever a file is written
      */
-    void writeOutput(bool isSubStep, bool verbose = true)
+    void writeOutput(bool isSubStep OPM_UNUSED, bool verbose = true)
     {
         if (!enableVtkOutput_())
             return;

--- a/ewoms/io/dgfvanguard.hh
+++ b/ewoms/io/dgfvanguard.hh
@@ -147,20 +147,20 @@ public:
 protected:
     void addFractures_(Dune::GridPtr<Grid>& dgfPointer)
     {
-        typedef typename Grid::LevelGridView GridView;
+        typedef typename Grid::LevelGridView LevelGridView;
 
         // check if fractures are available (only 2d currently)
         if (dgfPointer.nofParameters(static_cast<int>(Grid::dimension)) == 0)
             return;
 
-        GridView gridView = dgfPointer->levelGridView(/*level=*/0);
+        LevelGridView gridView = dgfPointer->levelGridView(/*level=*/0);
         const unsigned edgeCodim = Grid::dimension - 1;
 
 #if DUNE_VERSION_NEWER(DUNE_GRID, 2,6)
-        typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView> VertexMapper;
+        typedef Dune::MultipleCodimMultipleGeomTypeMapper<LevelGridView> VertexMapper;
         VertexMapper vertexMapper(gridView, Dune::mcmgVertexLayout());
 #else
-        typedef Dune::MultipleCodimMultipleGeomTypeMapper<GridView, Dune::MCMGVertexLayout> VertexMapper;
+        typedef Dune::MultipleCodimMultipleGeomTypeMapper<LevelGridView, Dune::MCMGVertexLayout> VertexMapper;
         VertexMapper vertexMapper(gridView);
 #endif
 

--- a/ewoms/linear/matrixblock.hh
+++ b/ewoms/linear/matrixblock.hh
@@ -291,8 +291,8 @@ class SuperLU<BCRSMatrix<Ewoms::MatrixBlock<T, n, m>, A> >
 public:
     typedef BCRSMatrix<Ewoms::MatrixBlock<T, n, m>, A> RealMatrix;
 
-    SuperLU(const RealMatrix& matrix, int verbose, bool reuse=true)
-        : Base(reinterpret_cast<const Matrix&>(matrix), verbose, reuse)
+    SuperLU(const RealMatrix& matrix, int verb, bool reuse=true)
+        : Base(reinterpret_cast<const Matrix&>(matrix), verb, reuse)
     {}
 };
 #endif

--- a/ewoms/linear/overlappingbcrsmatrix.hh
+++ b/ewoms/linear/overlappingbcrsmatrix.hh
@@ -91,9 +91,9 @@ public:
 
     // this constructor is required to make the class compatible with the SeqILU class of
     // Dune >= 2.7.
-    OverlappingBCRSMatrix(size_t numRows,
-                          size_t numCols,
-                          typename BCRSMatrix::BuildMode buildMode)
+    OverlappingBCRSMatrix(size_t numRows OPM_UNUSED,
+                          size_t numCols OPM_UNUSED,
+                          typename BCRSMatrix::BuildMode buildMode OPM_UNUSED)
     { throw std::logic_error("OverlappingBCRSMatrix objects cannot be build from scratch!"); }
 
     ~OverlappingBCRSMatrix()

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -273,7 +273,6 @@ public:
                 fluidState_.setRs(0.0);
         }
 
-        typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;
         paramCache.setRegionIndex(pvtRegionIdx);
         paramCache.setMaxOilSat(SoMax);

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -536,7 +536,7 @@ public:
         }
     }
 
-    static Scalar primaryVarWeight(unsigned pvIdx)
+    static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
     {
         assert(primaryVarApplies(pvIdx));
 
@@ -560,14 +560,13 @@ public:
     {
         assert(eqApplies(eqIdx));
 
-        if (eqIdx == contiPolymerEqIdx) {
+        if (eqIdx == contiPolymerEqIdx)
             return "conti^polymer";
-        } else {
+        else
             return "conti^polymer_molecularweight";
-        }
     }
 
-    static Scalar eqWeight(unsigned eqIdx)
+    static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
     {
         assert(eqApplies(eqIdx));
 

--- a/ewoms/models/immiscible/immiscibleintensivequantities.hh
+++ b/ewoms/models/immiscible/immiscibleintensivequantities.hh
@@ -96,7 +96,6 @@ public:
         EnergyIntensiveQuantities::updateTemperatures_(fluidState_, elemCtx, dofIdx, timeIdx);
 
         // material law parameters
-        typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
         const auto& problem = elemCtx.problem();
         const typename MaterialLaw::Params& materialParams =
             problem.materialLawParams(elemCtx, dofIdx, timeIdx);
@@ -123,7 +122,6 @@ public:
         for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx)
             fluidState_.setPressure(phaseIdx, p0 + (pC[phaseIdx] - pC[0]));
 
-        typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
         typename FluidSystem::template ParameterCache<Evaluation> paramCache;
         paramCache.updateAll(fluidState_);
 

--- a/ewoms/models/richards/richardsintensivequantities.hh
+++ b/ewoms/models/richards/richardsintensivequantities.hh
@@ -92,7 +92,6 @@ public:
         fluidState_.setTemperature(T);
 
         // material law parameters
-        typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
         const auto& problem = elemCtx.problem();
         const typename MaterialLaw::Params& materialParams =
             problem.materialLawParams(elemCtx, dofIdx, timeIdx);

--- a/tests/lens_immiscible_ecfv_ad_cu1.cc
+++ b/tests/lens_immiscible_ecfv_ad_cu1.cc
@@ -38,7 +38,9 @@
 
 #include <ewoms/common/start.hh>
 
+// fake forward declaration to prevent esoteric compiler warning
 int mainCU1(int argc, char **argv);
+
 int mainCU1(int argc, char **argv)
 {
     typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;

--- a/tests/lens_immiscible_ecfv_ad_cu2.cc
+++ b/tests/lens_immiscible_ecfv_ad_cu2.cc
@@ -38,6 +38,9 @@
 
 #include <ewoms/common/start.hh>
 
+// fake forward declaration to prevent esoteric compiler warning
+int mainCU2(int argc, char **argv);
+
 int mainCU2(int argc, char **argv)
 {
     typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;


### PR DESCRIPTION
the flags which I used are
```
-pedantic \
-Wall \
-Wextra \
-Wformat-nonliteral \
-Wcast-align
-Wpointer-arith \
-Wmissing-declarations \
-Wcast-qual \
-Wshadow
-Wwrite-strings \
-Wchar-subscripts \
-Wredundant-decls \
-fstrict-overflow \
-O3 \
-march=native \
-DNDEBUG=1
```

note that some heavy filtering is not the worst idea because DUNE is far from not emiting any warnings with these flags.

Also, there were some pesky warnings in test_ecl_output which I don't know how to fix:

```
tests/test_ecl_output.cc:218:73: warning: missing initializer for member ‘Opm::data::Connection::effective_Kh’ [-Wmissing-field-initializers]
```