### PR TITLE
Add Schedule and SummaryConfig arguments to setExternalDeck()

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -158,10 +158,12 @@ public:
      * management of these two objects, i.e., they are not allowed to be deleted as long
      * as the simulator vanguard object is alive.
      */
-    static void setExternalDeck(Opm::Deck* deck, Opm::EclipseState* eclState)
+    static void setExternalDeck(Opm::Deck* deck, Opm::EclipseState* eclState, Opm::Schedule * schedule, Opm::SummaryConfig * summaryConfig)
     {
         externalDeck_ = deck;
         externalEclState_ = eclState;
+        externalEclSchedule_ = schedule;
+        externalEclSummaryConfig_ = summaryConfig;
     }
 
     /*!


### PR DESCRIPTION
The parsing process creates four top level objects: `Deck, EclipseState, Schedule` and `SummaryConfig`. With the advent of the `ErrorGuard` class it makes sense to create all four objects with the same `ErrorGuard`instance - to ensure that the maximum amount of error messages are presented to the user, before we jump ship.

With this PR - and the accompanying in opm-simulators, all four objects are created in `flow.cpp` and then all are set in the ewoms model using `setExternalDeck()`.



Depends on: https://github.com/OPM/opm-simulators/pull/1704

~~Should merge: #454 first~~