### PR TITLE
WIP: Remove strict-parsing option

### DIFF
--- a/ebos/eclbasevanguard.hh
+++ b/ebos/eclbasevanguard.hh
@@ -65,7 +65,6 @@ NEW_PROP_TAG(Scalar);
 NEW_PROP_TAG(EclDeckFileName);
 NEW_PROP_TAG(OutputDir);
 NEW_PROP_TAG(EnableOpmRstFile);
-NEW_PROP_TAG(EclStrictParsing);
 NEW_PROP_TAG(EclOutputInterval);
 NEW_PROP_TAG(IgnoreKeywords);
 
@@ -73,7 +72,6 @@ SET_STRING_PROP(EclBaseVanguard, IgnoreKeywords, "");
 SET_STRING_PROP(EclBaseVanguard, EclDeckFileName, "");
 SET_INT_PROP(EclBaseVanguard, EclOutputInterval, -1); // use the deck-provided value
 SET_BOOL_PROP(EclBaseVanguard, EnableOpmRstFile, true);
-SET_BOOL_PROP(EclBaseVanguard, EclStrictParsing, false);
 
 END_PROPERTIES
 
@@ -113,8 +111,6 @@ public:
                              "Include OPM-specific keywords in the ECL restart file to enable restart of OPM simulators from these files");
         EWOMS_REGISTER_PARAM(TypeTag, std::string, IgnoreKeywords,
                              "List of Eclipse keywords which should be ignored. As a ':' separated string.");
-        EWOMS_REGISTER_PARAM(TypeTag, bool, EclStrictParsing,
-                             "Use strict mode for parsing - all errors are collected before the applicaton exists.");
     }
 
     /*!
@@ -231,9 +227,6 @@ public:
                 offset = pos + 1;
             }
         }
-
-        if (EWOMS_GET_PARAM(TypeTag, bool , EclStrictParsing))
-            parseContext.update(Opm::InputError::DELAYED_EXIT1);
 
         if (!externalDeck_) {
             if (myRank == 0)


### PR DESCRIPTION
Seems this should be in flow/opm-simulators: https://github.com/OPM/opm-simulators/pull/1704