### PR TITLE
Fix generic boundary conditions for blackoil model

### DIFF
--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -426,11 +426,15 @@ protected:
             // only works for the element centered finite volume method. for ebos this
             // does not matter, though.
             unsigned upstreamIdx = upstreamIndex_(phaseIdx);
-            const auto& up = elemCtx.intensiveQuantities(upstreamIdx, timeIdx);
-            if (upstreamIdx == interiorDofIdx_)
+            if (upstreamIdx == interiorDofIdx_) {
+                const auto& up = elemCtx.intensiveQuantities(upstreamIdx, timeIdx);
                 volumeFlux_[phaseIdx] =
                     pressureDifference_[phaseIdx]*up.mobility(phaseIdx)*(-trans/faceArea);
-            else {
+
+                if (enableSolvent && phaseIdx == gasPhaseIdx) {
+                        asImp_().setSolventVolumeFlux( pressureDifference_[phaseIdx]*up.solventMobility()*(-trans/faceArea));
+                }
+            } else {
                 // compute the phase mobility using the material law parameters of the
                 // interior element. TODO: this could probably be done more efficiently
                 const auto& matParams =
@@ -443,6 +447,11 @@ protected:
                 const auto& mob = kr[phaseIdx]/exFluidState.viscosity(phaseIdx);
                 volumeFlux_[phaseIdx] =
                     pressureDifference_[phaseIdx]*mob*(-trans/faceArea);
+
+                // Solvent inflow is not yet supported
+                if (enableSolvent && phaseIdx == gasPhaseIdx) {
+                    asImp_().setSolventVolumeFlux( 0.0 );
+                }
             }
         }
     }

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -1306,6 +1306,7 @@ public:
             unsigned globalDofIdx = context.globalSpaceIndex(interiorDofIdx, timeIdx);
             values.setThermalFlow(context, spaceIdx, timeIdx, initialFluidStates_[globalDofIdx]);
         }
+
     }
 
     /*!
@@ -2051,6 +2052,21 @@ private:
                 dofFluidState.setRv(rvData[cartesianDofIdx]);
             else if (Indices::gasEnabled && Indices::oilEnabled)
                 dofFluidState.setRv(0.0);
+
+            //////
+            // set invB_
+            //////
+            for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
+                if (!FluidSystem::phaseIsActive(phaseIdx))
+                    continue;
+
+                const auto& b = FluidSystem::inverseFormationVolumeFactor(dofFluidState, phaseIdx, pvtRegionIndex(dofIdx));
+                dofFluidState.setInvB(phaseIdx, b);
+
+                const auto& rho = FluidSystem::density(dofFluidState, phaseIdx, pvtRegionIndex(dofIdx));
+                dofFluidState.setDensity(phaseIdx, rho);
+
+            }
         }
     }
 

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -891,6 +891,11 @@ public:
 
     }
 
+    const Scalar molarMass() const
+    {
+        return 0.25; // kg/mol
+    }
+
 
 
 

--- a/ewoms/models/blackoil/blackoilsolventmodules.hh
+++ b/ewoms/models/blackoil/blackoilsolventmodules.hh
@@ -1521,6 +1521,10 @@ public:
     const Evaluation& solventVolumeFlux() const
     { return solventVolumeFlux_; }
 
+    void setSolventVolumeFlux(const Evaluation& solventVolumeFlux) {
+        solventVolumeFlux_ = solventVolumeFlux;
+    }
+
 private:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
@@ -1555,6 +1559,9 @@ public:
 
     const Evaluation& solventVolumeFlux() const
     { throw std::runtime_error("solventVolumeFlux() called but solvents are disabled"); }
+
+    void setSolventVolumeFlux(const Evaluation& solventVolumeFlux)
+    { throw std::runtime_error("setSolventVolumeFlux() called but solvents are disabled"); }
 };
 
 } // namespace Ewoms


### PR DESCRIPTION
This makes it possible to set non-trivial boundary conditions in the blackoil model
Currently the boundary must be set explicit in boundary() in the eclproblem class 
and enableBoundaryMassFlux needs to be set to true in eclfluxmodule.hh

TODO
Make it settable from deck using customized keywords 

Note:
Currently it doesn't allow for polymer or solvent influx
on the boundary with the free flow option