### PR TITLE
Temporarily disable the SPE1 test.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,12 +133,12 @@ EwomsAddApplication(ebos
                     EXE_NAME ebos
                     CONDITION OPM_GRID_FOUND AND HAVE_ECL_INPUT AND HAVE_ECL_OUTPUT)
 
-opm_add_test(SPE1
-  EXE_NAME ebos
-  NO_COMPILE
-  DEPENDS ebos
-  CONDITION opm-common_FOUND AND opm-grid_FOUND
-  DRIVER_ARGS --spe1 "${COMPARE_ECL_COMMAND}")
+# opm_add_test(SPE1
+#   EXE_NAME ebos
+#   NO_COMPILE
+#   DEPENDS ebos
+#   CONDITION opm-common_FOUND AND opm-grid_FOUND
+#   DRIVER_ARGS --spe1 "${COMPARE_ECL_COMMAND}")
 
 if(OPM_GRID_FOUND AND HAVE_ECL_INPUT AND HAVE_ECL_OUTPUT)
   install(TARGETS ebos DESTINATION bin)


### PR DESCRIPTION
In order to re-enable it we should:
 - Use input and reference data in opm-tests.
 - Ensure that the jenkins update feature updates it.

I'll self-merge when green, unless someone beats me to it.