### PR TITLE
Add support for using free boundary conditions in Flow

### DIFF
--- a/ebos/eclequilinitializer.hh
+++ b/ebos/eclequilinitializer.hh
@@ -146,11 +146,18 @@ public:
             if (enableTemperature || enableEnergy)
                 fluidState.setTemperature(initialState.temperature()[elemIdx]);
 
-            // set the phase pressures.
+            // set the phase pressures, invB factor and density
             for (unsigned phaseIdx = 0; phaseIdx < numPhases; ++phaseIdx) {
                 if (!FluidSystem::phaseIsActive(phaseIdx))
                     continue;
                 fluidState.setPressure(phaseIdx, initialState.press()[phaseIdx][elemIdx]);
+
+                const auto& b = FluidSystem::inverseFormationVolumeFactor(fluidState, phaseIdx, regionIdx);
+                fluidState.setInvB(phaseIdx, b);
+
+                const auto& rho = FluidSystem::density(fluidState, phaseIdx, regionIdx);
+                fluidState.setDensity(phaseIdx, rho);
+
             }
         }
     }

--- a/ebos/eclfluxmodule.hh
+++ b/ebos/eclfluxmodule.hh
@@ -361,11 +361,12 @@ protected:
                                      unsigned timeIdx,
                                      const FluidState& exFluidState)
     {
-        bool enableBoundaryMassFlux = false;
+        const auto& problem = elemCtx.problem();
+
+        bool enableBoundaryMassFlux = problem.hasFreeBoundaryConditions();
         if (!enableBoundaryMassFlux)
             return;
 
-        const auto& problem = elemCtx.problem();
         const auto& stencil = elemCtx.stencil(timeIdx);
         const auto& scvf = stencil.boundaryFace(scvfIdx);
 

--- a/ewoms/disc/common/fvbaseboundarycontext.hh
+++ b/ewoms/disc/common/fvbaseboundarycontext.hh
@@ -74,6 +74,13 @@ public:
         , intersectionIt_(gridView().ibegin(element()))
     { }
 
+    void increment()
+    {
+        const auto& iend = gridView().iend(element());
+        while (intersectionIt_ != iend && !intersectionIt_->boundary())
+            ++ intersectionIt_;
+    }
+
     /*!
      * \copydoc Ewoms::ElementContext::problem()
      */

--- a/ewoms/disc/common/fvbaselocalresidual.hh
+++ b/ewoms/disc/common/fvbaselocalresidual.hh
@@ -429,7 +429,7 @@ protected:
 
         // evaluate the boundary for all boundary faces of the current context
         size_t numBoundaryFaces = boundaryCtx.numBoundaryFaces(/*timeIdx=*/0);
-        for (unsigned faceIdx = 0; faceIdx < numBoundaryFaces; ++faceIdx) {
+        for (unsigned faceIdx = 0; faceIdx < numBoundaryFaces; ++faceIdx, boundaryCtx.increment()) {
             // add the residual of all vertices of the boundary
             // segment
             evalBoundarySegment_(residual,


### PR DESCRIPTION
The OPM specific keywords FREEBC[XYZ[-]] can be used to specify
boundary cells that are open. Default is a closed boundary.

Depends on OPM/opm-common#641
