### PR TITLE
introduce an "experimental mode"

### DIFF
--- a/ebos/ebos.cc
+++ b/ebos/ebos.cc
@@ -36,6 +36,11 @@ BEGIN_PROPERTIES
 
 NEW_TYPE_TAG(EclProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
 
+// Enable experimental features for ebos: ebos is the research simulator of the OPM
+// project. If you're looking for a more stable "production quality" simulator, consider
+// using `flow`
+SET_BOOL_PROP(EclProblem, EnableExperiments, true);
+
 END_PROPERTIES
 
 int main(int argc, char **argv)

--- a/ebos/eclproblem.hh
+++ b/ebos/eclproblem.hh
@@ -325,6 +325,10 @@ SET_BOOL_PROP(EclBaseProblem, EnableThermalFluxBoundaries, false);
 
 SET_BOOL_PROP(EclBaseProblem, EnableTracerModel, false);
 
+// By default, simulators derived from the EclBaseProblem are production simulators,
+// i.e., experimental features must be explicitly enabled at compile time
+SET_BOOL_PROP(EclBaseProblem, EnableExperiments, false);
+
 END_PROPERTIES
 
 namespace Ewoms {

--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -279,6 +279,9 @@ SET_BOOL_PROP(FvBaseDiscretization, ExtensiveStorageTerm, false);
 // use volumetric residuals is default
 SET_BOOL_PROP(FvBaseDiscretization, UseVolumetricResidual, true);
 
+//! eWoms is mainly targeted at research, so experimental features are enabled by
+//! default.
+SET_BOOL_PROP(FvBaseDiscretization, EnableExperiments, true);
 
 END_PROPERTIES
 

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -308,6 +308,10 @@ NEW_PROP_TAG(ExtensiveStorageTerm);
 //! \brief Specify whether to use volumetric residuals or not
 NEW_PROP_TAG(UseVolumetricResidual);
 
+
+//! Specify if experimental features should be enabled or not.
+NEW_PROP_TAG(EnableExperiments);
+
 END_PROPERTIES
 
 #endif


### PR DESCRIPTION
this is a compile time switch with the intention to be able to more easily turn experimental features that are not yet considered to be production quality on and off. DUNE has a similar mechanism (i.e., the `DUNE_GRID_EXPERIMENTAL_GRID_EXTENSIONS` macro), but this relies on the preprocessor.

For now, the property does not have any effect.