### PR TITLE
do not use BCRSMatrix::entry()

### DIFF
--- a/ewoms/linear/istlsparsematrixadapter.hh
+++ b/ewoms/linear/istlsparsematrixadapter.hh
@@ -153,19 +153,19 @@ public:
      * \brief Fill given block with entries stored in the matrix.
      */
     void block(const size_t rowIdx, const size_t colIdx, MatrixBlock& value) const
-    { value = istlMatrix_->entry(rowIdx, colIdx); }
+    { value = (*istlMatrix_)[rowIdx][colIdx]; }
 
     /*!
      * \brief Set matrix block to given block.
      */
     void setBlock(const size_t rowIdx, const size_t colIdx, const MatrixBlock& value)
-    { istlMatrix_->entry(rowIdx, colIdx) = value; }
+    { (*istlMatrix_)[rowIdx][colIdx] = value; }
 
     /*!
      * \brief Add block to matrix block.
      */
     void addToBlock(const size_t rowIdx, const size_t colIdx, const MatrixBlock& value)
-    { istlMatrix_->entry(rowIdx, colIdx) += value; }
+    { (*istlMatrix_)[rowIdx][colIdx] += value; }
 
     /*!
      * \brief Commit matrix from local caches into matrix native structure.


### PR DESCRIPTION
this method seems to be intended only for BCRS matrices which are build in implicit mode. This might be a mistake in DUNE because the method works fine for any matrices provided that they are fully set up.

This assert is only triggered if the `DUNE_ISTL_WITH_CHECKING` macro is set, so the impacts of this mistake should be quite limited.