### PR TITLE
black oil newton method: allow the compiler to see at compile time if  a given extension is enabled

### DIFF
--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -284,6 +284,9 @@ protected:
                     nextValue[pvIdx] = 0.0;
             }
 
+            // keep the temperature above 100 and below 1000 Kelvin
+            if (enableEnergy && pvIdx == Indices::temperatureIdx)
+                nextValue[pvIdx] = std::max(std::min(nextValue[pvIdx], 1000.0), 100.0);
         }
 
         // switch the new primary variables to something which is physically meaningful.


### PR DESCRIPTION
i.e., we now check for `enable$BLACKOIL_EXTENSION` compile time variables. this should allow the compiler to produce slightly better optimized machine code if the respective extension is disabled.