### PR TITLE
make all headers self sufficient

### DIFF
--- a/ewoms/disc/common/fvbasefdlocallinearizer.hh
+++ b/ewoms/disc/common/fvbasefdlocallinearizer.hh
@@ -58,7 +58,7 @@ NEW_PROP_TAG(LocalLinearizer);
 NEW_PROP_TAG(Evaluation);
 NEW_PROP_TAG(NumericDifferenceMethod);
 NEW_PROP_TAG(BaseEpsilon);
-
+NEW_PROP_TAG(SparseMatrixAdapter);
 NEW_PROP_TAG(LocalResidual);
 NEW_PROP_TAG(Simulator);
 NEW_PROP_TAG(Problem);

--- a/ewoms/io/vtkmultiphasemodule.hh
+++ b/ewoms/io/vtkmultiphasemodule.hh
@@ -33,6 +33,7 @@
 #include <ewoms/common/propertysystem.hh>
 #include <ewoms/common/parametersystem.hh>
 
+#include <opm/material/common/MathToolbox.hpp>
 #include <opm/material/common/Valgrind.hpp>
 
 #include <dune/common/fvector.hh>

--- a/ewoms/linear/parallelamgbackend.hh
+++ b/ewoms/linear/parallelamgbackend.hh
@@ -30,6 +30,7 @@
 #include "parallelbasebackend.hh"
 #include "bicgstabsolver.hh"
 #include "combinedcriterion.hh"
+#include "istlsparsematrixadapter.hh"
 
 #include <dune/istl/bcrsmatrix.hh>
 #include <dune/istl/paamg/amg.hh>

--- a/ewoms/linear/parallelistlbackend.hh
+++ b/ewoms/linear/parallelistlbackend.hh
@@ -29,6 +29,7 @@
 
 #include "parallelbasebackend.hh"
 #include "istlsolverwrappers.hh"
+#include "istlsparsematrixadapter.hh"
 
 #include <dune/common/version.hh>
 
@@ -37,6 +38,7 @@ BEGIN_PROPERTIES
 NEW_TYPE_TAG(ParallelIstlLinearSolver, INHERITS_FROM(ParallelBaseLinearSolver));
 
 NEW_PROP_TAG(LinearSolverWrapper);
+NEW_PROP_TAG(SparseMatrixAdapter);
 
 //! number of iterations between solver restarts for the GMRES solver
 NEW_PROP_TAG(GMResRestart);


### PR DESCRIPTION
this is part of the pre-release maintainance: all eWoms headers should now be includable without strings attached, i.e., in any order and without having to include something before.