### PR TITLE
simulator: simplify the time step handling a bit

### DIFF
--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -416,13 +416,7 @@ public:
      *        the end of the simlation.
      */
     Scalar timeStepSize() const
-    {
-        Scalar maximumTimeStepSize =
-            std::min(episodeMaxTimeStepSize(),
-                     std::max( Scalar(0), endTime() - this->time()));
-
-        return std::min(timeStepSize_, maximumTimeStepSize);
-    }
+    { return timeStepSize_; }
 
     /*!
      * \brief Returns number of time steps which have been
@@ -749,14 +743,12 @@ public:
             }
             else {
                 Scalar dt;
-                if (timeStepIdx_ < static_cast<int>(forcedTimeSteps_.size())) {
+                if (timeStepIdx_ < static_cast<int>(forcedTimeSteps_.size()))
                     // use the next time step size from the input file
                     dt = forcedTimeSteps_[timeStepIdx_];
-                }
-                else {
+                else
                     // ask the problem to provide the next time step size
-                    dt = problem_->nextTimeStepSize();
-                }
+                    dt = std::min(maxTimeStepSize(), problem_->nextTimeStepSize());
 
                 setTimeStepSize(dt);
             }


### PR DESCRIPTION
`timeStepSize()` now always returns the value specified via `setTimeStepSize()`, i.e., the time loop is now solely responsible for not crossing episode boundaries in the middle of time steps and for not going past the specified end time of the simulation.