### PR TITLE
black oil: fix the determination of the maximum oil saturation

### DIFF
--- a/ewoms/io/vtkblackoilmodule.hh
+++ b/ewoms/io/vtkblackoilmodule.hh
@@ -193,8 +193,6 @@ public:
         if (!EWOMS_GET_PARAM(TypeTag, bool, EnableVtkOutput))
             return;
 
-        typedef Opm::MathToolbox<Evaluation> Toolbox;
-
         for (unsigned dofIdx = 0; dofIdx < elemCtx.numPrimaryDof(/*timeIdx=*/0); ++dofIdx) {
             const auto& fs = elemCtx.intensiveQuantities(dofIdx, /*timeIdx=*/0).fluidState();
             typedef typename std::remove_const<typename std::remove_reference<decltype(fs)>::type>::type FluidState;
@@ -203,11 +201,12 @@ public:
             const auto& primaryVars = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0);
 
             unsigned pvtRegionIdx = elemCtx.primaryVars(dofIdx, /*timeIdx=*/0).pvtRegionIndex();
-            Scalar SoMax = elemCtx.problem().maxOilSaturation(globalDofIdx);
-            Scalar x_oG = Toolbox::value(fs.moleFraction(oilPhaseIdx, gasCompIdx));
-            Scalar x_gO = Toolbox::value(fs.moleFraction(gasPhaseIdx, oilCompIdx));
-            Scalar X_oG = Toolbox::value(fs.massFraction(oilPhaseIdx, gasCompIdx));
-            Scalar X_gO = Toolbox::value(fs.massFraction(gasPhaseIdx, oilCompIdx));
+            Scalar SoMax = std::max(Opm::getValue(fs.saturation(oilPhaseIdx)),
+                                    elemCtx.problem().maxOilSaturation(globalDofIdx));
+            Scalar x_oG = Opm::getValue(fs.moleFraction(oilPhaseIdx, gasCompIdx));
+            Scalar x_gO = Opm::getValue(fs.moleFraction(gasPhaseIdx, oilCompIdx));
+            Scalar X_oG = Opm::getValue(fs.massFraction(oilPhaseIdx, gasCompIdx));
+            Scalar X_gO = Opm::getValue(fs.massFraction(gasPhaseIdx, oilCompIdx));
             Scalar Rs = FluidSystem::convertXoGToRs(X_oG, pvtRegionIdx);
             Scalar Rv = FluidSystem::convertXgOToRv(X_gO, pvtRegionIdx);
 

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -197,7 +197,9 @@ public:
         // update the Saturation functions for the blackoil solvent module.
         asImp_().solventPostSatFuncUpdate_(elemCtx, dofIdx, timeIdx);
 
-        Scalar SoMax = elemCtx.problem().maxOilSaturation(globalSpaceIdx);
+        const Evaluation& SoMax =
+            Opm::max(fluidState_.saturation(oilPhaseIdx),
+                     elemCtx.problem().maxOilSaturation(globalSpaceIdx));
 
         // take the meaning of the switiching primary variable into account for the gas
         // and oil phase compositions


### PR DESCRIPTION
the oil saturation for the current iteration can be larger than the historic maximum. since oil saturation typically goes down over time in oil reservoirs, the impact of this is likely very limited...

this PR depends on OPM/opm-material#332 (but the inverse is not the case)