### PR TITLE
remove the isSubstep parameter from Problem::writeOutput()

### DIFF
--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -636,7 +636,7 @@ public:
 
             // write initial condition
             if (problem_->shouldWriteOutput())
-                EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(problem_->writeOutput(/*isSubstep=*/!episodeWillBeOver()));
+                EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(problem_->writeOutput());
 
             timeStepSize_ = oldTimeStepSize;
             timeStepIdx_ = oldTimeStepIdx;
@@ -715,7 +715,7 @@ public:
             // write the result to disk
             writeTimer_.start();
             if (problem_->shouldWriteOutput())
-                EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(problem_->writeOutput(/*isSubstep=*/!episodeWillBeOver()));
+                EWOMS_CATCH_PARALLEL_EXCEPTIONS_FATAL(problem_->writeOutput());
             writeTimer_.stop();
 
             // do the next time integration

--- a/ewoms/disc/common/fvbaseproblem.hh
+++ b/ewoms/disc/common/fvbaseproblem.hh
@@ -749,7 +749,7 @@ public:
      *
      * \param verbose Specify if a message should be printed whenever a file is written
      */
-    void writeOutput(bool isSubStep OPM_UNUSED, bool verbose = true)
+    void writeOutput(bool verbose = true)
     {
         if (!enableVtkOutput_())
             return;


### PR DESCRIPTION
with the recent fixes to `flow`, this is equivalent to `!simulator.episodeWillBeOver()`.