### PR TITLE
let the linear solver backend determine the type of the sparse matrix adapter

### DIFF
--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -50,7 +50,6 @@
 #include <ewoms/parallel/gridcommhandles.hh>
 #include <ewoms/parallel/threadmanager.hh>
 #include <ewoms/linear/nullborderlistmanager.hh>
-#include <ewoms/linear/istlsparsematrixadapter.hh>
 #include <ewoms/common/simulator.hh>
 #include <ewoms/common/alignedallocator.hh>
 #include <ewoms/common/timer.hh>
@@ -129,18 +128,6 @@ SET_TYPE_PROP(FvBaseDiscretization, DiscExtensiveQuantities, Ewoms::FvBaseExtens
 
 //! Calculates the gradient of any quantity given the index of a flux approximation point
 SET_TYPE_PROP(FvBaseDiscretization, GradientCalculator, Ewoms::FvBaseGradientCalculator<TypeTag>);
-
-//! Set the type of a global jacobian matrix from the solution types
-SET_PROP(FvBaseDiscretization, SparseMatrixAdapter)
-{
-private:
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
-    typedef Ewoms::MatrixBlock<Scalar, numEq, numEq> Block;
-
-public:
-    typedef typename Ewoms::Linear::IstlSparseMatrixAdapter<Block> type;
-};
 
 //! The maximum allowed number of timestep divisions for the
 //! Newton solver

--- a/ewoms/linear/parallelbasebackend.hh
+++ b/ewoms/linear/parallelbasebackend.hh
@@ -27,6 +27,7 @@
 #ifndef EWOMS_PARALLEL_BASE_BACKEND_HH
 #define EWOMS_PARALLEL_BASE_BACKEND_HH
 
+#include <ewoms/linear/istlsparsematrixadapter.hh>
 #include <ewoms/linear/overlappingbcrsmatrix.hh>
 #include <ewoms/linear/overlappingblockvector.hh>
 #include <ewoms/linear/overlappingpreconditioner.hh>
@@ -114,6 +115,20 @@ NEW_PROP_TAG(PreconditionerOrder);
 
 //! The relaxation factor of the preconditioner
 NEW_PROP_TAG(PreconditionerRelaxation);
+
+//! Set the type of a global jacobian matrix for linear solvers that are based on
+//! dune-istl.
+SET_PROP(ParallelBaseLinearSolver, SparseMatrixAdapter)
+{
+private:
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
+    typedef Ewoms::MatrixBlock<Scalar, numEq, numEq> Block;
+
+public:
+    typedef typename Ewoms::Linear::IstlSparseMatrixAdapter<Block> type;
+};
+
 END_PROPERTIES
 
 namespace Ewoms {


### PR DESCRIPTION
so far, this property was specified by the level of the base discretization. because explicitly set properties overwrite the stuff inherited from splices, so far it was not possible to specify linear solver backends which require a custom sparse matrix adapter unless the sparse matrix adapter class was explicitly set again at the problem level -- thus making the splice much less generic than it ought to be. (also, the whole point of the sparse matrix adapter abstraction is that the discretization does not need to know what the sparse matrix code does internally.)