### PR TITLE
Fix mixup between Grid::dimension and Grid::dimensionworld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,9 @@ opm_add_test(lens_immiscible_vcfv_fd
 opm_add_test(lens_immiscible_ecfv_ad
              TEST_ARGS --end-time=3000)
 
+opm_add_test(lens_immiscible_ecfv_ad_23
+             TEST_ARGS --end-time=3000)
+
 # this test is identical to the simulation of the lens problem that
 # uses the element centered finite volume discretization in
 # conjunction with automatic differentiation

--- a/ewoms/disc/common/fvbaseboundarycontext.hh
+++ b/ewoms/disc/common/fvbaseboundarycontext.hh
@@ -62,7 +62,7 @@ class FvBaseBoundaryContext
     enum { dimWorld = GridView::dimensionworld };
 
     typedef typename GridView::ctype CoordScalar;
-    typedef Dune::FieldVector<CoordScalar, dim> GlobalPosition;
+    typedef Dune::FieldVector<CoordScalar, dimWorld> GlobalPosition;
     typedef Dune::FieldVector<Scalar, dimWorld> Vector;
 
 public:

--- a/ewoms/disc/common/fvbaseelementcontext.hh
+++ b/ewoms/disc/common/fvbaseelementcontext.hh
@@ -78,11 +78,11 @@ class FvBaseElementContext
     typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
     typedef typename GridView::template Codim<0>::Entity Element;
 
-    static const unsigned dim = GridView::dimension;
+    static const unsigned dimWorld = GridView::dimensionworld;
     static const unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
 
     typedef typename GridView::ctype CoordScalar;
-    typedef Dune::FieldVector<CoordScalar, dim> GlobalPosition;
+    typedef Dune::FieldVector<CoordScalar, dimWorld> GlobalPosition;
 
     // we don't allow copies of element contexts!
     FvBaseElementContext(const FvBaseElementContext& ) = delete;

--- a/ewoms/disc/common/fvbasegradientcalculator.hh
+++ b/ewoms/disc/common/fvbasegradientcalculator.hh
@@ -60,8 +60,8 @@ class FvBaseGradientCalculator
     // we assume that the geometry with the most pointsq is a cube.
     enum { maxFap = 2 << dim };
 
-    typedef Dune::FieldVector<Scalar, dim> DimVector;
-    typedef Dune::FieldVector<Evaluation, dim> EvalDimVector;
+    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
+    typedef Dune::FieldVector<Evaluation, dimWorld> EvalDimVector;
 
 public:
     /*!

--- a/tests/lens_immiscible_ecfv_ad_23.cc
+++ b/tests/lens_immiscible_ecfv_ad_23.cc
@@ -1,0 +1,91 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Two-phase test for the immiscible model which uses the element-centered finite
+ *        volume discretization in conjunction with automatic differentiation
+ */
+#include "config.h"
+
+#include "lens_immiscible_ecfv_ad.hh"
+
+#include <dune/grid/geometrygrid.hh>
+#include <dune/grid/io/file/dgfparser/dgfgeogrid.hh>
+
+BEGIN_PROPERTIES
+
+// Use Dune-grid's GeometryGrid< YaspGrid >
+SET_PROP(LensProblemEcfvAd, Grid )
+{
+  template< class ctype, unsigned int dim, unsigned int dimworld >
+  class IdentityCoordFct
+    : public Dune::AnalyticalCoordFunction
+      < ctype, dim, dimworld, IdentityCoordFct< ctype, dim, dimworld > >
+  {
+    typedef IdentityCoordFct< ctype, dim, dimworld > This;
+    typedef Dune::AnalyticalCoordFunction< ctype, dim, dimworld, This > Base;
+
+  public:
+    typedef typename Base :: DomainVector DomainVector;
+    typedef typename Base :: RangeVector  RangeVector;
+
+    template< typename... Args >
+    IdentityCoordFct( Args&... )
+    {}
+
+    RangeVector operator()(const DomainVector& x) const
+    {
+      RangeVector y;
+      evaluate( x, y );
+      return y;
+    }
+
+    void evaluate( const DomainVector &x, RangeVector &y ) const
+    {
+      y = 0;
+      for( unsigned int i = 0; i<dim; ++i )
+        y[ i ] = x[ i ];
+    }
+
+  };
+
+  typedef Dune::YaspGrid< 2 > MyYaspGrid;
+
+public:
+  //typedef MyYaspGrid type;
+  typedef Dune::GeometryGrid< MyYaspGrid,
+                              IdentityCoordFct< typename MyYaspGrid::ctype,
+                                                MyYaspGrid::dimension,
+                                                MyYaspGrid::dimensionworld+1> >  type;
+};
+
+END_PROPERTIES
+
+#include <ewoms/common/start.hh>
+
+int main(int argc, char **argv)
+{
+    typedef TTAG(LensProblemEcfvAd) ProblemTypeTag;
+    return Ewoms::start<ProblemTypeTag>(argc, argv);
+}


### PR DESCRIPTION
In Element context global position definition sometimes the Grid::dimension is used instead of Grid::dimensionworld. This leads to compile errors when dimension != dimensionworld. 
