### PR TITLE
do no longer call createVariable() for plain floating point types

### DIFF
--- a/ewoms/disc/common/fvbaseprimaryvariables.hh
+++ b/ewoms/disc/common/fvbaseprimaryvariables.hh
@@ -89,10 +89,15 @@ public:
      */
     Evaluation makeEvaluation(unsigned varIdx, unsigned timeIdx) const
     {
-        if (timeIdx == 0)
-            return Toolbox::createVariable((*this)[varIdx], varIdx);
-        else
-            return Toolbox::createConstant((*this)[varIdx]);
+        if (std::is_same<Evaluation, Scalar>::value)
+            return (*this)[varIdx]; // finite differences
+        else {
+            // automatic differentiation
+            if (timeIdx == 0)
+                return Toolbox::createVariable((*this)[varIdx], varIdx);
+            else
+                return Toolbox::createConstant((*this)[varIdx]);
+        }
     }
 
     /*!

--- a/ewoms/models/blackoil/blackoilpolymermodules.hh
+++ b/ewoms/models/blackoil/blackoilpolymermodules.hh
@@ -844,15 +844,14 @@ public:
 
         const Scalar eps = 1e-14;
         // return 1.0 if the polymer has no effect on the water.
-        if (std::abs((viscosityMultiplier - 1.0)) < eps){
-            return ToolboxLocal::createConstantOne(v0);
-        }
+        if (std::abs((viscosityMultiplier - 1.0)) < eps)
+            return ToolboxLocal::createConstant(v0, 1.0);
 
         const std::vector<Scalar>& shearEffectRefLogVelocity = plyshlogShearEffectRefLogVelocity_[pvtnumRegionIdx];
         auto v0AbsLog = Opm::log(Opm::abs(v0));
         // return 1.0 if the velocity /sharte is smaller than the first velocity entry.
         if (v0AbsLog < shearEffectRefLogVelocity[0])
-            return ToolboxLocal::createConstantOne(v0);
+            return ToolboxLocal::createConstant(v0, 1.0);
 
         // compute shear factor from input
         // Z = (1 + (P - 1) * M(v)) / P

--- a/ewoms/models/common/energymodule.hh
+++ b/ewoms/models/common/energymodule.hh
@@ -633,11 +633,15 @@ protected:
     {
         const auto& priVars = context.primaryVars(spaceIdx, timeIdx);
         Evaluation val;
-        if (timeIdx == 0)
-            val = Toolbox::createVariable(priVars[temperatureIdx], temperatureIdx);
-        else
+        if (std::is_same<Evaluation, Scalar>::value) // finite differences
             val = Toolbox::createConstant(priVars[temperatureIdx]);
-
+        else {
+            // automatic differentiation
+            if (timeIdx == 0)
+                val = Toolbox::createVariable(priVars[temperatureIdx], temperatureIdx);
+            else
+                val = Toolbox::createConstant(priVars[temperatureIdx]);
+        }
         fluidState.setTemperature(val);
     }
 

--- a/ewoms/models/pvs/pvsprimaryvariables.hh
+++ b/ewoms/models/pvs/pvsprimaryvariables.hh
@@ -260,9 +260,14 @@ public:
             return 0.0;
 
         unsigned varIdx = switch0Idx + phaseIdx - 1;
-        if (timeIdx != 0)
-            Toolbox::createConstant((*this)[varIdx]);
-        return Toolbox::createVariable((*this)[varIdx], varIdx);
+        if (std::is_same<Evaluation, Scalar>::value)
+            return (*this)[varIdx]; // finite differences
+        else {
+            // automatic differentiation
+            if (timeIdx != 0)
+                Toolbox::createConstant((*this)[varIdx]);
+            return Toolbox::createVariable((*this)[varIdx], varIdx);
+        }
     }
 
     /*!


### PR DESCRIPTION
with OPM/opm-material#340, this will throw an exception. Never try to fix more than one thing at once...

Right now, this PR can be merged as-is as it is, and it is IMO a good idea to do so, because it is IMO good style to not to give the impression that a plain floating point object can represent an AD variable. It is required before for OPM/opm-material#340 can go in.