### PR TITLE
parameter system: allow to specify empty strings

### DIFF
--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -734,7 +734,7 @@ std::string parseCommandLineOptions(int argc,
         }
         seenKeys.insert(paramName);
 
-        if (s.empty() || s[0] != '=' || s.size()==1) {
+        if (s.empty() || s[0] != '=') {
             std::string msg =
                 std::string("Parameter '")+paramName+"' is missing a value. "
                 +" Please use "+argv[i]+"=value.";


### PR DESCRIPTION
this might be wanted in some instances.