### PR TITLE
simulator: make episode{Is,WillBe}Over() work if startTime() is negative

### DIFF
--- a/ewoms/common/simulator.hh
+++ b/ewoms/common/simulator.hh
@@ -547,7 +547,7 @@ public:
     {
         static const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e3;
 
-        return startTime() + this->time() >= (episodeStartTime_ + episodeLength())*(1 - eps);
+        return this->time() >= (episodeStartTime_ - startTime() + episodeLength())*(1 - eps);
     }
 
     /*!
@@ -558,8 +558,8 @@ public:
     {
         static const Scalar eps = std::numeric_limits<Scalar>::epsilon()*1e3;
 
-        return startTime() + this->time() + timeStepSize()
-            >=  (episodeStartTime_ + episodeLength())*(1 - eps);
+        return this->time() + timeStepSize()
+            >=  (episodeStartTime_ - startTime() + episodeLength())*(1 - eps);
     }
 
     /*!


### PR DESCRIPTION
for some reason, this happens with SPE-10 model 2.