### PR TITLE
Ewoms::start(): abort the run when encountering unknown parameters

### DIFF
--- a/bin/runtest.sh
+++ b/bin/runtest.sh
@@ -206,7 +206,6 @@ EndTime=100
   
 InitialTimeStepSize=100   # first in-line comment
 
-UndefinedParam  =  "blubb"; second in-line comment
   # full line comment
 ; also a full line comment
 EOF
@@ -215,6 +214,9 @@ EOF
             exit 1
         elif $TEST_BINARY --parameter-file="foobar.ini" 2>&1 > /dev/null; then
             echo "$TEST_BINARY does not abort even though the specified parameter file does not exist"
+            exit 1
+        elif $TEST_BINARY --undefined-param="bla" 2>&1 > /dev/null; then
+            echo "$TEST_BINARY does not signal an error even though an undefined command line parameter was passed"
             exit 1
         elif $TEST_BINARY --foo 2>&1 > /dev/null; then
             echo "$TEST_BINARY accepts flag parameters besides --help"

--- a/ewoms/common/parametersystem.hh
+++ b/ewoms/common/parametersystem.hh
@@ -124,6 +124,17 @@
         #ParamName, #ParamName,                                         \
         /*errorIfNotRegistered=*/false))
 
+/*!
+ * \ingroup Parameter
+ *
+ * \brief Retrieves the lists of parameters specified at runtime and their values.
+ *
+ * The two arguments besides the TypeTag are assumed to be STL containers which store
+ * std::pair<std::string, std::string>.
+ */
+#define EWOMS_GET_PARAM_LISTS(TypeTag, UsedParamList, UnusedParamList)    \
+    (::Ewoms::Parameters::getLists<TypeTag>(UsedParamList, UnusedParamList))
+
 //!\cond SKIP_THIS
 #define EWOMS_RESET_PARAMS_(TypeTag)            \
     (::Ewoms::Parameters::reset<TypeTag>())
@@ -993,7 +1004,8 @@ private:
     };
 
     static void check_(const std::string& paramTypeName,
-                       const std::string& propertyName, const char *paramName)
+                       const std::string& propertyName,
+                       const char *paramName)
     {
         typedef std::unordered_map<std::string, Blubb> StaticData;
         static StaticData staticData;
@@ -1065,6 +1077,34 @@ const ParamType get(const char *propTagName, const char *paramName, bool errorIf
     return Param<TypeTag>::template get<ParamType, PropTag>(propTagName,
                                                             paramName,
                                                             errorIfNotRegistered);
+}
+
+template <class TypeTag, class Container>
+const void getLists(Container& usedParams, Container& unusedParams)
+{
+    usedParams.clear();
+    unusedParams.clear();
+
+    typedef typename GET_PROP(TypeTag, ParameterMetaData) ParamsMeta;
+    if (ParamsMeta::registrationOpen())
+        throw std::runtime_error("Parameter lists can only retieved after _all_ of them have "
+                                 "been registered.");
+
+    // get all parameter keys
+    std::list<std::string> allKeysList;
+    const auto& paramTree = ParamsMeta::tree();
+    getFlattenedKeyList_(allKeysList, paramTree);
+
+    for (const auto& key : allKeysList) {
+        if (ParamsMeta::registry().find(key) == ParamsMeta::registry().end()) {
+            // key was not registered
+            unusedParams.emplace_back(key, paramTree[key]);
+        }
+        else {
+            // key was registered
+            usedParams.emplace_back(key, paramTree[key]);
+        }
+    }
 }
 
 template <class TypeTag>

--- a/ewoms/common/start.hh
+++ b/ewoms/common/start.hh
@@ -118,7 +118,11 @@ static inline void registerAllParameters_(bool finalizeRegistration = true)
  * \param argv Array with the command line argument strings
  */
 template <class TypeTag>
-static inline int setupParameters_(int argc, const char **argv, bool registerParams = true)
+static inline int setupParameters_(int argc,
+                                   const char **argv,
+                                   bool registerParams=true,
+                                   bool allowUnused=false,
+                                   bool handleHelp = true)
 {
     typedef typename GET_PROP_TYPE(TypeTag, Problem) Problem;
 
@@ -138,7 +142,7 @@ static inline int setupParameters_(int argc, const char **argv, bool registerPar
     // fill the parameter tree with the options from the command line
     const auto& positionalParamCallback = Problem::handlePositionalParameter;
     std::string helpPreamble = "";
-    if (myRank == 0)
+    if (myRank == 0 && handleHelp)
         helpPreamble = Problem::helpPreamble(argc, argv);
     std::string s =
         Parameters::parseCommandLineOptions<TypeTag>(argc,
@@ -169,6 +173,36 @@ static inline int setupParameters_(int argc, const char **argv, bool registerPar
 
         // read the parameter file.
         Parameters::parseParameterFile<TypeTag>(paramFileName, /*overwrite=*/false);
+    }
+
+    // make sure that no unknown parameters are encountered
+    typedef std::pair<std::string, std::string> KeyValuePair;
+    typedef std::list<KeyValuePair> ParamList;
+
+    ParamList usedParams;
+    ParamList unusedParams;
+
+    EWOMS_GET_PARAM_LISTS(TypeTag, usedParams, unusedParams);
+    if (!allowUnused && !unusedParams.empty()) {
+        if (myRank == 0) {
+            if (unusedParams.size() == 1)
+                std::cerr << "The following explicitly specified parameter is unknown:\n";
+            else
+                std::cerr << "The following " << unusedParams.size()
+                          << " explicitly specified parameters are unknown:\n";
+
+            std::cerr << "\n";
+            for (const auto& keyValue : unusedParams)
+                std::cerr << "   " << keyValue.first << "=\"" << keyValue.second << "\"\n";
+            std::cerr << "\n";
+
+            std::cerr << "Use\n"
+                      << "\n"
+                      << "  " << argv[0] << " --help\n"
+                      << "\n"
+                      <<"to obtain the list of recognized command line parameters.\n\n";
+        }
+        return /*status=*/1;
     }
 
     return /*status=*/0;


### PR DESCRIPTION
This patch is part of the quest to reduce surprising/unexpected behaviors and it aborts the simulation with a hopefully useful error message if unknown parameters are specified at runtime. The implementation of this is general, i.e. it works for any simulators that use `Ewoms::start()` without any scaffolding around it: with no modifications to opm-simulators `mebos` will give up if it encounters a parameter that is unknown to the black-oil variant and it will print the usage message multiple times on `--help`. `flow` will work as before but it will start complaining about unknown parameters. OPM/opm-simulators#1916 rectifies these issues.