### PR TITLE
implement option to continue if time integration failed with minimum time step

### DIFF
--- a/ewoms/disc/common/fvbasediscretization.hh
+++ b/ewoms/disc/common/fvbasediscretization.hh
@@ -133,6 +133,12 @@ SET_TYPE_PROP(FvBaseDiscretization, GradientCalculator, Ewoms::FvBaseGradientCal
 //! Newton solver
 SET_INT_PROP(FvBaseDiscretization, MaxTimeStepDivisions, 10);
 
+
+//! By default, do not continue with a non-converged solution instead of giving up
+//! if we encounter a time step size smaller than the minimum time
+//! step size.
+SET_BOOL_PROP(FvBaseDiscretization, ContinueOnConvergenceError, false);
+
 /*!
  * \brief A vector of quanties, each for one equation.
  */

--- a/ewoms/disc/common/fvbaseproperties.hh
+++ b/ewoms/disc/common/fvbaseproperties.hh
@@ -240,6 +240,13 @@ NEW_PROP_TAG(MinTimeStepSize);
 NEW_PROP_TAG(MaxTimeStepDivisions);
 
 /*!
+ * \brief Continue with a non-converged solution instead of giving up
+ *        if we encounter a time step size smaller than the minimum time
+ *        step size.
+ */
+NEW_PROP_TAG(ContinueOnConvergenceError);
+
+/*!
  * \brief Specify whether all intensive quantities for the grid should be
  *        cached in the discretization.
  *


### PR DESCRIPTION
this is basically a continuation of #522. By itself, this PR does nothing if `--continue-on-convergence-error=true` is not explicitly specified on the command line.