### PR TITLE
Add foam module

### DIFF
--- a/ewoms/models/blackoil/blackoilboundaryratevector.hh
+++ b/ewoms/models/blackoil/blackoilboundaryratevector.hh
@@ -61,6 +61,7 @@ class BlackOilBoundaryRateVector : public GET_PROP_TYPE(TypeTag, RateVector)
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { conti0EqIdx = Indices::conti0EqIdx };
     enum { contiEnergyEqIdx = Indices::contiEnergyEqIdx };
+    enum { enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam) };
 
     static constexpr bool blackoilConserveSurfaceVolume = GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume);
 

--- a/ewoms/models/blackoil/blackoilfoammodules.hh
+++ b/ewoms/models/blackoil/blackoilfoammodules.hh
@@ -32,8 +32,15 @@
 //#include <ewoms/io/vtkblackoilfoammodule.hh>
 #include <ewoms/models/common/quantitycallbacks.hh>
 
-//#include <opm/material/common/Tabulated1DFunction.hpp>
+#include <opm/material/common/Tabulated1DFunction.hpp>
 //#include <opm/material/common/IntervalTabulated2DFunction.hpp>
+
+#if HAVE_ECL_INPUT
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/FoamadsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/FoammobTable.hpp>
+#endif
 
 #include <opm/material/common/Valgrind.hpp>
 #include <opm/material/common/Unused.hpp>
@@ -68,13 +75,11 @@ class BlackOilFoamModule
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
 
-    //typedef typename Opm::Tabulated1DFunction<Scalar> TabulatedFunction;
-    //typedef typename Opm::IntervalTabulated2DFunction<Scalar> TabulatedTwoDFunction;
+    typedef typename Opm::Tabulated1DFunction<Scalar> TabulatedFunction;
 
     static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
     static constexpr unsigned contiFoamEqIdx = Indices::contiFoamEqIdx;
     static constexpr unsigned gasPhaseIdx = FluidSystem::gasPhaseIdx;
-
 
     static constexpr unsigned enableFoam = enableFoamV;
 
@@ -82,33 +87,32 @@ class BlackOilFoamModule
     static constexpr unsigned numPhases = FluidSystem::numPhases;
 
 public:
-    //enum AdsorptionBehaviour { Desorption = 1, NoDesorption = 2 };
-
     // a struct containing constants to calculate change to relative permeability,
     // based on model (1-9) in Table 1 of
-    // Kun  Ma,  Guangwei  Ren,  Khalid  Mateen,  Danielle  Morel,  and  PhilippeCordelier.
-    // Modeling techniques for foam flow in porous media.SPE Journal,20(03):453–470, jun 2015.
-    // The constants are provided by the keyword ...
+    // Kun Ma, Guangwei Ren, Khalid Mateen, Danielle Morel, and Philippe Cordelier:
+    // "Modeling techniques for foam flow in porous media", SPE Journal, 20(03):453–470, jun 2015.
+    // The constants are provided by various deck keywords as shown in the comments below.
     struct FoamCoefficients {
-        Scalar fm_mob = 2;
+        Scalar fm_min = 1e-20;   // FOAMFSC
+        Scalar fm_mob = 1.0;     // FOAMFRM
 
-        Scalar fm_surf = 1;
-        Scalar ep_surf = 1;
+        Scalar fm_surf = 1.0;    // FOAMFSC
+        Scalar ep_surf = 1.0;    // FOAMFSC
 
-        Scalar fm_oil = 1;
-        Scalar fl_oil = 0;
-        Scalar ep_oil = 1;
+        Scalar fm_oil = 1.0;     // FOAMFSO
+        Scalar fl_oil = 0.0;     // FOAMFSO
+        Scalar ep_oil = 0.0;     // FOAMFSO
 
-        Scalar fm_dry = 1;
-        Scalar ep_dry = 0;
+        Scalar fm_cap = 1.0;     // FOAMFCN
+        Scalar ep_cap = 0.0;     // FOAMFCN
 
-        Scalar fm_cap = 1;
-        Scalar ep_cap = 1;
+        Scalar fm_dry = 1.0;     // FOAMFSW
+        Scalar ep_dry = 0.0;     // FOAMFSW
     };
 
 #if HAVE_ECL_INPUT
     /*!
-     * \brief Initialize all internal data structures needed by the polymer module
+     * \brief Initialize all internal data structures needed by the foam module
      */
     static void initFromDeck(const Opm::Deck& deck, const Opm::EclipseState& eclState)
     {
@@ -126,112 +130,87 @@ public:
         if (!deck.hasKeyword("FOAM"))
             return; // foam treatment is supposed to be disabled
 
-        //unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
-        // TODO: do not hard code
-        setNumSatRegions(1);
+        const auto& tableManager = eclState.getTableManager();
+        const unsigned int numSatRegions = tableManager.getTabdims().getNumSatTables();
+        setNumSatRegions(numSatRegions);
+        const unsigned int numPvtRegions = tableManager.getTabdims().getNumPVTTables();
+        setNumPvtRegions(numPvtRegions);
 
+        // Get and check FOAMROCK data.
+        const Opm::FoamConfig& foamConf = eclState.getInitConfig().getFoamConfig();
+        if (numSatRegions != foamConf.size()) {
+            throw std::runtime_error("Inconsistent sizes, number of saturation regions differ from the number of elements "
+                                     "in FoamConfig, which typically corresponds to the number of records in FOAMROCK.");
+        }
+
+        // Get and check FOAMADS data.
+        const auto& foamadsTables = tableManager.getFoamadsTables();
+        if (foamadsTables.empty()) {
+            throw std::runtime_error("FOAMADS must be specified in FOAM runs");
+        }
+        if (numSatRegions != foamadsTables.size()) {
+            throw std::runtime_error("Inconsistent sizes, number of saturation regions differ from the "
+                                     "number of FOAMADS tables.");
+        }
+
+        // Set data that vary with saturation region.
+        for (std::size_t satReg = 0; satReg < numSatRegions; ++satReg) {
+            const auto& rec = foamConf.getRecord(satReg);
+            foamCoefficients_[satReg] = FoamCoefficients();
+            foamCoefficients_[satReg].fm_min = rec.minimumSurfactantConcentration();
+            foamCoefficients_[satReg].fm_surf = rec.referenceSurfactantConcentration();
+            foamCoefficients_[satReg].ep_surf = rec.exponent();
+            foamRockDensity_[satReg] = rec.rockDensity();
+            foamAllowDesorption_[satReg] = rec.allowDesorption();
+            const auto& foamadsTable = foamadsTables.template getTable<Opm::FoamadsTable>(satReg);
+            const auto& conc = foamadsTable.getFoamConcentrationColumn();
+            const auto& ads = foamadsTable.getAdsorbedFoamColumn();
+            adsorbedFoamTable_[satReg].setXYContainers(conc, ads);
+        }
+
+        // Get and check FOAMMOB data.
+        const auto& foammobTables = tableManager.getFoammobTables();
+        if (foammobTables.empty()) {
+            // When in the future adding support for the functional
+            // model, FOAMMOB will not be required anymore (functional
+            // family of keywords can be used instead, FOAMFSC etc.).
+            throw std::runtime_error("FOAMMOB must be specified in FOAM runs");
+        }
+        if (numPvtRegions != foammobTables.size()) {
+            throw std::runtime_error("Inconsistent sizes, number of PVT regions differ from the "
+                                     "number of FOAMMOB tables.");
+        }
+
+        // Set data that vary with PVT region.
+        for (std::size_t pvtReg = 0; pvtReg < numPvtRegions; ++pvtReg) {
+            const auto& foammobTable = foammobTables.template getTable<Opm::FoammobTable>(pvtReg);
+            const auto& conc = foammobTable.getFoamConcentrationColumn();
+            const auto& mobMult = foammobTable.getMobilityMultiplierColumn();
+            gasMobilityMultiplierTable_[pvtReg].setXYContainers(conc, mobMult);
+        }
     }
 #endif
 
-    // a struct containing the constants to calculate foam viscosity
-    // based on Mark-Houwink equation and Huggins equation, the constants are provided
-    // by the keyword PLYVMH
-    //struct PlyvmhCoefficients {
-    //    Scalar k_mh;
-    //    Scalar a_mh;
-    //    Scalar gamma;
-    //    Scalar kappa;
-    //};
-
     /*!
-     * \brief Specify the number of satuation regions.
-     *
-     * This must be called before setting the PLYROCK and PLYADS of any region.
+     * \brief Specify the number of saturation regions.
      */
     static void setNumSatRegions(unsigned numRegions)
     {
         foamCoefficients_.resize(numRegions);
-    //    plyrockDeadPoreVolume_.resize(numRegions);
-    //    plyrockResidualResistanceFactor_.resize(numRegions);
-    //    plyrockRockDensityFactor_.resize(numRegions);
-    //    plyrockAdsorbtionIndex_.resize(numRegions);
-    //    plyrockMaxAdsorbtion_.resize(numRegions);
-    //    plyadsAdsorbedFoam_.resize(numRegions);
+        foamRockDensity_.resize(numRegions);
+        foamAllowDesorption_.resize(numRegions);
+        adsorbedFoamTable_.resize(numRegions);
     }
 
-    /*!
-     * \brief Specify the foam properties a single region.
-     *
-     * The index of specified here must be in range [0, numSatRegions)
-     */
-    //static void setPlyrock(unsigned satRegionIdx,
-    //                       const Scalar& plyrockDeadPoreVolume,
-    //                       const Scalar& plyrockResidualResistanceFactor,
-    //                       const Scalar& plyrockRockDensityFactor,
-    //                       const Scalar& plyrockAdsorbtionIndex,
-    //                       const Scalar& plyrockMaxAdsorbtion)
-    //{
-    //    plyrockDeadPoreVolume_[satRegionIdx] = plyrockDeadPoreVolume;
-    //    plyrockResidualResistanceFactor_[satRegionIdx] = plyrockResidualResistanceFactor;
-    //    plyrockRockDensityFactor_[satRegionIdx] = plyrockRockDensityFactor;
-    //    plyrockAdsorbtionIndex_[satRegionIdx] = plyrockAdsorbtionIndex;
-    //    plyrockMaxAdsorbtion_[satRegionIdx] = plyrockMaxAdsorbtion;
-    //}
 
     /*!
-     * \brief Specify the number of pvt regions.
-     *
-     * This must be called before setting the PLYVISC of any region.
+     * \brief Specify the number of PVT regions.
      */
-    //static void setNumPvtRegions(unsigned numRegions)
-    //{
-    //    plyviscViscosityMultiplierTable_.resize(numRegions);
-    //}
+    static void setNumPvtRegions(unsigned numRegions)
+    {
+        gasMobilityMultiplierTable_.resize(numRegions);
+    }
 
-    /*!
-     * \brief Specify the foam viscosity a single region.
-     *
-     * The index of specified here must be in range [0, numSatRegions)
-     */
-    //static void setPlyvisc(unsigned satRegionIdx,
-    //                       const TabulatedFunction& plyviscViscosityMultiplierTable)
-    //{
-    //    plyviscViscosityMultiplierTable_[satRegionIdx] = plyviscViscosityMultiplierTable;
-    //}
-
-    /*!
-     * \brief Specify the number of mix regions.
-     *
-     * This must be called before setting the PLYMAC and PLMIXPAR of any region.
-     */
-    //static void setNumMixRegions(unsigned numRegions)
-    //{
-    //    plymaxMaxConcentration_.resize(numRegions);
-    //    plymixparToddLongstaff_.resize(numRegions);
-
-    //}
-
-    /*!
-     * \brief Specify the maximum foam concentration a single region.
-     *
-     * The index of specified here must be in range [0, numMixRegionIdx)
-     */
-    //static void setPlymax(unsigned mixRegionIdx,
-    //                      const Scalar& plymaxMaxConcentration)
-    //{
-    //    plymaxMaxConcentration_[mixRegionIdx] = plymaxMaxConcentration;
-    //}
-
-    /*!
-     * \brief Specify the maximum foam concentration a single region.
-     *
-     * The index of specified here must be in range [0, numMixRegionIdx)
-     */
-    //static void setPlmixpar(unsigned mixRegionIdx,
-    //                        const Scalar& plymixparToddLongstaff)
-    //{
-    //    plymixparToddLongstaff_[mixRegionIdx] = plymixparToddLongstaff;
-    //}
 
     /*!
      * \brief Register all run-time parameters for the black-oil foam module.
@@ -258,31 +237,28 @@ public:
         //model.addOutputModule(new Ewoms::VtkBlackOilFoamModule<TypeTag>(simulator));
     }
 
-    //static bool primaryVarApplies(unsigned pvIdx)
-    //{
-    //    // foam has been disabled at compile time
-    //    return enableFoam;
-    //}
+    static bool primaryVarApplies(unsigned pvIdx)
+    {
+        if (!enableFoam) {
+            return false;
+        } else {
+            return pvIdx == foamConcentrationIdx;
+        }
+    }
 
-    //static std::string primaryVarName(unsigned pvIdx)
-    //{
-    //    assert(primaryVarApplies(pvIdx));
+    static std::string primaryVarName(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+        assert(primaryVarApplies(pvIdx));
+        return "foam_concentration";
+    }
 
-    //    if (pvIdx == polymerConcentrationIdx) {
-    //        return "polymer_waterconcentration";
-    //    }
-    //    else {
-    //        return "polymer_molecularweight";
-    //    }
-    //}
+    static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
+    {
+       assert(primaryVarApplies(pvIdx));
 
-    //static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
-    //{
-    //    assert(primaryVarApplies(pvIdx));
-
-    //    // TODO: it may be beneficial to chose this differently.
-    //    return static_cast<Scalar>(1.0);
-    //}
+       // TODO: it may be beneficial to chose this differently.
+       return static_cast<Scalar>(1.0);
+    }
 
     static bool eqApplies(unsigned eqIdx)
     {
@@ -300,13 +276,13 @@ public:
         return "conti^foam";
     }
 
-    //static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
-    //{
-    //    assert(eqApplies(eqIdx));
+    static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
+    {
+       assert(eqApplies(eqIdx));
 
-    //    // TODO: it may be beneficial to chose this differently.
-    //    return static_cast<Scalar>(1.0);
-    //}
+       // TODO: it may be beneficial to chose this differently.
+       return static_cast<Scalar>(1.0);
+    }
 
     // must be called after water storage is computed
     template <class LhsEval>
@@ -328,15 +304,13 @@ public:
 
         // Foam/surfactant in gas phase.
         const LhsEval gasFoam = surfaceVolumeFreeGas
-            * Toolbox::template decay<LhsEval>(br) // TODO
             * Toolbox::template decay<LhsEval>(intQuants.foamConcentration());
 
         // Adsorbed foam/surfactant.
         const LhsEval adsorbedFoam =
             Toolbox::template decay<LhsEval>(1.0 - intQuants.porosity())
-            * Toolbox::template decay<LhsEval>(intQuants.foamRockDensity()) // TODO
-            * Toolbox::template decay<LhsEval>(intQuants.foamAdsorption())  // TODO
-            / Toolbox::template decay<LhsEval>(intQuants.porosity());
+            * Toolbox::template decay<LhsEval>(intQuants.foamRockDensity())
+            * Toolbox::template decay<LhsEval>(intQuants.foamAdsorbed());
 
         LhsEval accumulationFoam = gasFoam + adsorbedFoam;
         storage[contiFoamEqIdx] += accumulationFoam;
@@ -348,40 +322,28 @@ public:
                             unsigned timeIdx)
 
     {
-        if (!enableFoam)
+        if (!enableFoam) {
             return;
+        }
 
         const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
-
-        const unsigned upIdx = extQuants.upstreamIndex(FluidSystem::waterPhaseIdx);
+        const unsigned upIdx = extQuants.upstreamIndex(FluidSystem::gasPhaseIdx);
         const unsigned inIdx = extQuants.interiorIndex();
         const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
-        const unsigned contiWaterEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
 
-
+        // The effect of the gas mobility reduction factor is
+        // incorporated in the mobility, so the oil (if vaporized oil
+        // is active) and gas fluxes do not need modification here.
         if (upIdx == inIdx) {
-            flux[contiFoamEqIdx] = 0.;
-                    //extQuants.volumeFlux(waterPhaseIdx)
-                    //*up.fluidState().invB(waterPhaseIdx)
-                    //*up.polymerViscosityCorrection()
-                    ///extQuants.polymerShearFactor()
-                    //*up.polymerConcentration();
-
-            // modify water
-            flux[contiWaterEqIdx] /= 1.;
-                    //extQuants.waterShearFactor();
-        }
-        else {
-            flux[contiFoamEqIdx] = 0.;
-                    //extQuants.volumeFlux(waterPhaseIdx)
-                    //*Opm::decay<Scalar>(up.fluidState().invB(waterPhaseIdx))
-                    //*Opm::decay<Scalar>(up.polymerViscosityCorrection())
-                    ///Opm::decay<Scalar>(extQuants.polymerShearFactor())
-                    //*Opm::decay<Scalar>(up.polymerConcentration());
-
-            // modify water
-            flux[contiWaterEqIdx] /= 1.;
-                    //Opm::decay<Scalar>(extQuants.waterShearFactor());
+            flux[contiFoamEqIdx] =
+                extQuants.volumeFlux(gasPhaseIdx)
+                *up.fluidState().invB(gasPhaseIdx)
+                *up.foamConcentration();
+        } else {
+            flux[contiFoamEqIdx] =
+                extQuants.volumeFlux(gasPhaseIdx)
+                *Opm::decay<Scalar>(up.fluidState().invB(gasPhaseIdx))
+                *Opm::decay<Scalar>(up.foamConcentration());
         }
 
     }
@@ -403,10 +365,9 @@ public:
         if (!enableFoam)
             return;
 
-        //unsigned dofIdx = model.dofMapper().index(dof);
-        //const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
-        //outstream << priVars[polymerConcentrationIdx];
-        //outstream << priVars[polymerMoleWeightIdx];
+        unsigned dofIdx = model.dofMapper().index(dof);
+        const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
+        outstream << priVars[foamConcentrationIdx];
     }
 
     template <class DofEntity>
@@ -415,306 +376,90 @@ public:
         if (!enableFoam)
             return;
 
-        //unsigned dofIdx = model.dofMapper().index(dof);
-        //PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
-        //PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
+        unsigned dofIdx = model.dofMapper().index(dof);
+        PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
+        PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
 
-        //instream >> priVars0[polymerConcentrationIdx];
-        //instream >> priVars0[polymerMoleWeightIdx];
+        instream >> priVars0[foamConcentrationIdx];
 
-        //// set the primary variables for the beginning of the current time step.
-        //priVars1[polymerConcentrationIdx] = priVars0[polymerConcentrationIdx];
-        //priVars1[polymerMoleWeightIdx] = priVars0[polymerMoleWeightIdx];
+        // set the primary variables for the beginning of the current time step.
+        priVars1[foamConcentrationIdx] = priVars0[foamConcentrationIdx];
     }
 
-    //static const Scalar plyrockDeadPoreVolume(const ElementContext& elemCtx,
-    //                                          unsigned scvIdx,
-    //                                          unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyrockDeadPoreVolume_[satnumRegionIdx];
-    //}
+    static const Scalar foamRockDensity(const ElementContext& elemCtx,
+                                        unsigned scvIdx,
+                                        unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return foamRockDensity_[satnumRegionIdx];
+    }
 
-    //static const Scalar plyrockResidualResistanceFactor(const ElementContext& elemCtx,
-    //                                                    unsigned scvIdx,
-    //                                                    unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyrockResidualResistanceFactor_[satnumRegionIdx];
-    //}
+    static bool foamAllowDesorption(const ElementContext& elemCtx,
+                                    unsigned scvIdx,
+                                    unsigned timeIdx)
+    {
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return foamAllowDesorption_[satnumRegionIdx];
+    }
 
-    //static const Scalar plyrockRockDensityFactor(const ElementContext& elemCtx,
-    //                                             unsigned scvIdx,
-    //                                             unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyrockRockDensityFactor_[satnumRegionIdx];
-    //}
+    static const TabulatedFunction& adsorbedFoamTable(const ElementContext& elemCtx,
+                                                      unsigned scvIdx,
+                                                      unsigned timeIdx)
+    {
+       unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+       return adsorbedFoamTable_[satnumRegionIdx];
+    }
 
-    //static const Scalar plyrockAdsorbtionIndex(const ElementContext& elemCtx,
-    //                                           unsigned scvIdx,
-    //                                           unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyrockAdsorbtionIndex_[satnumRegionIdx];
-    //}
-
-    //static const Scalar plyrockMaxAdsorbtion(const ElementContext& elemCtx,
-    //                                         unsigned scvIdx,
-    //                                         unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyrockMaxAdsorbtion_[satnumRegionIdx];
-    //}
-
-    //static const TabulatedFunction& plyadsAdsorbedPolymer(const ElementContext& elemCtx,
-    //                                                      unsigned scvIdx,
-    //                                                      unsigned timeIdx)
-    //{
-    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyadsAdsorbedPolymer_[satnumRegionIdx];
-    //}
-
-    //static const TabulatedFunction& plyviscViscosityMultiplierTable(const ElementContext& elemCtx,
-    //                                                                unsigned scvIdx,
-    //                                                                unsigned timeIdx)
-    //{
-    //    unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
-    //}
-
-    //static const TabulatedFunction& plyviscViscosityMultiplierTable(unsigned pvtnumRegionIdx)
-    //{
-    //    return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
-    //}
-
-    //static const Scalar plymaxMaxConcentration(const ElementContext& elemCtx,
-    //                                           unsigned scvIdx,
-    //                                           unsigned timeIdx)
-    //{
-    //    unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plymaxMaxConcentration_[polymerMixRegionIdx];
-    //}
-
-    //static const Scalar plymixparToddLongstaff(const ElementContext& elemCtx,
-    //                                           unsigned scvIdx,
-    //                                           unsigned timeIdx)
-    //{
-    //    unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plymixparToddLongstaff_[polymerMixRegionIdx];
-    //}
+    static const TabulatedFunction& gasMobilityMultiplierTable(const ElementContext& elemCtx,
+                                                               unsigned scvIdx,
+                                                               unsigned timeIdx)
+    {
+       unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
+       return gasMobilityMultiplierTable_[pvtnumRegionIdx];
+    }
 
     static const FoamCoefficients& foamCoefficients(const ElementContext& elemCtx,
-                                                        const unsigned scvIdx,
-                                                        const unsigned timeIdx)
+                                                    const unsigned scvIdx,
+                                                    const unsigned timeIdx)
     {
-        //const unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
-        // TODO: Don't hard code!!!
-        return foamCoefficients_[0];
+        unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        return foamCoefficients_[satnumRegionIdx];
     }
 
-    //static const PlyvmhCoefficients& plyvmhCoefficients(const ElementContext& elemCtx,
-    //                                                    const unsigned scvIdx,
-    //                                                    const unsigned timeIdx)
-    //{
-    //    const unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
-    //    return plyvmhCoefficients_[polymerMixRegionIdx];
-    //}
-
-    ///*!
-    // * \brief Computes the shear factor
-    // *
-    // * Input is polymer concentration and either the water velocity or the shrate if hasShrate_ is true.
-    // * The pvtnumRegionIdx is needed to make sure the right table is used.
-    // */
-    //template <class Evaluation>
-    //static Evaluation computeShearFactor(const Evaluation& polymerConcentration,
-    //                                     unsigned pvtnumRegionIdx,
-    //                                     const Evaluation& v0)
-    //{
-    //    typedef Opm::MathToolbox<Evaluation> ToolboxLocal;
-
-    //    const auto& viscosityMultiplierTable = plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
-    //    Scalar viscosityMultiplier = viscosityMultiplierTable.eval(Opm::scalarValue(polymerConcentration), /*extrapolate=*/true);
-
-    //    const Scalar eps = 1e-14;
-    //    // return 1.0 if the polymer has no effect on the water.
-    //    if (std::abs((viscosityMultiplier - 1.0)) < eps){
-    //        return ToolboxLocal::createBlank(v0) + 1.;
-    //    }
-
-    //    const std::vector<Scalar>& shearEffectRefLogVelocity = plyshlogShearEffectRefLogVelocity_[pvtnumRegionIdx];
-    //    auto v0AbsLog = Opm::log(Opm::abs(v0));
-    //    // return 1.0 if the velocity /sharte is smaller than the first velocity entry.
-    //    if (v0AbsLog < shearEffectRefLogVelocity[0])
-    //        return ToolboxLocal::createBlank(v0) + 1.0;
-
-    //    // compute shear factor from input
-    //    // Z = (1 + (P - 1) * M(v)) / P
-    //    // where M(v) is computed from user input
-    //    // and P = viscosityMultiplier
-    //    const std::vector<Scalar>& shearEffectRefMultiplier = plyshlogShearEffectRefMultiplier_[pvtnumRegionIdx];
-    //    size_t numTableEntries = shearEffectRefLogVelocity.size();
-    //    assert(shearEffectRefMultiplier.size() == numTableEntries);
-
-    //    std::vector<Scalar> shearEffectMultiplier(numTableEntries, 1.0);
-    //    for (size_t i = 0; i < numTableEntries; ++i) {
-    //        shearEffectMultiplier[i] = (1.0 + (viscosityMultiplier - 1.0)*shearEffectRefMultiplier[i]) / viscosityMultiplier;
-    //        shearEffectMultiplier[i] = Opm::log(shearEffectMultiplier[i]);
-    //    }
-    //    // store the logarithmic velocity and logarithmic multipliers in a table for easy look up and
-    //    // linear interpolation in the logarithmic space.
-    //    TabulatedFunction logShearEffectMultiplier = TabulatedFunction(numTableEntries, shearEffectRefLogVelocity, shearEffectMultiplier, /*bool sortInputs =*/ false);
-
-    //    // Find sheared velocity (v) that satisfies
-    //    // F = log(v) + log (Z) - log(v0) = 0;
-
-    //    // Set up the function
-    //    // u = log(v)
-    //    auto F = [&logShearEffectMultiplier, &v0AbsLog](const Evaluation& u) {
-    //        return u + logShearEffectMultiplier.eval(u, true) - v0AbsLog;
-    //    };
-    //    // and its derivative
-    //    auto dF = [&logShearEffectMultiplier](const Evaluation& u) {
-    //        return 1 + logShearEffectMultiplier.evalDerivative(u, true);
-    //    };
-
-    //    // Solve F = 0 using Newton
-    //    // Use log(v0) as initial value for u
-    //    auto u = v0AbsLog;
-    //    bool converged = false;
-    //    for (int i = 0; i < 20; ++i) {
-    //        auto f = F(u);
-    //        auto df = dF(u);
-    //        u -= f/df;
-    //        if (std::abs(Opm::scalarValue(f)) < 1e-12) {
-    //            converged = true;
-    //            break;
-    //        }
-    //    }
-    //    if (!converged) {
-    //        throw std::runtime_error("Not able to compute shear velocity. \n");
-    //    }
-
-    //    // return the shear factor
-    //    return Opm::exp(logShearEffectMultiplier.eval(u, /*extrapolate=*/true));
-
-    //}
-
-    //const Scalar molarMass() const
-    //{
-    //    return 0.25; // kg/mol
-    //}
-
-
-
-
 private:
-    //static std::vector<Scalar> plyrockDeadPoreVolume_;
-    //static std::vector<Scalar> plyrockResidualResistanceFactor_;
-    //static std::vector<Scalar> plyrockRockDensityFactor_;
-    //static std::vector<Scalar> plyrockAdsorbtionIndex_;
-    //static std::vector<Scalar> plyrockMaxAdsorbtion_;
-    //static std::vector<TabulatedFunction> plyadsAdsorbedPolymer_;
-    //static std::vector<TabulatedFunction> plyviscViscosityMultiplierTable_;
-    //static std::vector<Scalar> plymaxMaxConcentration_;
-    //static std::vector<Scalar> plymixparToddLongstaff_;
-    //static std::vector<std::vector<Scalar>> plyshlogShearEffectRefMultiplier_;
-    //static std::vector<std::vector<Scalar>> plyshlogShearEffectRefLogVelocity_;
-    //static std::vector<Scalar> shrate_;
-    //static bool hasShrate_;
-    //static bool hasPlyshlog_;
-
+    static std::vector<Scalar> foamRockDensity_;
+    static std::vector<bool> foamAllowDesorption_;
     static std::vector<FoamCoefficients> foamCoefficients_;
-    //static std::vector<PlyvmhCoefficients> plyvmhCoefficients_;
-    //static std::map<int, TabulatedTwoDFunction> plymwinjTables_;
-    //static std::map<int, TabulatedTwoDFunction> skprwatTables_;
-
-    //static std::map<int, SkprpolyTable> skprpolyTables_;
+    static std::vector<TabulatedFunction> adsorbedFoamTable_;
+    static std::vector<TabulatedFunction> gasMobilityMultiplierTable_;
 };
 
 
 
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockDeadPoreVolume_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockResidualResistanceFactor_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockRockDensityFactor_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockAdsorbtionIndex_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockMaxAdsorbtion_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyadsAdsorbedPolymer_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyviscViscosityMultiplierTable_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymaxMaxConcentration_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymixparToddLongstaff_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefMultiplier_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefLogVelocity_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::shrate_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//bool
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::hasShrate_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//bool
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::hasPlyshlog_;
-//
+template <class TypeTag, bool enableFoam>
+std::vector<typename BlackOilFoamModule<TypeTag, enableFoam>::Scalar>
+BlackOilFoamModule<TypeTag, enableFoam>::foamRockDensity_;
+
+template <class TypeTag, bool enableFoam>
+std::vector<bool>
+BlackOilFoamModule<TypeTag, enableFoam>::foamAllowDesorption_;
 
 template <class TypeTag, bool enableFoam>
 std::vector<typename BlackOilFoamModule<TypeTag, enableFoam>::FoamCoefficients>
 BlackOilFoamModule<TypeTag, enableFoam>::foamCoefficients_;
 
-//template <class TypeTag, bool enablePolymerV>
-//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::PlyvmhCoefficients>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyvmhCoefficients_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedTwoDFunction>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymwinjTables_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedTwoDFunction>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::skprwatTables_;
-//
-//template <class TypeTag, bool enablePolymerV>
-//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::SkprpolyTable>
-//BlackOilPolymerModule<TypeTag, enablePolymerV>::skprpolyTables_;
+template <class TypeTag, bool enableFoam>
+std::vector<typename BlackOilFoamModule<TypeTag, enableFoam>::TabulatedFunction>
+BlackOilFoamModule<TypeTag, enableFoam>::adsorbedFoamTable_;
+
+template <class TypeTag, bool enableFoam>
+std::vector<typename BlackOilFoamModule<TypeTag, enableFoam>::TabulatedFunction>
+BlackOilFoamModule<TypeTag, enableFoam>::gasMobilityMultiplierTable_;
+
 
 /*!
  * \ingroup BlackOil
- * \class Ewoms::BlackOilPolymerIntensiveQuantities
+ * \class Ewoms::BlackOilFoamIntensiveQuantities
  *
  * \brief Provides the volumetric quantities required for the equations needed by the
  *        polymers extension of the black-oil model.
@@ -736,8 +481,9 @@ class BlackOilFoamIntensiveQuantities
 
     enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
     static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
+    static constexpr unsigned waterPhaseIdx = FluidSystem::waterPhaseIdx;
+    static constexpr unsigned oilPhaseIdx = FluidSystem::oilPhaseIdx;
     static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
-
 
 public:
 
@@ -747,143 +493,79 @@ public:
      *
      */
     void foamPropertiesUpdate_(const ElementContext& elemCtx,
-                                  unsigned dofIdx,
-                                  unsigned timeIdx)
+                               unsigned dofIdx,
+                               unsigned timeIdx)
     {
         const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
         foamConcentration_ = priVars.makeEvaluation(foamConcentrationIdx, timeIdx);
-        //const Scalar cmax = PolymerModule::plymaxMaxConcentration(elemCtx, dofIdx, timeIdx);
-
-        //// permeability reduction due to polymer
-        //const Scalar& maxAdsorbtion = PolymerModule::plyrockMaxAdsorbtion(elemCtx, dofIdx, timeIdx);
-        //const auto& plyadsAdsorbedPolymer = PolymerModule::plyadsAdsorbedPolymer(elemCtx, dofIdx, timeIdx);
-        //polymerAdsorption_ = plyadsAdsorbedPolymer.eval(polymerConcentration_, /*extrapolate=*/true);
-        //if (PolymerModule::plyrockAdsorbtionIndex(elemCtx, dofIdx, timeIdx) == PolymerModule::NoDesorption) {
-        //    const Scalar& maxPolymerAdsorption = elemCtx.problem().maxPolymerAdsorption(elemCtx, dofIdx, timeIdx);
-        //    polymerAdsorption_ = std::max(Evaluation(maxPolymerAdsorption) , polymerAdsorption_);
-        //}
-
-        //// compute resitanceFactor
-        //const Scalar& residualResistanceFactor = PolymerModule::plyrockResidualResistanceFactor(elemCtx, dofIdx, timeIdx);
-        //const Evaluation resistanceFactor = 1.0 + (residualResistanceFactor - 1.0) * polymerAdsorption_ / maxAdsorbtion;
-
-        //// compute effective viscosities
-        //if (!enablePolymerMolarWeight) {
-        //    const auto& fs = asImp_().fluidState_;
-        //    const Evaluation& muWater = fs.viscosity(waterPhaseIdx);
-        //    const auto& viscosityMultiplier = PolymerModule::plyviscViscosityMultiplierTable(elemCtx, dofIdx, timeIdx);
-        //    const Evaluation viscosityMixture = viscosityMultiplier.eval(polymerConcentration_, /*extrapolate=*/true) * muWater;
-
-        //    // Do the Todd-Longstaff mixing
-        //    const Scalar plymixparToddLongstaff = PolymerModule::plymixparToddLongstaff(elemCtx, dofIdx, timeIdx);
-        //    const Evaluation viscosityPolymer = viscosityMultiplier.eval(cmax, /*extrapolate=*/true) * muWater;
-        //    const Evaluation viscosityPolymerEffective = pow(viscosityMixture, plymixparToddLongstaff) * pow(viscosityPolymer, 1.0 - plymixparToddLongstaff);
-        //    const Evaluation viscosityWaterEffective = pow(viscosityMixture, plymixparToddLongstaff) * pow(muWater, 1.0 - plymixparToddLongstaff);
-
-        //    const Evaluation cbar = polymerConcentration_ / cmax;
-        //    // waterViscosity / effectiveWaterViscosity
-        //    waterViscosityCorrection_ = muWater * ((1.0 - cbar) / viscosityWaterEffective + cbar / viscosityPolymerEffective);
-        //    // effectiveWaterViscosity / effectivePolymerViscosity
-        //    polymerViscosityCorrection_ =  (muWater / waterViscosityCorrection_) / viscosityPolymerEffective;
-        //}
-        //else { // based on PLYVMH
-        //    const auto& plyvmhCoefficients = PolymerModule::plyvmhCoefficients(elemCtx, dofIdx, timeIdx);
-        //    const Scalar k_mh = plyvmhCoefficients.k_mh;
-        //    const Scalar a_mh = plyvmhCoefficients.a_mh;
-        //    const Scalar gamma = plyvmhCoefficients.gamma;
-        //    const Scalar kappa = plyvmhCoefficients.kappa;
-
-        //    // viscosity model based on Mark-Houwink equation and Huggins equation
-        //    // 1000 is a emperical constant, most likely related to unit conversion
-        //    const Evaluation intrinsicViscosity = k_mh * pow(polymerMoleWeight_ * 1000., a_mh);
-        //    const Evaluation x = polymerConcentration_ * intrinsicViscosity;
-        //    waterViscosityCorrection_ = 1.0 / (1.0 + gamma * (x + kappa * x * x));
-        //    polymerViscosityCorrection_ = 1.0;
-        //}
-
-        const auto& foamCoefficients = FoamModule::foamCoefficients(elemCtx, dofIdx, timeIdx);
-
-        const Scalar fm_mob = foamCoefficients.fm_mob;
-
-        const Scalar fm_surf = foamCoefficients.fm_surf;
-        const Scalar ep_surf = foamCoefficients.ep_surf;
-
-        const Scalar fm_oil = foamCoefficients.fm_oil;
-        const Scalar fl_oil = foamCoefficients.fl_oil;
-        const Scalar ep_oil = foamCoefficients.ep_oil;
-
-        const Scalar fm_dry = foamCoefficients.fm_dry;
-        const Scalar ep_dry = foamCoefficients.ep_dry;
-
-        const Scalar fm_cap = foamCoefficients.fm_cap;
-        const Scalar ep_cap = foamCoefficients.ep_cap;
-
         const auto& fs = asImp_().fluidState_;
-        const Evaluation C_surf = foamConcentration_;
-        const Evaluation Ca = 1e10; // TODO: replace with proper capillary number.
-        const Evaluation S_o = fs.saturation(oilPhaseIdx);
-        const Evaluation S_w = fs.saturation(waterPhaseIdx);
 
-        Evaluation F1 = pow(C_surf/fm_surf, ep_surf);
-        Evaluation F2 = pow((fm_oil-S_o)/(fm_oil-fl_oil), ep_oil);
-        Evaluation F3 = pow(fm_cap/Ca, ep_cap);
-        Evaluation F7 = 0.5 + atan(ep_dry*(S_w-fm_dry))/M_PI;
+        // Compute gas mobility reduction factor
+        Evaluation mobilityReductionFactor = 1.0;
+        if (false) { // TODO: allow this model
+            // The functional model is used.
+            const auto& foamCoefficients = FoamModule::foamCoefficients(elemCtx, dofIdx, timeIdx);
 
-        Evaluation mobilityReductionFactor = 1./(1. + fm_mob*F1*F2*F3*F7);
+            const Scalar fm_mob = foamCoefficients.fm_mob;
+
+            const Scalar fm_surf = foamCoefficients.fm_surf;
+            const Scalar ep_surf = foamCoefficients.ep_surf;
+
+            const Scalar fm_oil = foamCoefficients.fm_oil;
+            const Scalar fl_oil = foamCoefficients.fl_oil;
+            const Scalar ep_oil = foamCoefficients.ep_oil;
+
+            const Scalar fm_dry = foamCoefficients.fm_dry;
+            const Scalar ep_dry = foamCoefficients.ep_dry;
+
+            const Scalar fm_cap = foamCoefficients.fm_cap;
+            const Scalar ep_cap = foamCoefficients.ep_cap;
+
+            const Evaluation C_surf = foamConcentration_;
+            const Evaluation Ca = 1e10; // TODO: replace with proper capillary number.
+            const Evaluation S_o = fs.saturation(oilPhaseIdx);
+            const Evaluation S_w = fs.saturation(waterPhaseIdx);
+
+            Evaluation F1 = pow(C_surf/fm_surf, ep_surf);
+            Evaluation F2 = pow((fm_oil-S_o)/(fm_oil-fl_oil), ep_oil);
+            Evaluation F3 = pow(fm_cap/Ca, ep_cap);
+            Evaluation F7 = 0.5 + atan(ep_dry*(S_w-fm_dry))/M_PI;
+
+            mobilityReductionFactor = 1./(1. + fm_mob*F1*F2*F3*F7);
+        } else {
+            // The tabular model is used.
+            const auto& gasMobilityMultiplier = FoamModule::gasMobilityMultiplierTable(elemCtx, dofIdx, timeIdx);
+            mobilityReductionFactor = gasMobilityMultiplier.eval(foamConcentration_, /* extrapolate = */ true);
+        }
 
         // adjust gas mobility
         asImp_().mobility_[gasPhaseIdx] *= mobilityReductionFactor;
 
-        //// update rock properties
-        //polymerDeadPoreVolume_ = PolymerModule::plyrockDeadPoreVolume(elemCtx, dofIdx, timeIdx);
-        //polymerRockDensity_ = PolymerModule::plyrockRockDensityFactor(elemCtx, dofIdx, timeIdx);
+        foamRockDensity_ = FoamModule::foamRockDensity(elemCtx, dofIdx, timeIdx);
+
+        const auto& adsorbedFoamTable = FoamModule::adsorbedFoamTable(elemCtx, dofIdx, timeIdx);
+        foamAdsorbed_ = adsorbedFoamTable.eval(foamConcentration_, /*extrapolate=*/true);
+        if (!FoamModule::foamAllowDesorption(elemCtx, dofIdx, timeIdx)) {
+            throw std::runtime_error("Foam module does not support the 'no desorption' option.");
+        }
     }
 
-    //const Evaluation& polymerConcentration() const
-    //{ return polymerConcentration_; }
     const Evaluation& foamConcentration() const
     { return foamConcentration_; }
 
-    //const Evaluation& polymerMoleWeight() const
-    //{
-    //    if (!enablePolymerMolarWeight)
-    //        throw std::logic_error("polymerMoleWeight() is called but polymer milecular weight is disabled");
+    Scalar foamRockDensity() const
+    { return foamRockDensity_; }
 
-    //    return polymerMoleWeight_;
-    //}
-
-    //const Scalar& polymerDeadPoreVolume() const
-    //{ return polymerDeadPoreVolume_; }
-
-    //const Evaluation& polymerAdsorption() const
-    //{ return polymerAdsorption_; }
-
-    //const Scalar& polymerRockDensity() const
-    //{ return polymerRockDensity_; }
-
-    //// effectiveWaterViscosity / effectivePolymerViscosity
-    //const Evaluation& polymerViscosityCorrection() const
-    //{ return polymerViscosityCorrection_; }
-
-    //// waterViscosity / effectiveWaterViscosity
-    //const Evaluation& waterViscosityCorrection() const
-    //{ return waterViscosityCorrection_; }
-
+    const Evaluation& foamAdsorbed() const
+    { return foamAdsorbed_; }
 
 protected:
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }
 
     Evaluation foamConcentration_;
-    //// polymer molecular weight
-    //Evaluation polymerMoleWeight_;
-    //Scalar polymerDeadPoreVolume_;
-    //Scalar polymerRockDensity_;
-    //Evaluation polymerAdsorption_;
-    //Evaluation polymerViscosityCorrection_;
-    //Evaluation waterViscosityCorrection_;
-
-
+    Scalar foamRockDensity_;
+    Evaluation foamAdsorbed_;
 };
 
 template <class TypeTag>
@@ -899,184 +581,15 @@ public:
                                   unsigned timeIdx OPM_UNUSED)
     { }
 
-    //const Evaluation& polymerMoleWeight() const
-    //{ throw std::logic_error("polymerMoleWeight() called but polymer molecular weight is disabled"); }
-
-    //const Evaluation& polymerConcentration() const
-    //{ throw std::runtime_error("polymerConcentration() called but polymers are disabled"); }
 
     const Evaluation& foamConcentration() const
     { throw std::runtime_error("foamConcentration() called but foam is disabled"); }
 
-    //const Evaluation& polymerDeadPoreVolume() const
-    //{ throw std::runtime_error("polymerDeadPoreVolume() called but polymers are disabled"); }
+    Scalar foamRockDensity() const
+    { throw std::runtime_error("foamRockDensity() called but foam is disabled"); }
 
-    //const Evaluation& polymerAdsorption() const
-    //{ throw std::runtime_error("polymerAdsorption() called but polymers are disabled"); }
-
-    //const Evaluation& polymerRockDensity() const
-    //{ throw std::runtime_error("polymerRockDensity() called but polymers are disabled"); }
-
-    //const Evaluation& polymerViscosityCorrection() const
-    //{ throw std::runtime_error("polymerViscosityCorrection() called but polymers are disabled"); }
-
-    //const Evaluation& waterViscosityCorrection() const
-    //{ throw std::runtime_error("waterViscosityCorrection() called but polymers are disabled"); }
-};
-
-
-/*!
- * \ingroup BlackOil
- * \class Ewoms::BlackOilFoamExtensiveQuantities
- *
- * \brief Provides the foam specific extensive quantities to the generic black-oil
- *        module's extensive quantities.
- */
-template <class TypeTag, bool enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam)>
-class BlackOilFoamExtensiveQuantities
-{
-    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
-
-    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
-    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
-    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
-    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
-    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
-    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
-
-    static constexpr unsigned gasPhaseIdx = FluidSystem::gasPhaseIdx;
-    static constexpr int dimWorld = GridView::dimensionworld;
-    static constexpr unsigned waterPhaseIdx =  FluidSystem::waterPhaseIdx;
-
-    typedef Opm::MathToolbox<Evaluation> Toolbox;
-    typedef BlackOilFoamModule<TypeTag> FoamModule;
-    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
-    typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
-
-public:
-    ///*!
-    // * \brief Method which calculates the shear factor based on flow velocity
-    // *
-    // * This is the variant of the method which assumes that the problem is specified
-    // * using permeabilities, i.e., *not* via transmissibilities.
-    // */
-    //template <class Dummy = bool> // we need to make this method a template to avoid
-    //                              // compiler errors if it is not instantiated!
-    //void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
-    //                                unsigned scvfIdx OPM_UNUSED,
-    //                                unsigned timeIdx OPM_UNUSED)
-    //{
-    //    throw std::runtime_error("The extension of the blackoil model for foam is not yet "
-    //                             "implemented for problems specified using permeabilities.");
-    //}
-
-    ///*!
-    // * \brief Method which calculates the shear factor based on flow velocity
-    // *
-    // * This is the variant of the method which assumes that the problem is specified
-    // * using transmissibilities, i.e., *not* via permeabilities.
-    // */
-    //template <class Dummy = bool> // we need to make this method a template to avoid
-    //// compiler errors if it is not instantiated!
-    //void updateShearMultipliers(const ElementContext& elemCtx,
-    //                            unsigned scvfIdx,
-    //                            unsigned timeIdx)
-    //{
-
-    //    waterShearFactor_ = 1.0;
-    //    polymerShearFactor_ = 1.0;
-
-    //    if (!PolymerModule::hasPlyshlog())
-    //        return;
-
-    //    const ExtensiveQuantities& extQuants = asImp_();
-    //    unsigned upIdx = extQuants.upstreamIndex(waterPhaseIdx);
-    //    unsigned interiorDofIdx = extQuants.interiorIndex();
-    //    unsigned exteriorDofIdx = extQuants.exteriorIndex();
-    //    const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
-    //    const auto& intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx, timeIdx);
-    //    const auto& intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx, timeIdx);
-
-    //    // compute water velocity from flux
-    //    Evaluation poroAvg = intQuantsIn.porosity()*0.5 + intQuantsEx.porosity()*0.5;
-    //    unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvfIdx, timeIdx);
-    //    const Evaluation& Sw = up.fluidState().saturation(waterPhaseIdx);
-    //    unsigned cellIdx = elemCtx.globalSpaceIndex(scvfIdx, timeIdx);
-    //    const auto& materialLawManager = elemCtx.problem().materialLawManager();
-    //    const auto& scaledDrainageInfo =
-    //            materialLawManager->oilWaterScaledEpsInfoDrainage(cellIdx);
-    //    const Scalar& Swcr = scaledDrainageInfo.Swcr;
-
-    //    // guard against zero porosity and no mobile water
-    //    Evaluation denom = Opm::max(poroAvg * (Sw - Swcr), 1e-12);
-    //    Evaluation waterVolumeVelocity = extQuants.volumeFlux(waterPhaseIdx) / denom;
-
-    //    // if shrate is specified. Compute shrate based on the water velocity
-    //    if (PolymerModule::hasShrate()) {
-    //        const Evaluation& relWater = up.relativePermeability(waterPhaseIdx);
-    //        Scalar trans = elemCtx.problem().transmissibility(elemCtx, interiorDofIdx, exteriorDofIdx);
-    //        if (trans > 0.0) {
-    //            Scalar faceArea = elemCtx.stencil(timeIdx).interiorFace(scvfIdx).area();
-    //            auto dist = elemCtx.pos(interiorDofIdx, timeIdx) -  elemCtx.pos(exteriorDofIdx, timeIdx);
-    //            // compute permeability from transmissibility.
-    //            Scalar absPerm = trans / faceArea * dist.two_norm();
-    //            waterVolumeVelocity *=
-    //                PolymerModule::shrate(pvtnumRegionIdx)*Opm::sqrt(poroAvg*Sw / (relWater*absPerm));
-    //            assert(Opm::isfinite(waterVolumeVelocity));
-    //        }
-    //    }
-
-    //    // compute share factors for water and polymer
-    //    waterShearFactor_ =
-    //        PolymerModule::computeShearFactor(up.polymerConcentration(),
-    //                                          pvtnumRegionIdx,
-    //                                          waterVolumeVelocity);
-    //    polymerShearFactor_ =
-    //        PolymerModule::computeShearFactor(up.polymerConcentration(),
-    //                                          pvtnumRegionIdx,
-    //                                          waterVolumeVelocity*up.polymerViscosityCorrection());
-
-    //}
-
-    //const Evaluation& polymerShearFactor() const
-    //{ return polymerShearFactor_; }
-
-    //const Evaluation& waterShearFactor() const
-    //{ return waterShearFactor_; }
-
-
-private:
-    Implementation& asImp_()
-    { return *static_cast<Implementation*>(this); }
-
-    //Evaluation polymerShearFactor_;
-    //Evaluation waterShearFactor_;
-
-};
-
-template <class TypeTag>
-class BlackOilFoamExtensiveQuantities<TypeTag, false>
-{
-    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
-    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
-
-public:
-    //void updateShearMultipliers(const ElementContext& elemCtx OPM_UNUSED,
-    //                            unsigned scvfIdx OPM_UNUSED,
-    //                            unsigned timeIdx OPM_UNUSED)
-    //{ }
-
-    //void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
-    //                                unsigned scvfIdx OPM_UNUSED,
-    //                                unsigned timeIdx OPM_UNUSED)
-    //{ }
-
-    //const Evaluation& polymerShearFactor() const
-    //{ throw std::runtime_error("polymerShearFactor() called but polymers are disabled"); }
-
-    //const Evaluation& waterShearFactor() const
-    //{ throw std::runtime_error("waterShearFactor() called but polymers are disabled"); }
+    Scalar foamAdsorbed() const
+    { throw std::runtime_error("foamAdsorbed() called but foam is disabled"); }
 };
 
 

--- a/ewoms/models/blackoil/blackoilfoammodules.hh
+++ b/ewoms/models/blackoil/blackoilfoammodules.hh
@@ -1,0 +1,1085 @@
+// -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
+// vi: set et ts=4 sw=4 sts=4:
+/*
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 2 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+
+  Consult the COPYING file in the top-level source directory of this
+  module for the precise wording of the license and the list of
+  copyright holders.
+*/
+/*!
+ * \file
+ *
+ * \brief Contains the classes required to extend the black-oil model to include the effects of foam.
+ */
+#ifndef EWOMS_BLACK_OIL_FOAM_MODULE_HH
+#define EWOMS_BLACK_OIL_FOAM_MODULE_HH
+
+#include "blackoilproperties.hh"
+//#include <ewoms/io/vtkblackoilfoammodule.hh>
+#include <ewoms/models/common/quantitycallbacks.hh>
+
+//#include <opm/material/common/Tabulated1DFunction.hpp>
+//#include <opm/material/common/IntervalTabulated2DFunction.hpp>
+
+#include <opm/material/common/Valgrind.hpp>
+#include <opm/material/common/Unused.hpp>
+#include <opm/material/common/Exceptions.hpp>
+
+#include <dune/common/fvector.hh>
+
+#include <string>
+#include <math.h>
+
+namespace Ewoms {
+/*!
+ * \ingroup BlackOil
+ * \brief Contains the high level supplements required to extend the black oil
+ *        model to include the effects of foam.
+ */
+template <class TypeTag, bool enableFoamV = GET_PROP_VALUE(TypeTag, EnableFoam)>
+class BlackOilFoamModule
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, Model) Model;
+    typedef typename GET_PROP_TYPE(TypeTag, Simulator) Simulator;
+    typedef typename GET_PROP_TYPE(TypeTag, EqVector) EqVector;
+    typedef typename GET_PROP_TYPE(TypeTag, RateVector) RateVector;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+
+    typedef Opm::MathToolbox<Evaluation> Toolbox;
+
+    //typedef typename Opm::Tabulated1DFunction<Scalar> TabulatedFunction;
+    //typedef typename Opm::IntervalTabulated2DFunction<Scalar> TabulatedTwoDFunction;
+
+    static constexpr unsigned foamConcentrationIdx = Indices::foamConcentrationIdx;
+    static constexpr unsigned contiFoamEqIdx = Indices::contiFoamEqIdx;
+    static constexpr unsigned gasPhaseIdx = FluidSystem::gasPhaseIdx;
+
+
+    static constexpr unsigned enableFoam = enableFoamV;
+
+    static constexpr unsigned numEq = GET_PROP_VALUE(TypeTag, NumEq);
+    static constexpr unsigned numPhases = FluidSystem::numPhases;
+
+public:
+    //enum AdsorptionBehaviour { Desorption = 1, NoDesorption = 2 };
+
+    // a struct containing constants to calculate change to relative permeability,
+    // based on model (1-9) in Table 1 of
+    // Kun  Ma,  Guangwei  Ren,  Khalid  Mateen,  Danielle  Morel,  and  PhilippeCordelier.
+    // Modeling techniques for foam flow in porous media.SPE Journal,20(03):453–470, jun 2015.
+    // The constants are provided by the keyword ...
+    struct FoamCoefficients {
+        Scalar fm_mob = 2;
+
+        Scalar fm_surf = 1;
+        Scalar ep_surf = 1;
+
+        Scalar fm_oil = 1;
+        Scalar fl_oil = 0;
+        Scalar ep_oil = 1;
+
+        Scalar fm_dry = 1;
+        Scalar ep_dry = 0;
+
+        Scalar fm_cap = 1;
+        Scalar ep_cap = 1;
+    };
+
+#if HAVE_ECL_INPUT
+    /*!
+     * \brief Initialize all internal data structures needed by the polymer module
+     */
+    static void initFromDeck(const Opm::Deck& deck, const Opm::EclipseState& eclState)
+    {
+        // some sanity checks: if foam is enabled, the FOAM keyword must be
+        // present, if foam is disabled the keyword must not be present.
+        if (enableFoam && !deck.hasKeyword("FOAM")) {
+            throw std::runtime_error("Non-trivial foam treatment requested at compile time, but "
+                                     "the deck does not contain the FOAM keyword");
+        }
+        else if (!enableFoam && deck.hasKeyword("FOAM")) {
+            throw std::runtime_error("Foam treatment disabled at compile time, but the deck "
+                                     "contains the FOAM keyword");
+        }
+
+        if (!deck.hasKeyword("FOAM"))
+            return; // foam treatment is supposed to be disabled
+
+        //unsigned numSatRegions = tableManager.getTabdims().getNumSatTables();
+        // TODO: do not hard code
+        setNumSatRegions(1);
+
+    }
+#endif
+
+    // a struct containing the constants to calculate foam viscosity
+    // based on Mark-Houwink equation and Huggins equation, the constants are provided
+    // by the keyword PLYVMH
+    //struct PlyvmhCoefficients {
+    //    Scalar k_mh;
+    //    Scalar a_mh;
+    //    Scalar gamma;
+    //    Scalar kappa;
+    //};
+
+    /*!
+     * \brief Specify the number of satuation regions.
+     *
+     * This must be called before setting the PLYROCK and PLYADS of any region.
+     */
+    static void setNumSatRegions(unsigned numRegions)
+    {
+        foamCoefficients_.resize(numRegions);
+    //    plyrockDeadPoreVolume_.resize(numRegions);
+    //    plyrockResidualResistanceFactor_.resize(numRegions);
+    //    plyrockRockDensityFactor_.resize(numRegions);
+    //    plyrockAdsorbtionIndex_.resize(numRegions);
+    //    plyrockMaxAdsorbtion_.resize(numRegions);
+    //    plyadsAdsorbedFoam_.resize(numRegions);
+    }
+
+    /*!
+     * \brief Specify the foam properties a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    //static void setPlyrock(unsigned satRegionIdx,
+    //                       const Scalar& plyrockDeadPoreVolume,
+    //                       const Scalar& plyrockResidualResistanceFactor,
+    //                       const Scalar& plyrockRockDensityFactor,
+    //                       const Scalar& plyrockAdsorbtionIndex,
+    //                       const Scalar& plyrockMaxAdsorbtion)
+    //{
+    //    plyrockDeadPoreVolume_[satRegionIdx] = plyrockDeadPoreVolume;
+    //    plyrockResidualResistanceFactor_[satRegionIdx] = plyrockResidualResistanceFactor;
+    //    plyrockRockDensityFactor_[satRegionIdx] = plyrockRockDensityFactor;
+    //    plyrockAdsorbtionIndex_[satRegionIdx] = plyrockAdsorbtionIndex;
+    //    plyrockMaxAdsorbtion_[satRegionIdx] = plyrockMaxAdsorbtion;
+    //}
+
+    /*!
+     * \brief Specify the number of pvt regions.
+     *
+     * This must be called before setting the PLYVISC of any region.
+     */
+    //static void setNumPvtRegions(unsigned numRegions)
+    //{
+    //    plyviscViscosityMultiplierTable_.resize(numRegions);
+    //}
+
+    /*!
+     * \brief Specify the foam viscosity a single region.
+     *
+     * The index of specified here must be in range [0, numSatRegions)
+     */
+    //static void setPlyvisc(unsigned satRegionIdx,
+    //                       const TabulatedFunction& plyviscViscosityMultiplierTable)
+    //{
+    //    plyviscViscosityMultiplierTable_[satRegionIdx] = plyviscViscosityMultiplierTable;
+    //}
+
+    /*!
+     * \brief Specify the number of mix regions.
+     *
+     * This must be called before setting the PLYMAC and PLMIXPAR of any region.
+     */
+    //static void setNumMixRegions(unsigned numRegions)
+    //{
+    //    plymaxMaxConcentration_.resize(numRegions);
+    //    plymixparToddLongstaff_.resize(numRegions);
+
+    //}
+
+    /*!
+     * \brief Specify the maximum foam concentration a single region.
+     *
+     * The index of specified here must be in range [0, numMixRegionIdx)
+     */
+    //static void setPlymax(unsigned mixRegionIdx,
+    //                      const Scalar& plymaxMaxConcentration)
+    //{
+    //    plymaxMaxConcentration_[mixRegionIdx] = plymaxMaxConcentration;
+    //}
+
+    /*!
+     * \brief Specify the maximum foam concentration a single region.
+     *
+     * The index of specified here must be in range [0, numMixRegionIdx)
+     */
+    //static void setPlmixpar(unsigned mixRegionIdx,
+    //                        const Scalar& plymixparToddLongstaff)
+    //{
+    //    plymixparToddLongstaff_[mixRegionIdx] = plymixparToddLongstaff;
+    //}
+
+    /*!
+     * \brief Register all run-time parameters for the black-oil foam module.
+     */
+    static void registerParameters()
+    {
+        if (!enableFoam)
+            // foam has been disabled at compile time
+            return;
+
+        //Ewoms::VtkBlackOilFoamModule<TypeTag>::registerParameters();
+    }
+
+    /*!
+     * \brief Register all foam specific VTK and ECL output modules.
+     */
+    static void registerOutputModules(Model& model,
+                                      Simulator& simulator)
+    {
+        if (!enableFoam)
+            // foam have been disabled at compile time
+            return;
+
+        //model.addOutputModule(new Ewoms::VtkBlackOilFoamModule<TypeTag>(simulator));
+    }
+
+    //static bool primaryVarApplies(unsigned pvIdx)
+    //{
+    //    // foam has been disabled at compile time
+    //    return enableFoam;
+    //}
+
+    //static std::string primaryVarName(unsigned pvIdx)
+    //{
+    //    assert(primaryVarApplies(pvIdx));
+
+    //    if (pvIdx == polymerConcentrationIdx) {
+    //        return "polymer_waterconcentration";
+    //    }
+    //    else {
+    //        return "polymer_molecularweight";
+    //    }
+    //}
+
+    //static Scalar primaryVarWeight(unsigned pvIdx OPM_OPTIM_UNUSED)
+    //{
+    //    assert(primaryVarApplies(pvIdx));
+
+    //    // TODO: it may be beneficial to chose this differently.
+    //    return static_cast<Scalar>(1.0);
+    //}
+
+    static bool eqApplies(unsigned eqIdx)
+    {
+        if (!enableFoam)
+            return false;
+
+        return eqIdx == contiFoamEqIdx;
+
+    }
+
+    static std::string eqName(unsigned eqIdx)
+    {
+        assert(eqApplies(eqIdx));
+
+        return "conti^foam";
+    }
+
+    //static Scalar eqWeight(unsigned eqIdx OPM_OPTIM_UNUSED)
+    //{
+    //    assert(eqApplies(eqIdx));
+
+    //    // TODO: it may be beneficial to chose this differently.
+    //    return static_cast<Scalar>(1.0);
+    //}
+
+    // must be called after water storage is computed
+    template <class LhsEval>
+    static void addStorage(Dune::FieldVector<LhsEval, numEq>& storage,
+                           const IntensiveQuantities& intQuants)
+    {
+        if (!enableFoam)
+            return;
+
+        const auto& fs = intQuants.fluidState();
+
+        LhsEval surfaceVolumeFreeGas =
+            Toolbox::template decay<LhsEval>(fs.saturation(gasPhaseIdx))
+            * Toolbox::template decay<LhsEval>(fs.invB(gasPhaseIdx))
+            * Toolbox::template decay<LhsEval>(intQuants.porosity());
+
+        // Avoid singular matrix if no gas is present.
+        surfaceVolumeFreeGas = Opm::max(surfaceVolumeFreeGas, 1e-10);
+
+        // Foam/surfactant in gas phase.
+        const LhsEval gasFoam = surfaceVolumeFreeGas
+            * Toolbox::template decay<LhsEval>(br) // TODO
+            * Toolbox::template decay<LhsEval>(intQuants.foamConcentration());
+
+        // Adsorbed foam/surfactant.
+        const LhsEval adsorbedFoam =
+            Toolbox::template decay<LhsEval>(1.0 - intQuants.porosity())
+            * Toolbox::template decay<LhsEval>(intQuants.foamRockDensity()) // TODO
+            * Toolbox::template decay<LhsEval>(intQuants.foamAdsorption())  // TODO
+            / Toolbox::template decay<LhsEval>(intQuants.porosity());
+
+        LhsEval accumulationFoam = gasFoam + adsorbedFoam;
+        storage[contiFoamEqIdx] += accumulationFoam;
+    }
+
+    static void computeFlux(RateVector& flux,
+                            const ElementContext& elemCtx,
+                            unsigned scvfIdx,
+                            unsigned timeIdx)
+
+    {
+        if (!enableFoam)
+            return;
+
+        const auto& extQuants = elemCtx.extensiveQuantities(scvfIdx, timeIdx);
+
+        const unsigned upIdx = extQuants.upstreamIndex(FluidSystem::waterPhaseIdx);
+        const unsigned inIdx = extQuants.interiorIndex();
+        const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+        const unsigned contiWaterEqIdx = Indices::conti0EqIdx + Indices::canonicalToActiveComponentIndex(FluidSystem::waterCompIdx);
+
+
+        if (upIdx == inIdx) {
+            flux[contiFoamEqIdx] = 0.;
+                    //extQuants.volumeFlux(waterPhaseIdx)
+                    //*up.fluidState().invB(waterPhaseIdx)
+                    //*up.polymerViscosityCorrection()
+                    ///extQuants.polymerShearFactor()
+                    //*up.polymerConcentration();
+
+            // modify water
+            flux[contiWaterEqIdx] /= 1.;
+                    //extQuants.waterShearFactor();
+        }
+        else {
+            flux[contiFoamEqIdx] = 0.;
+                    //extQuants.volumeFlux(waterPhaseIdx)
+                    //*Opm::decay<Scalar>(up.fluidState().invB(waterPhaseIdx))
+                    //*Opm::decay<Scalar>(up.polymerViscosityCorrection())
+                    ///Opm::decay<Scalar>(extQuants.polymerShearFactor())
+                    //*Opm::decay<Scalar>(up.polymerConcentration());
+
+            // modify water
+            flux[contiWaterEqIdx] /= 1.;
+                    //Opm::decay<Scalar>(extQuants.waterShearFactor());
+        }
+
+    }
+
+    /*!
+     * \brief Return how much a Newton-Raphson update is considered an error
+     */
+    static Scalar computeUpdateError(const PrimaryVariables& oldPv OPM_UNUSED,
+                                     const EqVector& delta OPM_UNUSED)
+    {
+        // do not consider the change of foam primary variables for convergence
+        // TODO: maybe this should be changed
+        return static_cast<Scalar>(0.0);
+    }
+
+    template <class DofEntity>
+    static void serializeEntity(const Model& model, std::ostream& outstream, const DofEntity& dof)
+    {
+        if (!enableFoam)
+            return;
+
+        //unsigned dofIdx = model.dofMapper().index(dof);
+        //const PrimaryVariables& priVars = model.solution(/*timeIdx=*/0)[dofIdx];
+        //outstream << priVars[polymerConcentrationIdx];
+        //outstream << priVars[polymerMoleWeightIdx];
+    }
+
+    template <class DofEntity>
+    static void deserializeEntity(Model& model, std::istream& instream, const DofEntity& dof)
+    {
+        if (!enableFoam)
+            return;
+
+        //unsigned dofIdx = model.dofMapper().index(dof);
+        //PrimaryVariables& priVars0 = model.solution(/*timeIdx=*/0)[dofIdx];
+        //PrimaryVariables& priVars1 = model.solution(/*timeIdx=*/1)[dofIdx];
+
+        //instream >> priVars0[polymerConcentrationIdx];
+        //instream >> priVars0[polymerMoleWeightIdx];
+
+        //// set the primary variables for the beginning of the current time step.
+        //priVars1[polymerConcentrationIdx] = priVars0[polymerConcentrationIdx];
+        //priVars1[polymerMoleWeightIdx] = priVars0[polymerMoleWeightIdx];
+    }
+
+    //static const Scalar plyrockDeadPoreVolume(const ElementContext& elemCtx,
+    //                                          unsigned scvIdx,
+    //                                          unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyrockDeadPoreVolume_[satnumRegionIdx];
+    //}
+
+    //static const Scalar plyrockResidualResistanceFactor(const ElementContext& elemCtx,
+    //                                                    unsigned scvIdx,
+    //                                                    unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyrockResidualResistanceFactor_[satnumRegionIdx];
+    //}
+
+    //static const Scalar plyrockRockDensityFactor(const ElementContext& elemCtx,
+    //                                             unsigned scvIdx,
+    //                                             unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyrockRockDensityFactor_[satnumRegionIdx];
+    //}
+
+    //static const Scalar plyrockAdsorbtionIndex(const ElementContext& elemCtx,
+    //                                           unsigned scvIdx,
+    //                                           unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyrockAdsorbtionIndex_[satnumRegionIdx];
+    //}
+
+    //static const Scalar plyrockMaxAdsorbtion(const ElementContext& elemCtx,
+    //                                         unsigned scvIdx,
+    //                                         unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyrockMaxAdsorbtion_[satnumRegionIdx];
+    //}
+
+    //static const TabulatedFunction& plyadsAdsorbedPolymer(const ElementContext& elemCtx,
+    //                                                      unsigned scvIdx,
+    //                                                      unsigned timeIdx)
+    //{
+    //    unsigned satnumRegionIdx = elemCtx.problem().satnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyadsAdsorbedPolymer_[satnumRegionIdx];
+    //}
+
+    //static const TabulatedFunction& plyviscViscosityMultiplierTable(const ElementContext& elemCtx,
+    //                                                                unsigned scvIdx,
+    //                                                                unsigned timeIdx)
+    //{
+    //    unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
+    //}
+
+    //static const TabulatedFunction& plyviscViscosityMultiplierTable(unsigned pvtnumRegionIdx)
+    //{
+    //    return plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
+    //}
+
+    //static const Scalar plymaxMaxConcentration(const ElementContext& elemCtx,
+    //                                           unsigned scvIdx,
+    //                                           unsigned timeIdx)
+    //{
+    //    unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plymaxMaxConcentration_[polymerMixRegionIdx];
+    //}
+
+    //static const Scalar plymixparToddLongstaff(const ElementContext& elemCtx,
+    //                                           unsigned scvIdx,
+    //                                           unsigned timeIdx)
+    //{
+    //    unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plymixparToddLongstaff_[polymerMixRegionIdx];
+    //}
+
+    static const FoamCoefficients& foamCoefficients(const ElementContext& elemCtx,
+                                                        const unsigned scvIdx,
+                                                        const unsigned timeIdx)
+    {
+        //const unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
+        // TODO: Don't hard code!!!
+        return foamCoefficients_[0];
+    }
+
+    //static const PlyvmhCoefficients& plyvmhCoefficients(const ElementContext& elemCtx,
+    //                                                    const unsigned scvIdx,
+    //                                                    const unsigned timeIdx)
+    //{
+    //    const unsigned polymerMixRegionIdx = elemCtx.problem().plmixnumRegionIndex(elemCtx, scvIdx, timeIdx);
+    //    return plyvmhCoefficients_[polymerMixRegionIdx];
+    //}
+
+    ///*!
+    // * \brief Computes the shear factor
+    // *
+    // * Input is polymer concentration and either the water velocity or the shrate if hasShrate_ is true.
+    // * The pvtnumRegionIdx is needed to make sure the right table is used.
+    // */
+    //template <class Evaluation>
+    //static Evaluation computeShearFactor(const Evaluation& polymerConcentration,
+    //                                     unsigned pvtnumRegionIdx,
+    //                                     const Evaluation& v0)
+    //{
+    //    typedef Opm::MathToolbox<Evaluation> ToolboxLocal;
+
+    //    const auto& viscosityMultiplierTable = plyviscViscosityMultiplierTable_[pvtnumRegionIdx];
+    //    Scalar viscosityMultiplier = viscosityMultiplierTable.eval(Opm::scalarValue(polymerConcentration), /*extrapolate=*/true);
+
+    //    const Scalar eps = 1e-14;
+    //    // return 1.0 if the polymer has no effect on the water.
+    //    if (std::abs((viscosityMultiplier - 1.0)) < eps){
+    //        return ToolboxLocal::createBlank(v0) + 1.;
+    //    }
+
+    //    const std::vector<Scalar>& shearEffectRefLogVelocity = plyshlogShearEffectRefLogVelocity_[pvtnumRegionIdx];
+    //    auto v0AbsLog = Opm::log(Opm::abs(v0));
+    //    // return 1.0 if the velocity /sharte is smaller than the first velocity entry.
+    //    if (v0AbsLog < shearEffectRefLogVelocity[0])
+    //        return ToolboxLocal::createBlank(v0) + 1.0;
+
+    //    // compute shear factor from input
+    //    // Z = (1 + (P - 1) * M(v)) / P
+    //    // where M(v) is computed from user input
+    //    // and P = viscosityMultiplier
+    //    const std::vector<Scalar>& shearEffectRefMultiplier = plyshlogShearEffectRefMultiplier_[pvtnumRegionIdx];
+    //    size_t numTableEntries = shearEffectRefLogVelocity.size();
+    //    assert(shearEffectRefMultiplier.size() == numTableEntries);
+
+    //    std::vector<Scalar> shearEffectMultiplier(numTableEntries, 1.0);
+    //    for (size_t i = 0; i < numTableEntries; ++i) {
+    //        shearEffectMultiplier[i] = (1.0 + (viscosityMultiplier - 1.0)*shearEffectRefMultiplier[i]) / viscosityMultiplier;
+    //        shearEffectMultiplier[i] = Opm::log(shearEffectMultiplier[i]);
+    //    }
+    //    // store the logarithmic velocity and logarithmic multipliers in a table for easy look up and
+    //    // linear interpolation in the logarithmic space.
+    //    TabulatedFunction logShearEffectMultiplier = TabulatedFunction(numTableEntries, shearEffectRefLogVelocity, shearEffectMultiplier, /*bool sortInputs =*/ false);
+
+    //    // Find sheared velocity (v) that satisfies
+    //    // F = log(v) + log (Z) - log(v0) = 0;
+
+    //    // Set up the function
+    //    // u = log(v)
+    //    auto F = [&logShearEffectMultiplier, &v0AbsLog](const Evaluation& u) {
+    //        return u + logShearEffectMultiplier.eval(u, true) - v0AbsLog;
+    //    };
+    //    // and its derivative
+    //    auto dF = [&logShearEffectMultiplier](const Evaluation& u) {
+    //        return 1 + logShearEffectMultiplier.evalDerivative(u, true);
+    //    };
+
+    //    // Solve F = 0 using Newton
+    //    // Use log(v0) as initial value for u
+    //    auto u = v0AbsLog;
+    //    bool converged = false;
+    //    for (int i = 0; i < 20; ++i) {
+    //        auto f = F(u);
+    //        auto df = dF(u);
+    //        u -= f/df;
+    //        if (std::abs(Opm::scalarValue(f)) < 1e-12) {
+    //            converged = true;
+    //            break;
+    //        }
+    //    }
+    //    if (!converged) {
+    //        throw std::runtime_error("Not able to compute shear velocity. \n");
+    //    }
+
+    //    // return the shear factor
+    //    return Opm::exp(logShearEffectMultiplier.eval(u, /*extrapolate=*/true));
+
+    //}
+
+    //const Scalar molarMass() const
+    //{
+    //    return 0.25; // kg/mol
+    //}
+
+
+
+
+private:
+    //static std::vector<Scalar> plyrockDeadPoreVolume_;
+    //static std::vector<Scalar> plyrockResidualResistanceFactor_;
+    //static std::vector<Scalar> plyrockRockDensityFactor_;
+    //static std::vector<Scalar> plyrockAdsorbtionIndex_;
+    //static std::vector<Scalar> plyrockMaxAdsorbtion_;
+    //static std::vector<TabulatedFunction> plyadsAdsorbedPolymer_;
+    //static std::vector<TabulatedFunction> plyviscViscosityMultiplierTable_;
+    //static std::vector<Scalar> plymaxMaxConcentration_;
+    //static std::vector<Scalar> plymixparToddLongstaff_;
+    //static std::vector<std::vector<Scalar>> plyshlogShearEffectRefMultiplier_;
+    //static std::vector<std::vector<Scalar>> plyshlogShearEffectRefLogVelocity_;
+    //static std::vector<Scalar> shrate_;
+    //static bool hasShrate_;
+    //static bool hasPlyshlog_;
+
+    static std::vector<FoamCoefficients> foamCoefficients_;
+    //static std::vector<PlyvmhCoefficients> plyvmhCoefficients_;
+    //static std::map<int, TabulatedTwoDFunction> plymwinjTables_;
+    //static std::map<int, TabulatedTwoDFunction> skprwatTables_;
+
+    //static std::map<int, SkprpolyTable> skprpolyTables_;
+};
+
+
+
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockDeadPoreVolume_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockResidualResistanceFactor_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockRockDensityFactor_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockAdsorbtionIndex_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyrockMaxAdsorbtion_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyadsAdsorbedPolymer_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedFunction>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyviscViscosityMultiplierTable_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymaxMaxConcentration_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymixparToddLongstaff_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefMultiplier_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyshlogShearEffectRefLogVelocity_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::Scalar>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::shrate_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//bool
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::hasShrate_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//bool
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::hasPlyshlog_;
+//
+
+template <class TypeTag, bool enableFoam>
+std::vector<typename BlackOilFoamModule<TypeTag, enableFoam>::FoamCoefficients>
+BlackOilFoamModule<TypeTag, enableFoam>::foamCoefficients_;
+
+//template <class TypeTag, bool enablePolymerV>
+//std::vector<typename BlackOilPolymerModule<TypeTag, enablePolymerV>::PlyvmhCoefficients>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plyvmhCoefficients_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedTwoDFunction>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::plymwinjTables_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::TabulatedTwoDFunction>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::skprwatTables_;
+//
+//template <class TypeTag, bool enablePolymerV>
+//std::map<int, typename BlackOilPolymerModule<TypeTag, enablePolymerV>::SkprpolyTable>
+//BlackOilPolymerModule<TypeTag, enablePolymerV>::skprpolyTables_;
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilPolymerIntensiveQuantities
+ *
+ * \brief Provides the volumetric quantities required for the equations needed by the
+ *        polymers extension of the black-oil model.
+ */
+template <class TypeTag, bool enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam)>
+class BlackOilFoamIntensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, PrimaryVariables) PrimaryVariables;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, MaterialLaw) MaterialLaw;
+    typedef typename GET_PROP_TYPE(TypeTag, Indices) Indices;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+
+    typedef BlackOilFoamModule<TypeTag> FoamModule;
+
+    enum { numPhases = GET_PROP_VALUE(TypeTag, NumPhases) };
+    static constexpr int foamConcentrationIdx = Indices::foamConcentrationIdx;
+    static constexpr int gasPhaseIdx = FluidSystem::gasPhaseIdx;
+
+
+public:
+
+    /*!
+     * \brief Update the intensive properties needed to handle polymers from the
+     *        primary variables
+     *
+     */
+    void foamPropertiesUpdate_(const ElementContext& elemCtx,
+                                  unsigned dofIdx,
+                                  unsigned timeIdx)
+    {
+        const PrimaryVariables& priVars = elemCtx.primaryVars(dofIdx, timeIdx);
+        foamConcentration_ = priVars.makeEvaluation(foamConcentrationIdx, timeIdx);
+        //const Scalar cmax = PolymerModule::plymaxMaxConcentration(elemCtx, dofIdx, timeIdx);
+
+        //// permeability reduction due to polymer
+        //const Scalar& maxAdsorbtion = PolymerModule::plyrockMaxAdsorbtion(elemCtx, dofIdx, timeIdx);
+        //const auto& plyadsAdsorbedPolymer = PolymerModule::plyadsAdsorbedPolymer(elemCtx, dofIdx, timeIdx);
+        //polymerAdsorption_ = plyadsAdsorbedPolymer.eval(polymerConcentration_, /*extrapolate=*/true);
+        //if (PolymerModule::plyrockAdsorbtionIndex(elemCtx, dofIdx, timeIdx) == PolymerModule::NoDesorption) {
+        //    const Scalar& maxPolymerAdsorption = elemCtx.problem().maxPolymerAdsorption(elemCtx, dofIdx, timeIdx);
+        //    polymerAdsorption_ = std::max(Evaluation(maxPolymerAdsorption) , polymerAdsorption_);
+        //}
+
+        //// compute resitanceFactor
+        //const Scalar& residualResistanceFactor = PolymerModule::plyrockResidualResistanceFactor(elemCtx, dofIdx, timeIdx);
+        //const Evaluation resistanceFactor = 1.0 + (residualResistanceFactor - 1.0) * polymerAdsorption_ / maxAdsorbtion;
+
+        //// compute effective viscosities
+        //if (!enablePolymerMolarWeight) {
+        //    const auto& fs = asImp_().fluidState_;
+        //    const Evaluation& muWater = fs.viscosity(waterPhaseIdx);
+        //    const auto& viscosityMultiplier = PolymerModule::plyviscViscosityMultiplierTable(elemCtx, dofIdx, timeIdx);
+        //    const Evaluation viscosityMixture = viscosityMultiplier.eval(polymerConcentration_, /*extrapolate=*/true) * muWater;
+
+        //    // Do the Todd-Longstaff mixing
+        //    const Scalar plymixparToddLongstaff = PolymerModule::plymixparToddLongstaff(elemCtx, dofIdx, timeIdx);
+        //    const Evaluation viscosityPolymer = viscosityMultiplier.eval(cmax, /*extrapolate=*/true) * muWater;
+        //    const Evaluation viscosityPolymerEffective = pow(viscosityMixture, plymixparToddLongstaff) * pow(viscosityPolymer, 1.0 - plymixparToddLongstaff);
+        //    const Evaluation viscosityWaterEffective = pow(viscosityMixture, plymixparToddLongstaff) * pow(muWater, 1.0 - plymixparToddLongstaff);
+
+        //    const Evaluation cbar = polymerConcentration_ / cmax;
+        //    // waterViscosity / effectiveWaterViscosity
+        //    waterViscosityCorrection_ = muWater * ((1.0 - cbar) / viscosityWaterEffective + cbar / viscosityPolymerEffective);
+        //    // effectiveWaterViscosity / effectivePolymerViscosity
+        //    polymerViscosityCorrection_ =  (muWater / waterViscosityCorrection_) / viscosityPolymerEffective;
+        //}
+        //else { // based on PLYVMH
+        //    const auto& plyvmhCoefficients = PolymerModule::plyvmhCoefficients(elemCtx, dofIdx, timeIdx);
+        //    const Scalar k_mh = plyvmhCoefficients.k_mh;
+        //    const Scalar a_mh = plyvmhCoefficients.a_mh;
+        //    const Scalar gamma = plyvmhCoefficients.gamma;
+        //    const Scalar kappa = plyvmhCoefficients.kappa;
+
+        //    // viscosity model based on Mark-Houwink equation and Huggins equation
+        //    // 1000 is a emperical constant, most likely related to unit conversion
+        //    const Evaluation intrinsicViscosity = k_mh * pow(polymerMoleWeight_ * 1000., a_mh);
+        //    const Evaluation x = polymerConcentration_ * intrinsicViscosity;
+        //    waterViscosityCorrection_ = 1.0 / (1.0 + gamma * (x + kappa * x * x));
+        //    polymerViscosityCorrection_ = 1.0;
+        //}
+
+        const auto& foamCoefficients = FoamModule::foamCoefficients(elemCtx, dofIdx, timeIdx);
+
+        const Scalar fm_mob = foamCoefficients.fm_mob;
+
+        const Scalar fm_surf = foamCoefficients.fm_surf;
+        const Scalar ep_surf = foamCoefficients.ep_surf;
+
+        const Scalar fm_oil = foamCoefficients.fm_oil;
+        const Scalar fl_oil = foamCoefficients.fl_oil;
+        const Scalar ep_oil = foamCoefficients.ep_oil;
+
+        const Scalar fm_dry = foamCoefficients.fm_dry;
+        const Scalar ep_dry = foamCoefficients.ep_dry;
+
+        const Scalar fm_cap = foamCoefficients.fm_cap;
+        const Scalar ep_cap = foamCoefficients.ep_cap;
+
+        const auto& fs = asImp_().fluidState_;
+        const Evaluation C_surf = foamConcentration_;
+        const Evaluation Ca = 1e10; // TODO: replace with proper capillary number.
+        const Evaluation S_o = fs.saturation(oilPhaseIdx);
+        const Evaluation S_w = fs.saturation(waterPhaseIdx);
+
+        Evaluation F1 = pow(C_surf/fm_surf, ep_surf);
+        Evaluation F2 = pow((fm_oil-S_o)/(fm_oil-fl_oil), ep_oil);
+        Evaluation F3 = pow(fm_cap/Ca, ep_cap);
+        Evaluation F7 = 0.5 + atan(ep_dry*(S_w-fm_dry))/M_PI;
+
+        Evaluation mobilityReductionFactor = 1./(1. + fm_mob*F1*F2*F3*F7);
+
+        // adjust gas mobility
+        asImp_().mobility_[gasPhaseIdx] *= mobilityReductionFactor;
+
+        //// update rock properties
+        //polymerDeadPoreVolume_ = PolymerModule::plyrockDeadPoreVolume(elemCtx, dofIdx, timeIdx);
+        //polymerRockDensity_ = PolymerModule::plyrockRockDensityFactor(elemCtx, dofIdx, timeIdx);
+    }
+
+    //const Evaluation& polymerConcentration() const
+    //{ return polymerConcentration_; }
+    const Evaluation& foamConcentration() const
+    { return foamConcentration_; }
+
+    //const Evaluation& polymerMoleWeight() const
+    //{
+    //    if (!enablePolymerMolarWeight)
+    //        throw std::logic_error("polymerMoleWeight() is called but polymer milecular weight is disabled");
+
+    //    return polymerMoleWeight_;
+    //}
+
+    //const Scalar& polymerDeadPoreVolume() const
+    //{ return polymerDeadPoreVolume_; }
+
+    //const Evaluation& polymerAdsorption() const
+    //{ return polymerAdsorption_; }
+
+    //const Scalar& polymerRockDensity() const
+    //{ return polymerRockDensity_; }
+
+    //// effectiveWaterViscosity / effectivePolymerViscosity
+    //const Evaluation& polymerViscosityCorrection() const
+    //{ return polymerViscosityCorrection_; }
+
+    //// waterViscosity / effectiveWaterViscosity
+    //const Evaluation& waterViscosityCorrection() const
+    //{ return waterViscosityCorrection_; }
+
+
+protected:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    Evaluation foamConcentration_;
+    //// polymer molecular weight
+    //Evaluation polymerMoleWeight_;
+    //Scalar polymerDeadPoreVolume_;
+    //Scalar polymerRockDensity_;
+    //Evaluation polymerAdsorption_;
+    //Evaluation polymerViscosityCorrection_;
+    //Evaluation waterViscosityCorrection_;
+
+
+};
+
+template <class TypeTag>
+class BlackOilFoamIntensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+
+public:
+    void foamPropertiesUpdate_(const ElementContext& elemCtx OPM_UNUSED,
+                                  unsigned scvIdx OPM_UNUSED,
+                                  unsigned timeIdx OPM_UNUSED)
+    { }
+
+    //const Evaluation& polymerMoleWeight() const
+    //{ throw std::logic_error("polymerMoleWeight() called but polymer molecular weight is disabled"); }
+
+    //const Evaluation& polymerConcentration() const
+    //{ throw std::runtime_error("polymerConcentration() called but polymers are disabled"); }
+
+    const Evaluation& foamConcentration() const
+    { throw std::runtime_error("foamConcentration() called but foam is disabled"); }
+
+    //const Evaluation& polymerDeadPoreVolume() const
+    //{ throw std::runtime_error("polymerDeadPoreVolume() called but polymers are disabled"); }
+
+    //const Evaluation& polymerAdsorption() const
+    //{ throw std::runtime_error("polymerAdsorption() called but polymers are disabled"); }
+
+    //const Evaluation& polymerRockDensity() const
+    //{ throw std::runtime_error("polymerRockDensity() called but polymers are disabled"); }
+
+    //const Evaluation& polymerViscosityCorrection() const
+    //{ throw std::runtime_error("polymerViscosityCorrection() called but polymers are disabled"); }
+
+    //const Evaluation& waterViscosityCorrection() const
+    //{ throw std::runtime_error("waterViscosityCorrection() called but polymers are disabled"); }
+};
+
+
+/*!
+ * \ingroup BlackOil
+ * \class Ewoms::BlackOilFoamExtensiveQuantities
+ *
+ * \brief Provides the foam specific extensive quantities to the generic black-oil
+ *        module's extensive quantities.
+ */
+template <class TypeTag, bool enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam)>
+class BlackOilFoamExtensiveQuantities
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) Implementation;
+
+    typedef typename GET_PROP_TYPE(TypeTag, Scalar) Scalar;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, IntensiveQuantities) IntensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, ExtensiveQuantities) ExtensiveQuantities;
+    typedef typename GET_PROP_TYPE(TypeTag, FluidSystem) FluidSystem;
+    typedef typename GET_PROP_TYPE(TypeTag, GridView) GridView;
+
+    static constexpr unsigned gasPhaseIdx = FluidSystem::gasPhaseIdx;
+    static constexpr int dimWorld = GridView::dimensionworld;
+    static constexpr unsigned waterPhaseIdx =  FluidSystem::waterPhaseIdx;
+
+    typedef Opm::MathToolbox<Evaluation> Toolbox;
+    typedef BlackOilFoamModule<TypeTag> FoamModule;
+    typedef Dune::FieldVector<Scalar, dimWorld> DimVector;
+    typedef Dune::FieldVector<Evaluation, dimWorld> DimEvalVector;
+
+public:
+    ///*!
+    // * \brief Method which calculates the shear factor based on flow velocity
+    // *
+    // * This is the variant of the method which assumes that the problem is specified
+    // * using permeabilities, i.e., *not* via transmissibilities.
+    // */
+    //template <class Dummy = bool> // we need to make this method a template to avoid
+    //                              // compiler errors if it is not instantiated!
+    //void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+    //                                unsigned scvfIdx OPM_UNUSED,
+    //                                unsigned timeIdx OPM_UNUSED)
+    //{
+    //    throw std::runtime_error("The extension of the blackoil model for foam is not yet "
+    //                             "implemented for problems specified using permeabilities.");
+    //}
+
+    ///*!
+    // * \brief Method which calculates the shear factor based on flow velocity
+    // *
+    // * This is the variant of the method which assumes that the problem is specified
+    // * using transmissibilities, i.e., *not* via permeabilities.
+    // */
+    //template <class Dummy = bool> // we need to make this method a template to avoid
+    //// compiler errors if it is not instantiated!
+    //void updateShearMultipliers(const ElementContext& elemCtx,
+    //                            unsigned scvfIdx,
+    //                            unsigned timeIdx)
+    //{
+
+    //    waterShearFactor_ = 1.0;
+    //    polymerShearFactor_ = 1.0;
+
+    //    if (!PolymerModule::hasPlyshlog())
+    //        return;
+
+    //    const ExtensiveQuantities& extQuants = asImp_();
+    //    unsigned upIdx = extQuants.upstreamIndex(waterPhaseIdx);
+    //    unsigned interiorDofIdx = extQuants.interiorIndex();
+    //    unsigned exteriorDofIdx = extQuants.exteriorIndex();
+    //    const auto& up = elemCtx.intensiveQuantities(upIdx, timeIdx);
+    //    const auto& intQuantsIn = elemCtx.intensiveQuantities(interiorDofIdx, timeIdx);
+    //    const auto& intQuantsEx = elemCtx.intensiveQuantities(exteriorDofIdx, timeIdx);
+
+    //    // compute water velocity from flux
+    //    Evaluation poroAvg = intQuantsIn.porosity()*0.5 + intQuantsEx.porosity()*0.5;
+    //    unsigned pvtnumRegionIdx = elemCtx.problem().pvtRegionIndex(elemCtx, scvfIdx, timeIdx);
+    //    const Evaluation& Sw = up.fluidState().saturation(waterPhaseIdx);
+    //    unsigned cellIdx = elemCtx.globalSpaceIndex(scvfIdx, timeIdx);
+    //    const auto& materialLawManager = elemCtx.problem().materialLawManager();
+    //    const auto& scaledDrainageInfo =
+    //            materialLawManager->oilWaterScaledEpsInfoDrainage(cellIdx);
+    //    const Scalar& Swcr = scaledDrainageInfo.Swcr;
+
+    //    // guard against zero porosity and no mobile water
+    //    Evaluation denom = Opm::max(poroAvg * (Sw - Swcr), 1e-12);
+    //    Evaluation waterVolumeVelocity = extQuants.volumeFlux(waterPhaseIdx) / denom;
+
+    //    // if shrate is specified. Compute shrate based on the water velocity
+    //    if (PolymerModule::hasShrate()) {
+    //        const Evaluation& relWater = up.relativePermeability(waterPhaseIdx);
+    //        Scalar trans = elemCtx.problem().transmissibility(elemCtx, interiorDofIdx, exteriorDofIdx);
+    //        if (trans > 0.0) {
+    //            Scalar faceArea = elemCtx.stencil(timeIdx).interiorFace(scvfIdx).area();
+    //            auto dist = elemCtx.pos(interiorDofIdx, timeIdx) -  elemCtx.pos(exteriorDofIdx, timeIdx);
+    //            // compute permeability from transmissibility.
+    //            Scalar absPerm = trans / faceArea * dist.two_norm();
+    //            waterVolumeVelocity *=
+    //                PolymerModule::shrate(pvtnumRegionIdx)*Opm::sqrt(poroAvg*Sw / (relWater*absPerm));
+    //            assert(Opm::isfinite(waterVolumeVelocity));
+    //        }
+    //    }
+
+    //    // compute share factors for water and polymer
+    //    waterShearFactor_ =
+    //        PolymerModule::computeShearFactor(up.polymerConcentration(),
+    //                                          pvtnumRegionIdx,
+    //                                          waterVolumeVelocity);
+    //    polymerShearFactor_ =
+    //        PolymerModule::computeShearFactor(up.polymerConcentration(),
+    //                                          pvtnumRegionIdx,
+    //                                          waterVolumeVelocity*up.polymerViscosityCorrection());
+
+    //}
+
+    //const Evaluation& polymerShearFactor() const
+    //{ return polymerShearFactor_; }
+
+    //const Evaluation& waterShearFactor() const
+    //{ return waterShearFactor_; }
+
+
+private:
+    Implementation& asImp_()
+    { return *static_cast<Implementation*>(this); }
+
+    //Evaluation polymerShearFactor_;
+    //Evaluation waterShearFactor_;
+
+};
+
+template <class TypeTag>
+class BlackOilFoamExtensiveQuantities<TypeTag, false>
+{
+    typedef typename GET_PROP_TYPE(TypeTag, ElementContext) ElementContext;
+    typedef typename GET_PROP_TYPE(TypeTag, Evaluation) Evaluation;
+
+public:
+    //void updateShearMultipliers(const ElementContext& elemCtx OPM_UNUSED,
+    //                            unsigned scvfIdx OPM_UNUSED,
+    //                            unsigned timeIdx OPM_UNUSED)
+    //{ }
+
+    //void updateShearMultipliersPerm(const ElementContext& elemCtx OPM_UNUSED,
+    //                                unsigned scvfIdx OPM_UNUSED,
+    //                                unsigned timeIdx OPM_UNUSED)
+    //{ }
+
+    //const Evaluation& polymerShearFactor() const
+    //{ throw std::runtime_error("polymerShearFactor() called but polymers are disabled"); }
+
+    //const Evaluation& waterShearFactor() const
+    //{ throw std::runtime_error("waterShearFactor() called but polymers are disabled"); }
+};
+
+
+} // namespace Ewoms
+
+#endif

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -35,7 +35,7 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, unsigned PVOffset>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, bool enableFoam, unsigned PVOffset>
 struct BlackOilIndices
 {
     //! Number of phases active at all times
@@ -45,6 +45,8 @@ struct BlackOilIndices
     static const bool oilEnabled = true;
     static const bool waterEnabled = true;
     static const bool gasEnabled = true;
+
+    //static const bool foamEnabled = foamEnabled___;
 
     //! Are solvents involved?
     static const bool enableSolvent = numSolventsV > 0;
@@ -64,8 +66,11 @@ struct BlackOilIndices
     //! Number of energy equations to be considered
     static const int numEnergy = enableEnergy ? numEnergyV : 0;
 
+    //! Number of foam equations to be considered
+    static const int numFoam = enableFoam? 1 : 0;
+
     //! The number of equations
-    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy;
+    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy + numFoam;
 
     //! \brief returns the index of "active" component
     static constexpr unsigned canonicalToActiveComponentIndex(unsigned compIdx)
@@ -106,9 +111,14 @@ struct BlackOilIndices
     static const int polymerMoleWeightIdx =
         numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
 
+    //! Index of the primary variable for the foam
+    static const int foamConcentrationIdx =
+        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
+
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : - 1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers + numFoam : - 1000;
+
 
     ////////
     // Equation indices
@@ -130,9 +140,14 @@ struct BlackOilIndices
     static const int contiPolymerMWEqIdx =
         numPolymers > 1 ? contiPolymerEqIdx + 1 : -1000;
 
+    //! Index of the continuity equation for the foam component
+    static const int contiFoamEqIdx =
+        enableFoam ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
+
+
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers + numFoam : -1000;
 };
 
 } // namespace Ewoms

--- a/ewoms/models/blackoil/blackoilindices.hh
+++ b/ewoms/models/blackoil/blackoilindices.hh
@@ -46,8 +46,6 @@ struct BlackOilIndices
     static const bool waterEnabled = true;
     static const bool gasEnabled = true;
 
-    //static const bool foamEnabled = foamEnabled___;
-
     //! Are solvents involved?
     static const bool enableSolvent = numSolventsV > 0;
 

--- a/ewoms/models/blackoil/blackoilintensivequantities.hh
+++ b/ewoms/models/blackoil/blackoilintensivequantities.hh
@@ -31,6 +31,7 @@
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
+#include "blackoilfoammodules.hh"
 #include "blackoilenergymodules.hh"
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 #include <opm/material/common/Valgrind.hpp>
@@ -54,6 +55,7 @@ class BlackOilIntensiveQuantities
     , public GET_PROP_TYPE(TypeTag, FluxModule)::FluxIntensiveQuantities
     , public BlackOilSolventIntensiveQuantities<TypeTag>
     , public BlackOilPolymerIntensiveQuantities<TypeTag>
+    , public BlackOilFoamIntensiveQuantities<TypeTag>
     , public BlackOilEnergyIntensiveQuantities<TypeTag>
 {
     typedef typename GET_PROP_TYPE(TypeTag, DiscIntensiveQuantities) ParentType;
@@ -72,6 +74,7 @@ class BlackOilIntensiveQuantities
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+    enum { enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam) };
     enum { enableTemperature = GET_PROP_VALUE(TypeTag, EnableTemperature) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { enableExperiments = GET_PROP_VALUE(TypeTag, EnableExperiments) };
@@ -346,6 +349,7 @@ public:
         asImp_().solventPvtUpdate_(elemCtx, dofIdx, timeIdx);
         asImp_().polymerPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
         asImp_().updateEnergyQuantities_(elemCtx, dofIdx, timeIdx, paramCache);
+        asImp_().foamPropertiesUpdate_(elemCtx, dofIdx, timeIdx);
 
         // update the quantities which are required by the chosen
         // velocity model
@@ -425,6 +429,7 @@ private:
     friend BlackOilSolventIntensiveQuantities<TypeTag>;
     friend BlackOilPolymerIntensiveQuantities<TypeTag>;
     friend BlackOilEnergyIntensiveQuantities<TypeTag>;
+    friend BlackOilFoamIntensiveQuantities<TypeTag>;
 
     Implementation& asImp_()
     { return *static_cast<Implementation*>(this); }

--- a/ewoms/models/blackoil/blackoillocalresidual.hh
+++ b/ewoms/models/blackoil/blackoillocalresidual.hh
@@ -32,6 +32,7 @@
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
 #include "blackoilenergymodules.hh"
+#include "blackoilfoammodules.hh"
 
 #include <opm/material/fluidstates/BlackOilFluidState.hpp>
 
@@ -80,6 +81,7 @@ class BlackOilLocalResidual : public GET_PROP_TYPE(TypeTag, DiscLocalResidual)
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
     typedef BlackOilEnergyModule<TypeTag> EnergyModule;
+    typedef BlackOilFoamModule<TypeTag> FoamModule;
 
 public:
     /*!
@@ -144,6 +146,9 @@ public:
 
         // deal with energy (if present)
         EnergyModule::addStorage(storage, intQuants);
+
+        // deal with foam (if present)
+        FoamModule::addStorage(storage, intQuants);
     }
 
     /*!
@@ -181,6 +186,9 @@ public:
 
         // deal with energy (if present)
         EnergyModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
+
+        // deal with foam (if present)
+        FoamModule::computeFlux(flux, elemCtx, scvfIdx, timeIdx);
     }
 
     /*!

--- a/ewoms/models/blackoil/blackoilmodel.hh
+++ b/ewoms/models/blackoil/blackoilmodel.hh
@@ -43,6 +43,7 @@
 #include "blackoilproperties.hh"
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
+#include "blackoilfoammodules.hh"
 #include "blackoildarcyfluxmodule.hh"
 
 #include <ewoms/models/common/multiphasebasemodel.hh>
@@ -111,6 +112,7 @@ SET_TYPE_PROP(BlackOilModel, Indices,
               Ewoms::BlackOilIndices<GET_PROP_VALUE(TypeTag, EnableSolvent),
                                      GET_PROP_VALUE(TypeTag, EnablePolymer),
                                      GET_PROP_VALUE(TypeTag, EnableEnergy),
+                                     GET_PROP_VALUE(TypeTag, EnableFoam),
                                      /*PVOffset=*/0>);
 
 //! Set the fluid system to the black-oil fluid system by default
@@ -128,6 +130,7 @@ public:
 SET_BOOL_PROP(BlackOilModel, EnableSolvent, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymer, false);
 SET_BOOL_PROP(BlackOilModel, EnablePolymerMW, false);
+SET_BOOL_PROP(BlackOilModel, EnableFoam, false);
 
 //! By default, the blackoil model is isothermal and does not conserve energy
 SET_BOOL_PROP(BlackOilModel, EnableTemperature, false);

--- a/ewoms/models/blackoil/blackoilnewtonmethod.hh
+++ b/ewoms/models/blackoil/blackoilnewtonmethod.hh
@@ -187,6 +187,7 @@ protected:
         static constexpr bool enablePolymer = Indices::polymerConcentrationIdx >= 0;
         static constexpr bool enablePolymerWeight = Indices::polymerMoleWeightIdx >= 0;
         static constexpr bool enableEnergy = Indices::temperatureIdx >= 0;
+        static constexpr bool enableFoam = Indices::foamConcentrationIdx >= 0;
 
         currentValue.checkDefined();
         Opm::Valgrind::CheckDefined(update);
@@ -283,6 +284,10 @@ protected:
                 if (polymerConcentration < 1.e-10)
                     nextValue[pvIdx] = 0.0;
             }
+
+            // keep the foam concentration above 0
+            if (enableFoam && pvIdx == Indices::foamConcentrationIdx)
+                nextValue[pvIdx] = std::max(nextValue[pvIdx], 0.0);
 
             // keep the temperature above 100 and below 1000 Kelvin
             if (enableEnergy && pvIdx == Indices::temperatureIdx)

--- a/ewoms/models/blackoil/blackoilprimaryvariables.hh
+++ b/ewoms/models/blackoil/blackoilprimaryvariables.hh
@@ -32,6 +32,7 @@
 #include "blackoilsolventmodules.hh"
 #include "blackoilpolymermodules.hh"
 #include "blackoilenergymodules.hh"
+#include "blackoilfoammodules.hh"
 
 #include <ewoms/disc/common/fvbaseprimaryvariables.hh>
 
@@ -90,6 +91,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
+    enum { enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam) };
     enum { enableEnergy = GET_PROP_VALUE(TypeTag, EnableEnergy) };
     enum { gasCompIdx = FluidSystem::gasCompIdx };
     enum { waterCompIdx = FluidSystem::waterCompIdx };
@@ -100,6 +102,7 @@ class BlackOilPrimaryVariables : public FvBasePrimaryVariables<TypeTag>
     typedef BlackOilSolventModule<TypeTag, enableSolvent> SolventModule;
     typedef BlackOilPolymerModule<TypeTag, enablePolymer> PolymerModule;
     typedef BlackOilEnergyModule<TypeTag, enableEnergy> EnergyModule;
+    typedef BlackOilFoamModule<TypeTag, enableFoam> FoamModule;
 
     static_assert(numPhases == 3, "The black-oil model assumes three phases!");
     static_assert(numComponents == 3, "The black-oil model assumes three components!");
@@ -589,6 +592,14 @@ private:
             return 0.0;
 
         return (*this)[Indices::polymerConcentrationIdx];
+    }
+
+    Scalar foamConcentration_() const
+    {
+        if (!enableFoam)
+            return 0.0;
+
+        return (*this)[Indices::foamConcentrationIdx];
     }
 
     Scalar temperature_() const

--- a/ewoms/models/blackoil/blackoilproperties.hh
+++ b/ewoms/models/blackoil/blackoilproperties.hh
@@ -52,6 +52,8 @@ NEW_PROP_TAG(EnablePolymer);
 NEW_PROP_TAG(EnablePolymerMW);
 //! Enable surface volume scaling
 NEW_PROP_TAG(BlackoilConserveSurfaceVolume);
+//! Enable the ECL-blackoil extension for foam
+NEW_PROP_TAG(EnableFoam);
 
 //! Allow the spatial and temporal domains to exhibit non-constant temperature
 //! in the black-oil model

--- a/ewoms/models/blackoil/blackoilratevector.hh
+++ b/ewoms/models/blackoil/blackoilratevector.hh
@@ -146,6 +146,10 @@ public:
             (*this)[Indices::contiPolymerEqIdx] *= PolymerModule::molarMass(pvtRegionIdx);
         }
 
+        if ( enableFoam ) {
+            throw std::logic_error("setMolarRate() not implemented for foam");
+        }
+
         // convert to "surface volume" if requested
         if (GET_PROP_VALUE(TypeTag, BlackoilConserveSurfaceVolume)) {
             if (FluidSystem::phaseIsActive(FluidSystem::gasPhaseIdx)) {

--- a/ewoms/models/blackoil/blackoilratevector.hh
+++ b/ewoms/models/blackoil/blackoilratevector.hh
@@ -58,6 +58,7 @@ class BlackOilRateVector
 
     typedef BlackOilSolventModule<TypeTag> SolventModule;
     typedef BlackOilPolymerModule<TypeTag> PolymerModule;
+    typedef BlackOilFoamModule<TypeTag> FoamModule;
 
     enum { numEq = GET_PROP_VALUE(TypeTag, NumEq) };
     enum { numComponents = GET_PROP_VALUE(TypeTag, NumComponents) };
@@ -67,6 +68,7 @@ class BlackOilRateVector
     enum { enableSolvent = GET_PROP_VALUE(TypeTag, EnableSolvent) };
     enum { enablePolymer = GET_PROP_VALUE(TypeTag, EnablePolymer) };
     enum { enablePolymerMolarWeight = GET_PROP_VALUE(TypeTag, EnablePolymerMW) };
+    enum { enableFoam = GET_PROP_VALUE(TypeTag, EnableFoam) };
 
     typedef Opm::MathToolbox<Evaluation> Toolbox;
     typedef Dune::FieldVector<Evaluation, numEq> ParentType;

--- a/ewoms/models/blackoil/blackoiltwophaseindices.hh
+++ b/ewoms/models/blackoil/blackoiltwophaseindices.hh
@@ -37,7 +37,7 @@ namespace Ewoms {
  *
  * \brief The primary variable and equation indices for the black-oil model.
  */
-template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
+template <unsigned numSolventsV, unsigned numPolymersV, unsigned numEnergyV, bool enableFoam, unsigned PVOffset, unsigned disabledCanonicalCompIdx>
 struct BlackOilTwoPhaseIndices
 {
     //! Is phase enabled or not
@@ -63,11 +63,14 @@ struct BlackOilTwoPhaseIndices
     //! Number of energy equations to be considered
     static const int numEnergy = enableEnergy ? numEnergyV : 0;
 
+    //! Number of foam equations to be considered
+    static const int numFoam = enableFoam? 1 : 0;
+
     //! The number of fluid phases
     static const int numPhases = 2;
 
     //! The number of equations
-    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy;
+    static const int numEq = numPhases + numSolvents + numPolymers + numEnergy + numFoam;
 
     //////////////////////////////
     // Primary variable indices
@@ -99,9 +102,13 @@ struct BlackOilTwoPhaseIndices
     static const int polymerMoleWeightIdx =
         numPolymers > 1 ? polymerConcentrationIdx + 1 : -1000;
 
+    //! Index of the primary variable for the foam
+    static const int foamConcentrationIdx =
+        enableFoam ? polymerMoleWeightIdx + 1 : -1000;
+
     //! Index of the primary variable for temperature
     static const int temperatureIdx  =
-        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : - 1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers + numFoam : - 1000;
 
     //////////////////////
     // Equation indices
@@ -160,9 +167,13 @@ struct BlackOilTwoPhaseIndices
     static const int contiPolymerMWEqIdx =
         numPolymers > 1 ? contiPolymerEqIdx + 1 : -1000;
 
+    //! Index of the continuity equation for the foam  component
+    static const int contiFoamEqIdx =
+        enableFoam ? contiPolymerMWEqIdx + 1 : -1000;
+
     //! Index of the continuity equation for energy
     static const int contiEnergyEqIdx =
-        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers : -1000;
+        enableEnergy ? PVOffset + numPhases + numSolvents + numPolymers + numFoam : -1000;
 };
 
 } // namespace Ewoms


### PR DESCRIPTION
This adds a foam module, which should be considered experimental for the time being. It supports a subset of foam features: most importantly gas mobility reduction tables (FOAMMOB) and foam adsorption (FOAMADS, FOAMROCK).

A companion PR in opm-simulators is needed.