### PR TITLE
changed: quell some more unused parameter warnings without MPI

### DIFF
--- a/ewoms/linear/globalindices.hh
+++ b/ewoms/linear/globalindices.hh
@@ -136,7 +136,9 @@ public:
     /*!
      * \brief Send a border index to a remote process.
      */
-    void sendBorderIndex(ProcessRank peerRank, Index domesticIdx, Index peerLocalIdx)
+    void sendBorderIndex(ProcessRank peerRank OPM_UNUSED_NOMPI,
+                         Index domesticIdx OPM_UNUSED_NOMPI,
+                         Index peerLocalIdx OPM_UNUSED_NOMPI)
     {
 #if HAVE_MPI
         PeerIndexGlobalIndex sendBuf;
@@ -155,7 +157,7 @@ public:
      * \brief Receive an index on the border from a remote
      *        process and add it the translation maps.
      */
-    void receiveBorderIndex(ProcessRank peerRank)
+    void receiveBorderIndex(ProcessRank peerRank OPM_UNUSED_NOMPI)
     {
 #if HAVE_MPI
         PeerIndexGlobalIndex recvBuf;
@@ -280,7 +282,7 @@ protected:
 #endif // HAVE_MPI
     }
 
-    void sendBorderTo_(ProcessRank peerRank)
+    void sendBorderTo_(ProcessRank peerRank OPM_UNUSED_NOMPI)
     {
 #if HAVE_MPI
         // send (local index on myRank, global index) pairs to the
@@ -303,7 +305,7 @@ protected:
 #endif // HAVE_MPI
     }
 
-    void receiveBorderFrom_(ProcessRank peerRank)
+    void receiveBorderFrom_(ProcessRank peerRank OPM_UNUSED_NOMPI)
     {
 #if HAVE_MPI
         // retrieve the global indices for which we are not master

--- a/ewoms/linear/overlappingbcrsmatrix.hh
+++ b/ewoms/linear/overlappingbcrsmatrix.hh
@@ -636,7 +636,7 @@ private:
 #endif // HAVE_MPI
     }
 
-    void receiveCopyEntries_(int peerRank)
+    void receiveCopyEntries_(int peerRank OPM_UNUSED_NOMPI)
     {
 #if HAVE_MPI
         MpiBuffer<block_type> &mpiRecvBuff = *entryValuesRecvBuff_[peerRank];


### PR DESCRIPTION
missed originally as they are only emitted from clang, not gcc